### PR TITLE
[PRD-3899] ExcelOutputProcessorMetadata was being used before being init...

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/FlowExcelOutputProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/FlowExcelOutputProcessor.java
@@ -65,6 +65,7 @@ public class FlowExcelOutputProcessor extends AbstractTableOutputProcessor
 
 
     this.metaData = new ExcelOutputProcessorMetaData(ExcelOutputProcessorMetaData.PAGINATION_MANUAL);
+    this.metaData.initialize(config);
     this.flowSelector = new DisplayAllFlowSelector();
 
     this.printer = new ExcelPrinter();


### PR DESCRIPTION
...ialized, causing CellBackgroundProducer to incorrectly configure the unalignedPagebands feature.  This resulted in the page offset not being calculated correctly when formatting the cell background.

@tmorgner please review
