### PR TITLE
PRD-4313: Fixing the element rendering and global layout state

### DIFF
--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/AbstractReportDesignerContext.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/AbstractReportDesignerContext.java
@@ -1,0 +1,283 @@
+package org.pentaho.reporting.designer.core;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.ArrayList;
+
+import org.pentaho.reporting.designer.core.auth.GlobalAuthenticationStore;
+import org.pentaho.reporting.designer.core.editor.ReportRenderContext;
+import org.pentaho.reporting.designer.core.model.ModelUtility;
+import org.pentaho.reporting.designer.core.settings.RecentFilesModel;
+import org.pentaho.reporting.engine.classic.core.CompoundDataFactory;
+import org.pentaho.reporting.engine.classic.core.MasterReport;
+import org.pentaho.reporting.engine.classic.core.Section;
+import org.pentaho.reporting.engine.classic.core.SubReport;
+import org.pentaho.reporting.engine.classic.core.event.ReportModelEvent;
+import org.pentaho.reporting.engine.classic.core.event.ReportModelListener;
+
+public abstract class AbstractReportDesignerContext implements ReportDesignerContext
+{
+  private static class SubReportsRemovealHandler implements ReportModelListener
+  {
+    private AbstractReportDesignerContext designerContext;
+
+    private SubReportsRemovealHandler(final AbstractReportDesignerContext designerContext)
+    {
+      this.designerContext = designerContext;
+    }
+
+    public void nodeChanged(final ReportModelEvent event)
+    {
+      designerContext.setSelectionWaiting(false);
+
+      if (!event.isNodeDeleteEvent())
+      {
+        return;
+      }
+
+      final Object o = event.getParameter();
+      if (o instanceof Section == false)
+      {
+        return;
+      }
+
+      final SubReport[] subReports = ModelUtility.findSubReports((Section) o);
+      for (int i = 0; i < subReports.length; i++)
+      {
+        final SubReport report = subReports[i];
+        final int count = designerContext.getReportRenderContextCount();
+        for (int x = 0; x < count; x++)
+        {
+          final ReportRenderContext context = designerContext.getReportRenderContext(x);
+          if (context.getReportDefinition() == report)
+          {
+            designerContext.removeReportRenderContext(x);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+
+  private PropertyChangeSupport propertyChangeSupport;
+  private String statusText;
+  private ReportRenderContext activeContext;
+  private ArrayList<ReportRenderContext> contexts;
+  private RecentFilesModel recentFilesModel;
+  private boolean selectionWaiting;
+  private GlobalAuthenticationStore authenticationStore;
+  private int page;
+  private int pageTotal;
+  private ReportDesignerView view;
+
+  public AbstractReportDesignerContext(final ReportDesignerView view)
+  {
+    if (view == null)
+    {
+      throw new NullPointerException();
+    }
+    this.view = view;
+    this.recentFilesModel = new RecentFilesModel();
+    this.contexts = new ArrayList<ReportRenderContext>();
+    this.propertyChangeSupport = new PropertyChangeSupport(this);
+    this.authenticationStore = new GlobalAuthenticationStore();
+  }
+
+  public RecentFilesModel getRecentFilesModel()
+  {
+    return recentFilesModel;
+  }
+
+  public int addMasterReport(final MasterReport masterReportElement)
+  {
+    setSelectionWaiting(false);
+
+    masterReportElement.setDataFactory(CompoundDataFactory.normalize(masterReportElement.getDataFactory()));
+    final ReportRenderContext context =
+        new ReportRenderContext(masterReportElement, masterReportElement, null, getGlobalAuthenticationStore());
+    contexts.add(context);
+    context.resetChangeTracker();
+
+    masterReportElement.addReportModelListener(new SubReportsRemovealHandler(this));
+
+    final int index = contexts.size() - 1;
+    propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, null, context);
+    return index;
+  }
+
+  public int addSubReport(final ReportRenderContext parentReportContext, final SubReport subReportElement)
+  {
+    setSelectionWaiting(false);
+
+    subReportElement.setDataFactory(CompoundDataFactory.normalize(subReportElement.getDataFactory()));
+    final ReportRenderContext context = new ReportRenderContext(parentReportContext.getMasterReportElement(),
+        subReportElement, parentReportContext,
+        getGlobalAuthenticationStore());
+    contexts.add(context);
+
+    subReportElement.addReportModelListener(new SubReportsRemovealHandler(this));
+
+    final int index = contexts.size() - 1;
+    propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, null, context);
+    return index;
+  }
+
+  public void removeReportRenderContext(final int index)
+  {
+    // todo: Also remove all subreports ..
+    setSelectionWaiting(false);
+
+    final ReportRenderContext context = contexts.get(index);
+    try
+    {
+      contexts.remove(index);
+      if (context != activeContext)
+      {
+        propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, context, null);
+        return;
+      }
+
+      if (index == 0)
+      {
+        if (contexts.isEmpty() == false)
+        {
+          setActiveContext(contexts.get(0));
+        }
+        else
+        {
+          setActiveContext(null);
+        }
+      }
+      else
+      {
+        setActiveContext(contexts.get(index - 1));
+      }
+      propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, context, null);
+    }
+    finally
+    {
+      context.dispose();
+    }
+  }
+
+  public int getReportRenderContextCount()
+  {
+    return contexts.size();
+  }
+
+  public ReportRenderContext getReportRenderContext(final int index)
+  {
+    return contexts.get(index);
+  }
+
+  public ReportRenderContext getActiveContext()
+  {
+    return activeContext;
+  }
+
+  public void setActiveContext(final ReportRenderContext activeContext)
+  {
+    if (activeContext != null)
+    {
+      if (contexts.contains(activeContext) == false)
+      {
+        throw new IllegalArgumentException("None of my contexts");
+      }
+    }
+
+    setSelectionWaiting(false);
+
+    final ReportRenderContext context = this.activeContext;
+    this.activeContext = activeContext;
+    propertyChangeSupport.firePropertyChange(ACTIVE_CONTEXT_PROPERTY, context, activeContext);
+  }
+
+  public String getStatusText()
+  {
+    return statusText;
+  }
+
+  public void setStatusText(final String statusText)
+  {
+    final String oldText = this.statusText;
+    this.statusText = statusText;
+    propertyChangeSupport.firePropertyChange(STATUS_TEXT_PROPERTY, oldText, statusText);
+  }
+
+  public void addPropertyChangeListener(final PropertyChangeListener listener)
+  {
+    propertyChangeSupport.addPropertyChangeListener(listener);
+  }
+
+  public void removePropertyChangeListener(final PropertyChangeListener listener)
+  {
+    propertyChangeSupport.removePropertyChangeListener(listener);
+  }
+
+  public void addPropertyChangeListener(final String propertyName, final PropertyChangeListener listener)
+  {
+    propertyChangeSupport.addPropertyChangeListener(propertyName, listener);
+  }
+
+  public void removePropertyChangeListener(final String propertyName, final PropertyChangeListener listener)
+  {
+    propertyChangeSupport.removePropertyChangeListener(propertyName, listener);
+  }
+
+  public ReportDesignerView getView()
+  {
+    return view;
+  }
+
+  public int findActiveContextIndex()
+  {
+    for (int i = 0; i < contexts.size(); i++)
+    {
+      final ReportRenderContext context = contexts.get(i);
+      if (context == activeContext)
+      {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  public boolean isSelectionWaiting()
+  {
+    return selectionWaiting;
+  }
+
+  public void setSelectionWaiting(final boolean selectionWaiting)
+  {
+    final boolean oldSelectionWaiting = this.selectionWaiting;
+    this.selectionWaiting = selectionWaiting;
+    propertyChangeSupport.firePropertyChange("selectionWaiting", oldSelectionWaiting, selectionWaiting);//NON-NLS
+  }
+
+  public GlobalAuthenticationStore getGlobalAuthenticationStore()
+  {
+    return authenticationStore;
+  }
+
+  public void setPageNumbers(final int page, final int pageTotal)
+  {
+    final int oldPage = this.page;
+    final int oldPageTotal = this.pageTotal;
+    this.page = page;
+    this.pageTotal = pageTotal;
+
+    propertyChangeSupport.firePropertyChange("pageTotal", oldPageTotal, pageTotal);//NON-NLS
+    propertyChangeSupport.firePropertyChange("page", oldPage, page);//NON-NLS
+  }
+
+  public int getPage()
+  {
+    return page;
+  }
+
+  public int getPageTotal()
+  {
+    return pageTotal;
+  }
+}

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/DefaultReportDesignerContext.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/DefaultReportDesignerContext.java
@@ -18,118 +18,28 @@
 package org.pentaho.reporting.designer.core;
 
 import java.awt.Component;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
-import java.util.ArrayList;
 import javax.swing.JComponent;
 import javax.swing.JPopupMenu;
 
-import org.pentaho.reporting.designer.core.auth.GlobalAuthenticationStore;
-import org.pentaho.reporting.designer.core.editor.ReportRenderContext;
-import org.pentaho.reporting.designer.core.model.ModelUtility;
-import org.pentaho.reporting.designer.core.settings.RecentFilesModel;
 import org.pentaho.reporting.designer.core.xul.XulDesignerFrame;
-import org.pentaho.reporting.engine.classic.core.CompoundDataFactory;
-import org.pentaho.reporting.engine.classic.core.MasterReport;
-import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
-import org.pentaho.reporting.engine.classic.core.Section;
-import org.pentaho.reporting.engine.classic.core.SubReport;
-import org.pentaho.reporting.engine.classic.core.event.ReportModelEvent;
-import org.pentaho.reporting.engine.classic.core.event.ReportModelListener;
 import org.pentaho.ui.xul.XulException;
 
-/**
- * Todo: Document Me
- *
- * @author Thomas Morgner
- */
-public class DefaultReportDesignerContext implements ReportDesignerContext
+public class DefaultReportDesignerContext extends AbstractReportDesignerContext
 {
-  private static class SubReportsRemovealHandler implements ReportModelListener
-  {
-    private DefaultReportDesignerContext designerContext;
-
-    private SubReportsRemovealHandler(final DefaultReportDesignerContext designerContext)
-    {
-      this.designerContext = designerContext;
-    }
-
-    public void nodeChanged(final ReportModelEvent event)
-    {
-      designerContext.setSelectionWaiting(false);
-
-      if (!event.isNodeDeleteEvent())
-      {
-        return;
-      }
-
-      final Object o = event.getParameter();
-      if (o instanceof Section == false)
-      {
-        return;
-      }
-
-      final SubReport[] subReports = ModelUtility.findSubReports((Section) o);
-      for (int i = 0; i < subReports.length; i++)
-      {
-        final SubReport report = subReports[i];
-        final int count = designerContext.getReportRenderContextCount();
-        for (int x = 0; x < count; x++)
-        {
-          final ReportRenderContext context = designerContext.getReportRenderContext(x);
-          if (context.getReportDefinition() == report)
-          {
-            designerContext.removeReportRenderContext(x);
-            break;
-          }
-        }
-      }
-    }
-  }
-
-
-  private PropertyChangeSupport propertyChangeSupport;
-  private String statusText;
-  private ReportRenderContext activeContext;
-  private ArrayList<ReportRenderContext> contexts;
-  private Component parent;
-  private RecentFilesModel recentFilesModel;
   private XulDesignerFrame xulDesignerFrame;
-  private boolean selectionWaiting;
-  private GlobalAuthenticationStore authenticationStore;
-  private int page;
-  private int pageTotal;
-  private ReportDesignerView view;
+  private Component parent;
 
   public DefaultReportDesignerContext(final Component parent, final ReportDesignerView view) throws XulException
   {
-    if (view == null)
-    {
-      throw new NullPointerException();
-    }
-    this.view = view;
+    super(view);
     this.parent = parent;
-    this.recentFilesModel = new RecentFilesModel();
-    this.contexts = new ArrayList<ReportRenderContext>();
-    this.propertyChangeSupport = new PropertyChangeSupport(this);
     this.xulDesignerFrame = new XulDesignerFrame();
     this.xulDesignerFrame.setReportDesignerContext(this);
-    this.authenticationStore = new GlobalAuthenticationStore();
   }
 
   public XulDesignerFrame getXulDesignerFrame()
   {
     return xulDesignerFrame;
-  }
-
-  public RecentFilesModel getRecentFilesModel()
-  {
-    return recentFilesModel;
-  }
-
-  public Component getParent()
-  {
-    return parent;
   }
 
   public JPopupMenu getPopupMenu(final String id)
@@ -142,196 +52,8 @@ public class DefaultReportDesignerContext implements ReportDesignerContext
     return xulDesignerFrame.getToolBar(id);
   }
 
-  public int addMasterReport(final MasterReport masterReportElement) throws ReportDataFactoryException
+  public Component getParent()
   {
-    setSelectionWaiting(false);
-
-    masterReportElement.setDataFactory(CompoundDataFactory.normalize(masterReportElement.getDataFactory()));
-    final ReportRenderContext context =
-        new ReportRenderContext(masterReportElement, masterReportElement, null, getGlobalAuthenticationStore());
-    contexts.add(context);
-    context.resetChangeTracker();
-
-    masterReportElement.addReportModelListener(new SubReportsRemovealHandler(this));
-
-    final int index = contexts.size() - 1;
-    propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, null, context);
-    return index;
-  }
-
-  public int addSubReport(final ReportRenderContext parentReportContext, final SubReport subReportElement)
-      throws ReportDataFactoryException
-  {
-    setSelectionWaiting(false);
-
-    subReportElement.setDataFactory(CompoundDataFactory.normalize(subReportElement.getDataFactory()));
-    final ReportRenderContext context = new ReportRenderContext(parentReportContext.getMasterReportElement(),
-                                                                subReportElement, parentReportContext,
-                                                                getGlobalAuthenticationStore());
-    contexts.add(context);
-
-    subReportElement.addReportModelListener(new SubReportsRemovealHandler(this));
-
-    final int index = contexts.size() - 1;
-    propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, null, context);
-    return index;
-  }
-
-  public void removeReportRenderContext(final int index)
-  {
-    // todo: Also remove all subreports ..
-    setSelectionWaiting(false);
-
-    final ReportRenderContext context = contexts.get(index);
-    try
-    {
-      contexts.remove(index);
-      if (context != activeContext)
-      {
-        propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, context, null);
-        return;
-      }
-
-      if (index == 0)
-      {
-        if (contexts.isEmpty() == false)
-        {
-          setActiveContext(contexts.get(0));
-        }
-        else
-        {
-          setActiveContext(null);
-        }
-      }
-      else
-      {
-        setActiveContext(contexts.get(index - 1));
-      }
-      propertyChangeSupport.fireIndexedPropertyChange(REPORT_RENDER_CONTEXT_PROPERTY, index, context, null);
-    }
-    finally
-    {
-      context.dispose();
-    }
-  }
-
-  public int getReportRenderContextCount()
-  {
-    return contexts.size();
-  }
-
-  public ReportRenderContext getReportRenderContext(final int index)
-  {
-    return contexts.get(index);
-  }
-
-  public ReportRenderContext getActiveContext()
-  {
-    return activeContext;
-  }
-
-  public void setActiveContext(final ReportRenderContext activeContext)
-  {
-    if (activeContext != null)
-    {
-      if (contexts.contains(activeContext) == false)
-      {
-        throw new IllegalArgumentException("None of my contexts");
-      }
-    }
-
-    setSelectionWaiting(false);
-
-    final ReportRenderContext context = this.activeContext;
-    this.activeContext = activeContext;
-    propertyChangeSupport.firePropertyChange(ACTIVE_CONTEXT_PROPERTY, context, activeContext);
-  }
-
-  public String getStatusText()
-  {
-    return statusText;
-  }
-
-  public void setStatusText(final String statusText)
-  {
-    final String oldText = this.statusText;
-    this.statusText = statusText;
-    propertyChangeSupport.firePropertyChange(STATUS_TEXT_PROPERTY, oldText, statusText);
-  }
-
-  public void addPropertyChangeListener(final PropertyChangeListener listener)
-  {
-    propertyChangeSupport.addPropertyChangeListener(listener);
-  }
-
-  public void removePropertyChangeListener(final PropertyChangeListener listener)
-  {
-    propertyChangeSupport.removePropertyChangeListener(listener);
-  }
-
-  public void addPropertyChangeListener(final String propertyName, final PropertyChangeListener listener)
-  {
-    propertyChangeSupport.addPropertyChangeListener(propertyName, listener);
-  }
-
-  public void removePropertyChangeListener(final String propertyName, final PropertyChangeListener listener)
-  {
-    propertyChangeSupport.removePropertyChangeListener(propertyName, listener);
-  }
-
-  public ReportDesignerView getView()
-  {
-    return view;
-  }
-
-  public int findActiveContextIndex()
-  {
-    for (int i = 0; i < contexts.size(); i++)
-    {
-      final ReportRenderContext context = contexts.get(i);
-      if (context == activeContext)
-      {
-        return i;
-      }
-    }
-    return -1;
-  }
-
-  public boolean isSelectionWaiting()
-  {
-    return selectionWaiting;
-  }
-
-  public void setSelectionWaiting(final boolean selectionWaiting)
-  {
-    final boolean oldSelectionWaiting = this.selectionWaiting;
-    this.selectionWaiting = selectionWaiting;
-    propertyChangeSupport.firePropertyChange("selectionWaiting", oldSelectionWaiting, selectionWaiting);//NON-NLS
-  }
-
-  public GlobalAuthenticationStore getGlobalAuthenticationStore()
-  {
-    return authenticationStore;
-  }
-
-  public void setPageNumbers(final int page, final int pageTotal)
-  {
-    final int oldPage = this.page;
-    final int oldPageTotal = this.pageTotal;
-    this.page = page;
-    this.pageTotal = pageTotal;
-
-    propertyChangeSupport.firePropertyChange("pageTotal", oldPageTotal, pageTotal);//NON-NLS
-    propertyChangeSupport.firePropertyChange("page", oldPage, page);//NON-NLS
-  }
-
-  public int getPage()
-  {
-    return page;
-  }
-
-  public int getPageTotal()
-  {
-    return pageTotal;
+    return parent;
   }
 }

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/ReportRenderContext.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/ReportRenderContext.java
@@ -25,6 +25,7 @@ import org.pentaho.reporting.designer.core.auth.AuthenticationStore;
 import org.pentaho.reporting.designer.core.auth.GlobalAuthenticationStore;
 import org.pentaho.reporting.designer.core.auth.ReportAuthenticationStore;
 import org.pentaho.reporting.designer.core.editor.report.layouting.ReportLayouter;
