### PR TITLE
[BISERVER-8774] ERROR [net.sf.ehcache.store.DiskStore] libloader-dataCache: Failed to write element to disk

### DIFF
--- a/libraries/libloader/source/org/pentaho/reporting/libraries/resourceloader/loader/raw/RawResourceData.java
+++ b/libraries/libloader/source/org/pentaho/reporting/libraries/resourceloader/loader/raw/RawResourceData.java
@@ -19,6 +19,7 @@ package org.pentaho.reporting.libraries.resourceloader.loader.raw;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Arrays;
 
 import org.pentaho.reporting.libraries.resourceloader.ResourceData;
@@ -31,8 +32,9 @@ import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
  *
  * @author Thomas Morgner
  */
-public class RawResourceData implements ResourceData
-{
+public class RawResourceData implements ResourceData, Serializable
+{ 
+  private static final long serialVersionUID = 1L;
   private ResourceKey rawKey;
   private byte[] data;
   private transient volatile Long hashCode;


### PR DESCRIPTION
The pentaho log keeps logging the following error:

2013-04-01 10:48:39,167 ERROR [net.sf.ehcache.store.DiskStore] libloader-dataCache: Failed to write element to disk 'ResourceKey{schema=org.pentaho.reporting.libraries.resourceloader.loader.raw.RawResourceLoader, identifier=[B@17188069, factoryParameters={}, parent=null}'. Initial cause was org.pentaho.reporting.libraries.resourceloader.loader.raw.RawResourceData
java.io.NotSerializableException: org.pentaho.reporting.libraries.resourceloader.loader.raw.RawResourceData
at java.io.ObjectOutputStream.writeObject0(Unknown Source)
(…)
