### PR TITLE
PDI-10416 broke our tests.

### DIFF
--- a/engine/core/ivy.xml
+++ b/engine/core/ivy.xml
@@ -78,6 +78,7 @@
       <dependency org="org.mockito" name="mockito-all" rev="1.9.5-rc1" transitive="false" conf="test->default"/>
       <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
       <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+      <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4" transitive="false" changing="false" conf="test->default"/>
       <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
       <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
       <dependency org="org.databene" name="contiperf" rev="2.2.0" conf="test->default"/>

--- a/engine/testcases/ivy.xml
+++ b/engine/testcases/ivy.xml
@@ -44,6 +44,7 @@
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
     <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4" transitive="false" changing="false" conf="test->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
 	</dependencies>


### PR DESCRIPTION
EHCache really needs SLF4J and randomly removing it from our dependencies wont make it happier!