+import org.pentaho.reporting.designer.core.editor.report.layouting.SharedElementRenderer;
 import org.pentaho.reporting.designer.core.inspections.AutoInspectionRunner;
 import org.pentaho.reporting.designer.core.model.ModelUtility;
 import org.pentaho.reporting.designer.core.model.ReportDataSchemaModel;
@@ -99,6 +100,7 @@ public class ReportRenderContext
 
   private static final String AUTHENTICATION_STORE_PROPERTY = "authentication-store";
 
+  private SharedElementRenderer sharedRenderer;
   private TreeSet<Integer> expandedNodes;
   private long changeTracker;
   private ZoomModel zoomModel;
@@ -110,12 +112,12 @@ public class ReportRenderContext
   private AutoInspectionRunner inspectionRunner;
   private NodeDeleteListener deleteListener;
   private HashMap<String, Object> properties;
-  private ReportLayouter reportLayouter;
 
   public ReportRenderContext(final MasterReport masterReport)
   {
     this(masterReport, masterReport, null, new GlobalAuthenticationStore());
   }
+
   public ReportRenderContext(final MasterReport masterReportElement,
                              final AbstractReportDefinition report,
                              final ReportRenderContext parentContext,
@@ -139,14 +141,6 @@ public class ReportRenderContext
       throw new NullPointerException();
     }
 
