### PR TITLE
[BISERVER-9996] Making pentahoBaseURL expectations consistent between bi...

### DIFF
--- a/designer/report-designer-assembly/resource/resources/classic-engine.properties
+++ b/designer/report-designer-assembly/resource/resources/classic-engine.properties
@@ -1,5 +1,5 @@
 org.pentaho.reporting.engine.classic.core.environment.serverBaseURL=http://localhost:8080/
-org.pentaho.reporting.engine.classic.core.environment.pentahoBaseURL=http://localhost:8080/pentaho
+org.pentaho.reporting.engine.classic.core.environment.pentahoBaseURL=http://localhost:8080/pentaho/
 org.pentaho.reporting.engine.classic.core.environment.solutionRoot=/
 org.pentaho.reporting.engine.classic.core.environment.hostColonPort=localhost:8080
 org.pentaho.reporting.engine.classic.core.environment.username=Designer

--- a/engine/extensions-drilldown/source/org/pentaho/reporting/engine/classic/extensions/drilldown/drilldown-profile.xml
+++ b/engine/extensions-drilldown/source/org/pentaho/reporting/engine/classic/extensions/drilldown/drilldown-profile.xml
@@ -78,14 +78,14 @@
                        class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
                        bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
                        expert="false" hidden="false" deprecated="false" preferred="false">
-      <attribute name="formula">ENV(&quot;pentahoBaseURL&quot;) &amp; &quot;/api/repos/&quot; &amp; [&quot;::pentaho-path&quot;] &amp; &quot;/viewer?&quot; &amp; [&quot;::parameter&quot;]</attribute>
+      <attribute name="formula">ENV(&quot;pentahoBaseURL&quot;) &amp; &quot;api/repos/&quot; &amp; [&quot;::pentaho-path&quot;] &amp; &quot;/viewer?&quot; &amp; [&quot;::parameter&quot;]</attribute>
       <attribute name="extension">prpt</attribute>
     </drilldown-profile>
     <drilldown-profile name="local-sugar-no-parameter"
                        class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
                        bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
                        expert="false" hidden="false" deprecated="false" preferred="false">
-      <attribute name="formula">ENV(&quot;pentahoBaseURL&quot;) &amp; &quot;/api/repos/&quot; &amp; [&quot;::pentaho-path&quot;] &amp; &quot;/content?&quot; &amp; [&quot;::parameter&quot;]</attribute>
+      <attribute name="formula">ENV(&quot;pentahoBaseURL&quot;) &amp; &quot;api/repos/&quot; &amp; [&quot;::pentaho-path&quot;] &amp; &quot;/content?&quot; &amp; [&quot;::parameter&quot;]</attribute>
       <attribute name="extension">prpt</attribute>
     </drilldown-profile>
   </group></drilldown-profiles>


### PR DESCRIPTION
...server and reporting.  Formerly drilldown-profile expected pentahoBaseURL to not have a trailing slash, but in 5.0 it does.
