### PR TITLE
PDI-9448 - Removed dependency on obsolete kettle-db jar file

### DIFF
--- a/designer/datasource-editor-jdbc/ivy.xml
+++ b/designer/datasource-editor-jdbc/ivy.xml
@@ -37,17 +37,6 @@
     </dependency>
 
     <!-- External dependencies -->
-    <!-- Kettle-core is required for the database dialog -->
-    <!--
-    <dependency org="${kettle.group}" name="kettle-core" rev="${dependency.kettle.revision}" transitive="false" changing="true" conf="default_external->default"/>
-    <dependency org="${kettle.group}" name="kettle-db"   rev="${dependency.kettle.revision}" transitive="false" changing="true" conf="default_external->default"/>
-    <dependency org="jaxen" name="jaxen" rev="1.1.1" transitive="false"  conf="default_external->default"/>
-    <dependency org="log4j" name="log4j" rev="1.2.8" transitive="false" conf="default_external->default"/>
-    <dependency org="commons-pool" name="commons-pool" rev="1.3" transitive="false" conf="default_external->default"/>
-    <dependency org="commons-dbcp" name="commons-dbcp" rev="1.2.1" transitive="false" conf="default_external->default"/>
-    <dependency org="commons-beanutils" name="commons-beanutils" rev="1.8.0-BETA" transitive="false" conf="default_external->default"/>
-
-    -->
     <dependency org="commons-logging" name="commons-logging-api" rev="1.1" transitive="false" conf="default_external->default"/>
     <dependency org="nickyb" name="sqleonardo" rev="2009.03.rc1"
                 transitive="false" conf="default_external->default"/>

--- a/engine/extensions-kettle/ivy.xml
+++ b/engine/extensions-kettle/ivy.xml
@@ -31,7 +31,6 @@
     <!-- kettle dependencies -->
     <dependency org="${kettle.group}" name="kettle-engine" rev="${dependency.kettle.revision}" transitive="false" changing="true" conf="default_external->default"/>
     <dependency org="${kettle.group}" name="kettle-core" rev="${dependency.kettle.revision}" transitive="false" changing="true" conf="default_external->default"/>
-    <dependency org="${kettle.group}" name="kettle-db" rev="${dependency.kettle.revision}" transitive="false" changing="true" conf="default_external->default"/>
     <dependency org="${kettle.group}" name="kettle5-log4j-plugin" rev="${dependency.kettle.revision}" transitive="false" changing="true" conf="default_external->default"/>
     <dependency org="${pentaho.group}" name="metastore" rev="${dependency.metastore.revision}" transitive="false" changing="true" conf="default_external->default"/>
 


### PR DESCRIPTION
The kettle-db jar file is obsolete and reporting is pulling this old jar from artifactory due to the version being TRUNK-SNAPSHOT. The new version of kettle-core and kettle-engine have the classes being used by reporting.