-    if (parentContext == null)
-    {
-      this.properties = new HashMap<String, Object>();
-    }
-    else
-    {
-      this.properties = parentContext.properties;
-    }
 
     this.selectionModel = new DefaultReportSelectionModel();
     this.masterReportElement = masterReportElement;
@@ -186,18 +180,33 @@ public class ReportRenderContext
       this.zoomModel.setZoomAsPercentage(zoomFactor.floatValue());
     }
 
+    if (parentContext == null)
+    {
+      this.properties = new HashMap<String, Object>();
+      this.sharedRenderer = new SharedElementRenderer(this);
+    }
+    else
+    {
+      this.sharedRenderer = parentContext.sharedRenderer;
+      this.properties = parentContext.properties;
+    }
+
     final Object maybeAuthStore = getProperty(AUTHENTICATION_STORE_PROPERTY);
     if (maybeAuthStore == null)
     {
       setProperty(AUTHENTICATION_STORE_PROPERTY, new ReportAuthenticationStore(globalAuthenticationStore));
     }
 
-    this.reportLayouter = new ReportLayouter(this);
   }
 
   public ReportLayouter getReportLayouter()
   {
-    return reportLayouter;
+    return sharedRenderer.getLayouter();
+  }
+
+  public SharedElementRenderer getSharedRenderer()
+  {
+    return sharedRenderer;
   }
 
   public ReportSelectionModel getSelectionModel()

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/CrosstabRenderComponent.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/CrosstabRenderComponent.java
@@ -44,11 +44,6 @@ public class CrosstabRenderComponent extends AbstractRenderComponent
     super(designerContext, renderContext);
   }
 
