### PR TITLE
itext-rtf jar was pulling in the wrong org for bouncycastle:

### DIFF
--- a/engine/core/ivy.xml
+++ b/engine/core/ivy.xml
@@ -9,7 +9,7 @@
     	<conf name="test" visibility="private"/>
     	<conf name="source"/>
     </configurations>
-    
+
     <publications>
 	    <artifact name="${ivy.artifact.id}" type="jar" conf="default"/>
 	    <artifact name="${ivy.artifact.id}" m:classifier="sources" type="source" ext="jar" conf="source"/>
@@ -50,7 +50,11 @@
 
       <dependency org="bsf" name="bsf" rev="2.4.0" transitive="false" conf="default_external->default"/>
       <dependency org="org.beanshell" name="bsh" rev="1.3.0" conf="default_external->default"/>
-      <dependency org="com.lowagie" name="itext-rtf" rev="2.1.7" conf="default_external->default" transitive="true"/>
+
+      <dependency org="com.lowagie" name="itext-rtf" rev="2.1.7" conf="default_external->default" transitive="false"/>
+      <dependency org="bouncycastle" name="bcprov-jdk14" rev="138" conf="default_external->default" transitive="false"/>
+      <dependency org="bouncycastle" name="bcmail-jdk14" rev="138" conf="default_external->default" transitive="false"/>
+
 
       <!-- external JDK 1.2.2 dependencies -->
       <!--
@@ -70,7 +74,6 @@
 
       <!-- Testing Dependencies -->
       <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
-      <!--<dependency org="org.databene" name="contiperf" rev="2.2.0" transitive="false" conf="test->default"/>-->
       <dependency org="org.mockito" name="mockito-all" rev="1.9.5-rc1" transitive="false" conf="test->default"/>
       <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
       <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>


### PR DESCRIPTION
From Marc Bachelor:

Two of the same file are in the lib folder with slightly different names:

-rw-r--r-- 1 black-d black-d 1551468 Jul 22 02:05 bcprov-jdk14-1.38.jar
-rw-r--r-- 1 black-d black-d 1551468 Jul 22 02:05 bcprov-jdk14-138.jar

This commit keeps only the 138 version of the jar and is consistent with 3.9
