### PR TITLE
Omit this test from the normal test run, as cobertura sucks big time. Wi...

### DIFF
--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd2087Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd2087Test.java
@@ -85,11 +85,13 @@ public class Prd2087Test extends TestCase
 
   public void testSeq1Crash2() throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     final MasterReport masterReport = DebugReportRunner.parseGoldenSampleReport("Prd-2087-small.prpt");
-    // masterReport.setCompatibilityLevel(ClassicEngineBoot.computeVersionId(3, 8, 0));
     DebugReportRunner.createPDF(masterReport);
-
-//    DebugReportRunner.showDialog(masterReport);
 
   }
   /**


### PR DESCRIPTION
...thout it, this test takes 1 minute (57.758sec), with it, on a beefy CI server, it takes 1h 20 minutes.