-  public void dispose()
-  {
-    super.dispose();
-  }
-
   public void installRenderer(final CrosstabRenderer rendererRoot,
                               final LinealModel horizontalLinealModel,
                               final HorizontalPositionsModel horizontalPositionsModel)

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/RootBandRenderComponent.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/RootBandRenderComponent.java
@@ -39,11 +39,6 @@ public class RootBandRenderComponent extends AbstractRenderComponent
     setShowTopBorder(showTopBorder);
   }
 
-  public void dispose()
-  {
-    super.dispose();
-  }
-
   public Element getDefaultElement()
   {
     if (elementRenderer == null)

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/layouting/DesignerTableContentProducer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/layouting/DesignerTableContentProducer.java
@@ -17,26 +17,31 @@
 
 package org.pentaho.reporting.designer.core.editor.report.layouting;
 
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
+import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.ParagraphRenderBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.RenderBox;
 import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.base.SheetLayout;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.base.TableContentProducer;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.base.TableRectangle;
 import org.pentaho.reporting.engine.classic.core.util.InstanceID;
 
 public class DesignerTableContentProducer extends TableContentProducer
 {
-  private HashMap<InstanceID, Object> conflicts;
+  private HashMap<InstanceID, Set<InstanceID>> conflicts;
+  private LinkedHashSet<InstanceID> conflictsPerCell;
 
   public DesignerTableContentProducer(final SheetLayout sheetLayout,
                                       final OutputProcessorMetaData metaData)
   {
     super(sheetLayout, metaData);
-    conflicts = new HashMap<InstanceID, Object>();
+    conflicts = new HashMap<InstanceID, Set<InstanceID>>();
+    conflictsPerCell = new LinkedHashSet<InstanceID>();
   }
 
   protected boolean startBox(final RenderBox box)
@@ -45,17 +50,64 @@ public class DesignerTableContentProducer extends TableContentProducer
     return super.startBox(box);
   }
 
-  protected void handleContentConflict(final RenderBox box)
+  protected boolean isProcessed(final RenderBox box)
   {
-    // shall we collect more information?
-    conflicts.put (box.getInstanceId(), Boolean.TRUE);
-    super.handleContentConflict(box);
+    // we process all boxes, regardless of their previous state.
+    return false;
   }
 
-  public Map<InstanceID, Object> computeConflicts (final RenderBox box)
+  protected void handleContentConflict(final RenderBox box)
   {
-    computeDesigntimeConflicts(box);
-    return Collections.unmodifiableMap(conflicts);
+    super.handleContentConflict(box);
+
+    // shall we collect more information?
+    final TableRectangle lookupRectangle = getLookupRectangle();
+    final int rectX2 = lookupRectangle.getX2();
+    final int rectY2 = lookupRectangle.getY2();
+
+    conflictsPerCell.clear();
+
+    for (int r = lookupRectangle.getY1(); r < rectY2; r++)
+    {
+      for (int c = lookupRectangle.getX1(); c < rectX2; c++)
+      {
+        final RenderBox content = getContent(r, c);
+        if (content != null)
+        {
+          conflictsPerCell.add(content.getInstanceId());
+        }
+      }
+    }
+
+    conflicts.put(box.getInstanceId(), new LinkedHashSet<InstanceID>(conflictsPerCell));
+  }
+
+  public Map<InstanceID, Set<InstanceID>> computeConflicts(final LogicalPageBox box,
+                                                           final Map<InstanceID, Set<InstanceID>> collectedConflicts)
+  {
+    if (collectedConflicts == null)
+    {
+      throw new NullPointerException();
+    }
+
+    conflicts.clear();
+    this.compute(box, false);
+    collectedConflicts.putAll(conflicts);
+    return collectedConflicts;
+  }
+
+  public Map<InstanceID, Set<InstanceID>> computeBoxConflicts(final LogicalPageBox box,
+                                                              final Map<InstanceID, Set<InstanceID>> collectedConflicts)
+  {
+    if (collectedConflicts == null)
+    {
+      throw new NullPointerException();
+    }
+
+    conflicts.clear();
+    this.computeDesigntimeConflicts(box);
+    collectedConflicts.putAll(conflicts);
+    return collectedConflicts;
   }
 
   protected void processParagraphChilds(final ParagraphRenderBox box)

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/layouting/ElementRenderer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/layouting/ElementRenderer.java
@@ -22,6 +22,9 @@ import java.awt.geom.Rectangle2D;
 import javax.swing.event.ChangeListener;
 
 import org.pentaho.reporting.designer.core.model.lineal.LinealModel;
+import org.pentaho.reporting.designer.core.util.BreakPositionsList;
+import org.pentaho.reporting.engine.classic.core.Element;
+import org.pentaho.reporting.engine.classic.core.Section;
 import org.pentaho.reporting.engine.classic.core.metadata.ElementType;
 import org.pentaho.reporting.engine.classic.core.util.InstanceID;
 import org.pentaho.reporting.engine.classic.core.util.geom.StrictBounds;
@@ -36,8 +39,6 @@ public interface ElementRenderer
   public void setVisualHeight(final double visualHeight);
 
   public double getVisualHeight();
-
-  public double getComputedHeight();
 
   public long[] getHorizontalEdgePositionKeys();
 
@@ -60,4 +61,16 @@ public interface ElementRenderer
   public boolean draw(Graphics2D g2);
 
   public StrictBounds getRootElementBounds();
+
+  Section getElement();
+
+  Element[] getElementsAt (double x, double y, double width, double height);
+  Element[] getElementsAt (double x, double y);
+
+  BreakPositionsList getHorizontalEdgePositions();
+  BreakPositionsList getVerticalEdgePositions();
+
+  void invalidateLayout();
+
+  void dispose();
 }

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/layouting/TransferGlobalLayoutProcessStep.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/layouting/TransferGlobalLayoutProcessStep.java
@@ -1,0 +1,156 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2009 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.designer.core.editor.report.layouting;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.pentaho.reporting.designer.core.model.CachedLayoutData;
+import org.pentaho.reporting.designer.core.model.ModelUtility;
+import org.pentaho.reporting.designer.core.util.BreakPositionsList;
+import org.pentaho.reporting.engine.classic.core.Element;
+import org.pentaho.reporting.engine.classic.core.MasterReport;
+import org.pentaho.reporting.engine.classic.core.RootLevelBand;
+import org.pentaho.reporting.engine.classic.core.Section;
+import org.pentaho.reporting.engine.classic.core.SubReport;
+import org.pentaho.reporting.engine.classic.core.layout.model.CanvasRenderBox;
+import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
+import org.pentaho.reporting.engine.classic.core.layout.model.RenderBox;
+import org.pentaho.reporting.engine.classic.core.layout.model.context.BoxDefinition;
+import org.pentaho.reporting.engine.classic.core.layout.process.IterateSimpleStructureProcessStep;
+import org.pentaho.reporting.engine.classic.core.util.InstanceID;
+
+/**
+ * Computes the mapping between elements and their layouted position.
+ *
+ * @author Thomas Morgner
+ */
+public class TransferGlobalLayoutProcessStep extends IterateSimpleStructureProcessStep
+{
+  private Map<InstanceID, Element> elementsById;
+  private long age;
+  private BreakPositionsList horizontalEdgePositions;
+  private Map<InstanceID, Set<InstanceID>> conflicts;
+
+  public TransferGlobalLayoutProcessStep()
+  {
+    horizontalEdgePositions = new BreakPositionsList();
+    elementsById = new HashMap<InstanceID, Element>();
+  }
+
+  public Map<InstanceID, Element> getElementsById()
+  {
+    return elementsById;
+  }
+
+  public void performTransfer(final LogicalPageBox logicalPageBox,
+                              final Map<InstanceID, Set<InstanceID>> conflicts,
+                              final MasterReport report)
+  {
+    //noinspection AssignmentToCollectionOrArrayFieldFromParameter
+    this.conflicts = conflicts;
+    this.age += 1;
+    try
+    {
+      this.elementsById.clear();
+      elementsById.put(report.getObjectID(), report);
+      collectDesignTimeElements(report);
+      startProcessing(logicalPageBox);
+    }
+    finally
+    {
+      this.conflicts = null;
+    }
+  }
+
+  private void collectDesignTimeElements(final Section sectionReportElement)
+  {
+    final int count = sectionReportElement.getElementCount();
+    for (int i = 0; i < count; i++)
+    {
+      final Element reportElement = sectionReportElement.getElement(i);
+      final InstanceID id = reportElement.getObjectID();
+      elementsById.put(id, reportElement);
+
+      if (reportElement instanceof Section)
+      {
+        collectDesignTimeElements((Section) reportElement);
+      }
+    }
+
+    if (sectionReportElement instanceof RootLevelBand)
+    {
+      final RootLevelBand rlb = (RootLevelBand) sectionReportElement;
+      for (int i = 0; i < rlb.getSubReportCount(); i += 1)
+      {
+        final SubReport reportElement = rlb.getSubReport(i);
+        final InstanceID id = reportElement.getObjectID();
+        elementsById.put(id, reportElement);
+        collectDesignTimeElements(reportElement);
+      }
+    }
+  }
+
+  protected boolean startCanvasBox(final CanvasRenderBox box)
+  {
+    return startBox(box);
+  }
+
+  public boolean startBox(final RenderBox box)
+  {
+    final InstanceID id = box.getNodeLayoutProperties().getInstanceId();
+    final Element element = elementsById.get(id);
+    if (element == null)
+    {
+      return true;
+    }
+
+    final CachedLayoutData data = ModelUtility.getCachedLayoutData(element);
+    if (data.getLayoutAge() == age)
+    {
+      return true;
+    }
+
+    data.setX(box.getX());
+    data.setY(box.getY());
+    data.setWidth(box.getWidth());
+    data.setHeight(box.getHeight());
+    final BoxDefinition boxDefinition = box.getBoxDefinition();
+    data.setPaddingX(boxDefinition.getPaddingLeft() + boxDefinition.getBorder().getLeft().getWidth());
+    data.setPaddingY(boxDefinition.getPaddingTop() + boxDefinition.getBorder().getTop().getWidth());
+    data.setLayoutAge(age);
+    data.setElementType(box.getNodeType());
+    data.setConflictsInTableMode(conflicts.containsKey(id));
+
+    horizontalEdgePositions.add(data.getX(), id);
+    horizontalEdgePositions.add(data.getX() + data.getWidth(), id);
+    return true;
+  }
+
+  public BreakPositionsList getHorizontalEdgePositions()
+  {
+    return horizontalEdgePositions;
+  }
+
+  public void reset()
+  {
+    horizontalEdgePositions.clear();
+    elementsById.clear();
+  }
+}

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/messages/messages.properties
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/messages/messages.properties
@@ -79,6 +79,9 @@ MandatoryAttributeMissingInspection.MandatoryAttributeWithoutValueOrExpression=E
 MandatoryAttributeMissingInspection.MandatoryAttributeWithoutValue=Element ''{0}'' does not define a value for mandatory attribute ''{1}''
 
 OverlappingElementsInspection.ElementConflictsInTableMode=Element ''{0}'' overlaps with other content and will not be printed in table-exports.
