### PR TITLE
BISERVER-8600 Fix Pentaho Report Designer client tool to publish reports to the BI Server

### DIFF
--- a/designer/report-designer-assembly/resource/resources/report-designer.properties
+++ b/designer/report-designer-assembly/resource/resources/report-designer.properties
@@ -1,3 +1,3 @@
 org.pentaho.reporting.designer.extensions.pentaho.repository.PublishLocation=http://localhost:8080/pentaho
-org.pentaho.reporting.designer.extensions.pentaho.repository.ServerUser=joe
+org.pentaho.reporting.designer.extensions.pentaho.repository.ServerUser=admin
 org.pentaho.reporting.designer.extensions.pentaho.repository.ServerPassword=password

--- a/designer/report-designer-extension-pentaho/source/org/pentaho/reporting/designer/extensions/pentaho/repository/configuration.properties
+++ b/designer/report-designer-extension-pentaho/source/org/pentaho/reporting/designer/extensions/pentaho/repository/configuration.properties
@@ -6,7 +6,7 @@ org.pentaho.reporting.designer.extensions.pentaho.repository.PublishService=/Rep
 #
 # Defines the built in default location and username and password for the publish dialogs.
 org.pentaho.reporting.designer.extensions.pentaho.repository.PublishLocation=http://localhost:8080/pentaho
-org.pentaho.reporting.designer.extensions.pentaho.repository.ServerUser=joe
+org.pentaho.reporting.designer.extensions.pentaho.repository.ServerUser=admin
 org.pentaho.reporting.designer.extensions.pentaho.repository.ServerPassword=password
 
 

--- a/libraries/libpensol/source/org/pentaho/reporting/libraries/pensol/PentahoSolutionsFileSystemConfigBuilder.java
+++ b/libraries/libpensol/source/org/pentaho/reporting/libraries/pensol/PentahoSolutionsFileSystemConfigBuilder.java
@@ -11,11 +11,6 @@ public class PentahoSolutionsFileSystemConfigBuilder extends DefaultFileSystemCo
   {
   }
 
-  protected Class getConfigClass()
-  {
-    return PentahoSolutionFileProvider.class;
-  }
-
   public void setTimeOut(final FileSystemOptions opts, final int timeOut)
   {
       setParam(opts, TIMEOUT_KEY, timeOut);


### PR DESCRIPTION
also updated default user/pass for the publish dialogs (replaced "joe" with "admin")
