### PR TITLE
[PRD-4522]  Changing the order of parameter removes the param from the r...

### DIFF
--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/structuretree/DataReportTree.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/structuretree/DataReportTree.java
@@ -75,13 +75,11 @@ public class DataReportTree extends AbstractReportTree
         if (event.isNodeDeleteEvent())
         {
           handleNodeRemoved(event, realModel);
-          return;
         }
 
         if (event.isNodeAddedEvent())
         {
           handleNodeAdded(event, realModel);
-          return;
         }
 
         if (event.getType() == ReportModelEvent.NODE_PROPERTIES_CHANGED)


### PR DESCRIPTION
...eport.

When handling the nodeChanged event, there were exclusive checks for isDeleted() and isAdded().  When reordering, however, both of these things are true- the node is removed from one location and added to another location.
 Since isDeleted was checked first, PRD was returning before handling the add.