+OverlappingElementsInspection.ElementConflictsInTableModeSingle=Element ''{0}'' overlaps with element ''{1}'' and will not be printed in table-exports.
+OverlappingElementsInspection.ElementConflictsInTableModeMultiples=Element ''{0}'' overlaps with element ''{1}'' and {2} other elements and will not be printed in table-exports.
+OverlappingElementsInspection.UnidentifiedElement=<unidentified>
 
 ReportMigrationInspection.ElementInvalid=Element ''{0}'' is not allowed for reports in compatibility mode for version ''{1}''
 ReportMigrationInspection.AttributeInvalid=Attribute ''{0}'' on element ''{1}''is not allowed for reports in compatibility mode for version ''{2}''

--- a/designer/report-designer/test/org/pentaho/reporting/designer/FormulaDialogTest.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/FormulaDialogTest.java
@@ -8,7 +8,7 @@ import org.pentaho.openformula.ui.FormulaEditorDialog;
 import org.pentaho.reporting.designer.core.DefaultReportDesignerContext;
 import org.pentaho.reporting.designer.core.ReportDesignerBoot;
 import org.pentaho.reporting.designer.core.util.GUIUtils;
-import org.pentaho.reporting.designer.util.TestReportDesignerView;
+import org.pentaho.reporting.designer.testsupport.TestReportDesignerView;
 import org.pentaho.ui.xul.XulException;
 
 /**

--- a/designer/report-designer/test/org/pentaho/reporting/designer/Prd4313Test.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/Prd4313Test.java
@@ -1,0 +1,52 @@
+package org.pentaho.reporting.designer;
+
+import java.io.PrintStream;
+
+import junit.framework.TestCase;
+import org.pentaho.reporting.designer.core.editor.ReportRenderContext;
+import org.pentaho.reporting.designer.core.editor.report.layouting.ReportLayouter;
+import org.pentaho.reporting.designer.core.editor.report.layouting.SharedElementRenderer;
+import org.pentaho.reporting.designer.testsupport.TableTestUtil;
+import org.pentaho.reporting.designer.testsupport.TestReportDesignerContext;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.Element;
+import org.pentaho.reporting.engine.classic.core.MasterReport;
+import org.pentaho.reporting.engine.classic.core.SubReport;
+import org.pentaho.reporting.engine.classic.core.layout.ModelPrinter;
+
+public class Prd4313Test extends TestCase
+{
+  public void setUp ()
+  {
+    final PrintStream out = System.out;
+    final PrintStream err = System.err;
+    ClassicEngineBoot.getInstance().start();
+    System.setOut(out);
+    System.setErr(err);
+  }
+
+  public void testEventNotification()
+  {
+    final MasterReport report = new MasterReport();
+    final Element mrLabel = TableTestUtil.createDataItem("Label");
+    report.getPageHeader().addElement(mrLabel);
+
+    final Element mrLabel2 = TableTestUtil.createDataItem("Label2");
+    report.getPageHeader().addElement(mrLabel2);
+
+    final TestReportDesignerContext designerContext = new TestReportDesignerContext();
+    final int idx = designerContext.addMasterReport(report);
+    final ReportRenderContext masterContext = designerContext.getReportRenderContext(idx);
+//    final int srIdx = designerContext.addSubReport(masterContext, subReport);
+//    final ReportRenderContext subContext = designerContext.getReportRenderContext(srIdx);
+
+
+    final SharedElementRenderer sharedRenderer = masterContext.getSharedRenderer();
+    assertTrue(sharedRenderer.performLayouting());
+
+    ModelPrinter.INSTANCE.print(sharedRenderer.getPageBox());
+
+    // we should have conflicts ..
+  //  assertFalse(sharedRenderer.getConflicts().isEmpty());
+  }
+}

--- a/designer/report-designer/test/org/pentaho/reporting/designer/SubReportCrashTest.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/SubReportCrashTest.java
@@ -21,7 +21,7 @@ import java.net.URL;
 
 import junit.framework.TestCase;
 import org.pentaho.reporting.designer.core.ReportDesignerBoot;
-import org.pentaho.reporting.designer.util.DebugReportRunner;
+import org.pentaho.reporting.designer.testsupport.DebugReportRunner;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.libraries.resourceloader.Resource;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;

--- a/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/DebugReportRunner.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/DebugReportRunner.java
@@ -15,7 +15,7 @@
  * Copyright (c) 2000 - 2009 Pentaho Corporation, Simba Management Limited and Contributors.  All rights reserved.
  */
 
