### PR TITLE
[No case]: Moved some tests to the log-running category, so that they do...

### DIFF
--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd3245Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd3245Test.java
@@ -6,14 +6,12 @@ import java.net.URL;
 import junit.framework.TestCase;
 import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
-import org.pentaho.reporting.engine.classic.core.layout.ModelPrinter;
 import org.pentaho.reporting.engine.classic.core.layout.model.CanvasRenderBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.RenderBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.RenderNode;
 import org.pentaho.reporting.engine.classic.core.modules.gui.base.PreviewDialog;
 import org.pentaho.reporting.engine.classic.core.testsupport.DebugReportRunner;
-import org.pentaho.reporting.engine.classic.core.testsupport.selector.MatchFactory;
 import org.pentaho.reporting.libraries.resourceloader.Resource;
 import org.pentaho.reporting.libraries.resourceloader.ResourceException;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
@@ -79,6 +77,11 @@ public class Prd3245Test extends TestCase
 
   public void testGoldenSample () throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     final MasterReport report = DebugReportRunner.parseGoldenSampleReport("Prd-3245.prpt");
     assertChildren(1, DebugReportRunner.layoutPage(report, 0));
     assertChildren(2, DebugReportRunner.layoutPage(report, 1));

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd3689Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd3689Test.java
@@ -48,6 +48,11 @@ public class Prd3689Test extends TestCase
 
   public void testRunReport() throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     final URL url = getClass().getResource("Prd-3689.prpt");
     assertNotNull(url);
     final ResourceManager resourceManager = new ResourceManager();

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd3950Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd3950Test.java
@@ -23,6 +23,11 @@ public class Prd3950Test extends TestCase
 
   public void testGoldRun () throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     File file = GoldTestBase.locateGoldenSampleReport("Prd-3950.prpt");
     ResourceManager mgr = new ResourceManager();
     mgr.registerDefaults();

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Pre34Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Pre34Test.java
@@ -52,6 +52,11 @@ public class Pre34Test extends TestCase
 
   public void testReportSizePRD4251() throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     final URL url = getClass().getResource("Pre-34.xml");
     assertNotNull(url);
     final ResourceManager resourceManager = new ResourceManager();

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/crosstab/CrosstabPagebreakTest.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/crosstab/CrosstabPagebreakTest.java
@@ -24,6 +24,12 @@ public class CrosstabPagebreakTest extends TestCase
 
   public void testStandardReport() throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
+
     final MasterReport report = DebugReportRunner.parseGoldenSampleReport("Prd-3857-001.prpt");
     final Group rootGroup = report.getRootGroup();
     assertTrue(rootGroup instanceof CrosstabGroup);
@@ -48,6 +54,12 @@ public class CrosstabPagebreakTest extends TestCase
 
   public void testStandardReport2() throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
+
     final MasterReport report = DebugReportRunner.parseGoldenSampleReport("Prd-3857-001.prpt");
     final Group rootGroup = report.getRootGroup();
     assertTrue(rootGroup instanceof CrosstabGroup);

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/crosstab/CrosstabTest.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/crosstab/CrosstabTest.java
@@ -54,6 +54,11 @@ public class CrosstabTest extends TestCase
 
   public void testBreaking1() throws Exception
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     final MasterReport report = DebugReportRunner.parseGoldenSampleReport("Prd-3857-002.prpt");
     final LogicalPageBox logicalPageBox = DebugReportRunner.layoutPage(report, 0);
   }

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/layout/table/TableLayoutTest.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/layout/table/TableLayoutTest.java
@@ -56,6 +56,11 @@ public class TableLayoutTest extends TestCase
 
   public void testLayoutSmallToLarge() throws ReportProcessingException, ContentProcessingException
   {
+    if ("false".equals(ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
+        ("org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest")))
+    {
+      return;
+    }
     final int[][] layout = new int[][]{
         {200, 400},
         {400, 800}


### PR DESCRIPTION
... not clog up the build system.