-package org.pentaho.reporting.designer.util;
+package org.pentaho.reporting.designer.testsupport;
 
 import java.io.OutputStream;
 

--- a/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/TableTestUtil.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/TableTestUtil.java
@@ -1,0 +1,244 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2005-2011 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.designer.testsupport;
+
+import org.pentaho.reporting.engine.classic.core.AttributeNames;
+import org.pentaho.reporting.engine.classic.core.Band;
+import org.pentaho.reporting.engine.classic.core.Element;
+import org.pentaho.reporting.engine.classic.core.filter.types.LabelType;
+import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
+import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
+import org.pentaho.reporting.engine.classic.core.style.TableLayout;
+
+public class TableTestUtil
+{
+  public static interface ElementProducer
+  {
+    public Element createDataItem(final String text, final int row, final int column);
+
+    public Band createCell(final int row, final int column);
+  }
+
+  public static class DefaultElementProducer implements ElementProducer
+  {
+    private boolean createText;
+    private float width;
+    private float height;
+
+    public DefaultElementProducer(final boolean createText)
+    {
+      this.createText = createText;
+      this.width = 100;
+      this.height = 200;
+    }
+
+    public DefaultElementProducer(final float width,
+                                  final float height)
+    {
+      this.createText = true;
+      this.width = width;
+      this.height = height;
+    }
+
+    public Band createCell(final int row, final int column)
+    {
+      return TableTestUtil.createCell(1, 1);
+    }
+
+    public Element createDataItem(final String text, final int row, final int column)
+    {
+      if (createText)
+      {
+        return TableTestUtil.createDataItem(text, width, height);
+      }
+      return null;
+    }
+  }
+
+
+  public static Band createRow(final Element... boxes)
+  {
+    final Band tableRow = new Band();
+    tableRow.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_ROW);
+    tableRow.getStyle().setStyleProperty(ElementStyleKeys.MIN_WIDTH, 100f);
+    tableRow.getStyle().setStyleProperty(ElementStyleKeys.MIN_HEIGHT, 200f);
+    for (int i = 0; i < boxes.length; i++)
+    {
+      tableRow.addElement(boxes[i]);
+    }
+    return tableRow;
+  }
+
+  public static Band createAutoBox(final Element... boxes)
+  {
+    final Band tableRow = new Band();
+    tableRow.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_AUTO);
+    for (int i = 0; i < boxes.length; i++)
+    {
+      tableRow.addElement(boxes[i]);
+    }
+    return tableRow;
+  }
+
+  public static Band createCell(final Element dataItem)
+  {
+    return createCell(dataItem, 1, 1);
+  }
+
+  public static Band createCell(final Element dataItem, final int rowSpan, final int colSpan)
+  {
+    final Band tableCell = new Band();
+    tableCell.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_CELL);
+    tableCell.getStyle().setStyleProperty(ElementStyleKeys.MIN_WIDTH, 150f);
+    tableCell.getStyle().setStyleProperty(ElementStyleKeys.MIN_HEIGHT, 200f);
+    tableCell.setAttribute(AttributeNames.Table.NAMESPACE, AttributeNames.Table.ROWSPAN, rowSpan);
+    tableCell.setAttribute(AttributeNames.Table.NAMESPACE, AttributeNames.Table.COLSPAN, colSpan);
+    tableCell.addElement(dataItem);
+    return tableCell;
+  }
+
+  public static Band createCell(final int rowNumber, final int colNumber,
+                                final float cellWidth, final float cellHeight,
+                                final Element... elements)
+  {
+    final Band cell = new Band();
+    cell.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_CELL);
+    cell.getStyle().setStyleProperty(ElementStyleKeys.MIN_WIDTH, cellWidth);
+    cell.getStyle().setStyleProperty(ElementStyleKeys.MIN_HEIGHT, cellHeight);
+    cell.setName("c-" + rowNumber + "-" + colNumber);
+
+    for (int i = 0; i < elements.length; i++)
+    {
+      final Element element = elements[i];
+      cell.addElement(element);
+    }
+    return cell;
+  }
+
+  public static Element createDataItem(final String text)
+  {
+    return createDataItem(text, 100, 200);
+  }
+
+  public static Element createDataItem(final String text, final float width, final float height)
+  {
+    final Element label = new Element();
+    label.setElementType(LabelType.INSTANCE);
+    label.setAttribute(AttributeNames.Core.NAMESPACE, AttributeNames.Core.VALUE, text);
+    label.getStyle().setStyleProperty(ElementStyleKeys.MIN_WIDTH, width);
+    label.getStyle().setStyleProperty(ElementStyleKeys.MIN_HEIGHT, height);
+    return label;
+  }
+
+  public static Band createTable(final int columns, final int headerRows, final int dataRows)
+  {
+    return createTable(columns, headerRows, dataRows, false);
+  }
+
+  public static Band createTable(final int columns, final int headerRows, final int dataRows, final boolean addData)
+  {
+    return createTable(columns, headerRows, dataRows, new DefaultElementProducer(addData));
+  }
+
+  public static Band createTable(final int columns,
+                                 final int headerRows,
+                                 final int dataRows,
+                                 final ElementProducer producer)
+  {
+    final Band table = new Band();
+    table.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE);
+    table.getStyle().setStyleProperty(BandStyleKeys.TABLE_LAYOUT, TableLayout.fixed);
+
+    if (headerRows > 0)
+    {
+      final Band tableHeader = new Band();
+      tableHeader.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_HEADER);
+
+      for (int r = 0; r < headerRows; r += 1)
+      {
+        final Band row = new Band();
+        row.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_ROW);
+        row.setName("r-" + r);
+
+        for (int cellNumber = 0; cellNumber < columns; cellNumber++)
+        {
+          final Band cell = producer.createCell(r, cellNumber);
+          if (cell == null)
+          {
+            continue;
+          }
+
+          cell.setName("hr-" + r + "-" + cellNumber);
+          final Element dataItem = producer.createDataItem("Head-" + r + "-" + cellNumber, r, cellNumber);
+          if (dataItem != null)
+          {
+            cell.addElement(dataItem);
+          }
+          row.addElement(cell);
+        }
+        tableHeader.addElement(row);
+      }
+      table.addElement(tableHeader);
+    }
+
+    final Band tableBody = new Band();
+    tableBody.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_BODY);
+    for (int r = 0; r < dataRows; r += 1)
+    {
+      final Band row = new Band();
+      row.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_ROW);
+      row.setName("r-" + (r + headerRows));
+
+      for (int cellNumber = 0; cellNumber < columns; cellNumber++)
+      {
+        final Band cell = producer.createCell(r + headerRows, cellNumber);
+        if (cell == null)
+        {
+          continue;
+        }
+        cell.setName("dr-" + r + "-" + cellNumber);
+
+        Element dataItem = producer.createDataItem("Data-" + r + "-" + cellNumber, r + headerRows, cellNumber);
+        if (dataItem != null)
+        {
+          cell.addElement(dataItem);
+        }
+        row.addElement(cell);
+      }
+      tableBody.addElement(row);
+    }
+    table.addElement(tableBody);
+    return table;
+  }
+
+  public static Band createCell(final int rowSpan, final int colSpan)
+  {
+    return createCell(150, 20, rowSpan, colSpan);
+  }
+
+  public static Band createCell(final float width, final float height, final int rowSpan, final int colSpan)
+  {
+    final Band tableCell = new Band();
+    tableCell.getStyle().setStyleProperty(BandStyleKeys.LAYOUT, BandStyleKeys.LAYOUT_TABLE_CELL);
+    tableCell.getStyle().setStyleProperty(ElementStyleKeys.MIN_WIDTH, width);
+    tableCell.getStyle().setStyleProperty(ElementStyleKeys.MIN_HEIGHT, height);
+    tableCell.setAttribute(AttributeNames.Table.NAMESPACE, AttributeNames.Table.ROWSPAN, rowSpan);
+    tableCell.setAttribute(AttributeNames.Table.NAMESPACE, AttributeNames.Table.COLSPAN, colSpan);
+    return tableCell;
+  }
+}

--- a/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/TestReportDesignerContext.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/TestReportDesignerContext.java
@@ -1,0 +1,30 @@
+package org.pentaho.reporting.designer.testsupport;
+
+import java.awt.Component;
+import javax.swing.JComponent;
+import javax.swing.JPopupMenu;
+
+import org.pentaho.reporting.designer.core.AbstractReportDesignerContext;
+
+public class TestReportDesignerContext extends AbstractReportDesignerContext
+{
+  public TestReportDesignerContext()
+  {
+    super(new TestReportDesignerView());
+  }
+
+  public Component getParent()
+  {
+    return null;
+  }
+
+  public JPopupMenu getPopupMenu(final String id)
+  {
+    return null;
+  }
+
+  public JComponent getToolBar(final String id)
+  {
+    return null;
+  }
+}

--- a/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/TestReportDesignerView.java
+++ b/designer/report-designer/test/org/pentaho/reporting/designer/testsupport/TestReportDesignerView.java
@@ -1,4 +1,4 @@
-package org.pentaho.reporting.designer.util;
+package org.pentaho.reporting.designer.testsupport;
 
 import java.beans.PropertyChangeListener;
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/ModelPrinter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/ModelPrinter.java
@@ -57,6 +57,7 @@ public class ModelPrinter
     logger.debug(s);
   }
 
+  @SuppressWarnings("UnusedDeclaration")
   public void printParents(RenderNode box)
   {
     int level = 0;
@@ -122,14 +123,14 @@ public class ModelPrinter
       }
     }
 
-    if (false && box instanceof LogicalPageBox)
+    if (box instanceof LogicalPageBox)
     {
       final LogicalPageBox lbox = (LogicalPageBox) box;
       printBox(lbox.getHeaderArea(), level + 1);
       printBox(lbox.getWatermarkArea(), level + 1);
     }
     printChilds(box, level);
-    if (false && box instanceof LogicalPageBox)
+    if (box instanceof LogicalPageBox)
     {
       final LogicalPageBox lbox = (LogicalPageBox) box;
       printBox(lbox.getRepeatFooterArea(), level + 1);

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/FillFlowPagesStep.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/FillFlowPagesStep.java
@@ -104,7 +104,7 @@ public final class FillFlowPagesStep extends IterateVisualProcessStep
 
     final RenderBox footerArea = derived.getFooterArea();
     final long footerShift = contentEnd + repeatFooterArea.getHeight();
-    BoxShifter.shiftBoxUnchecked(repeatFooterArea, footerShift);
+    BoxShifter.shiftBoxUnchecked(footerArea, footerShift);
 
     // the renderer is responsible for painting the page-header and footer ..
 
@@ -216,8 +216,6 @@ public final class FillFlowPagesStep extends IterateVisualProcessStep
         cellInfo = cellInfo.parent;
       }
     }
-
-
   }
 
   protected boolean startTableSectionLevelBox(final RenderBox box)


### PR DESCRIPTION
This patch also adds a shared renderer, as all element-renderer implementations process the full report. That workload can be shared so that the report is executed only once.

Fixed problems with the overlapping node detection that resulted from the shared global rendering.
