### PR TITLE
PRD-4671 & PRD-4564: Removed parameterUpdateText() method as it is no longer needed...

### DIFF
--- a/libraries/libformula-ui/source/org/pentaho/openformula/ui/FormulaEditorModel.java
+++ b/libraries/libformula-ui/source/org/pentaho/openformula/ui/FormulaEditorModel.java
@@ -67,11 +67,6 @@ public class FormulaEditorModel
     return document.getElementAtPosition(index);
   }
 
-  public void updateParameterText(final int start, final int end, final String newText, final boolean hasDummyParams)
-  {
-    document.updateParameterText(start, end, newText, hasDummyParams);
-  }
-
   public void revalidateStructure()
   {
     document.revalidateStructure();

--- a/libraries/libformula-ui/source/org/pentaho/openformula/ui/FormulaEditorPanel.java
+++ b/libraries/libformula-ui/source/org/pentaho/openformula/ui/FormulaEditorPanel.java
@@ -211,7 +211,7 @@ public class FormulaEditorPanel extends JComponent implements FieldDefinitionSou
     }
   }
 
-  private class ParameterUpdateHandler implements ParameterUpdateListener
+  public class ParameterUpdateHandler implements ParameterUpdateListener
   {
     private ParameterUpdateHandler()
     {
@@ -326,9 +326,6 @@ public class FormulaEditorPanel extends JComponent implements FieldDefinitionSou
       // Rebuild the element nodes based on this new representation.
       editorModel.setFormulaText(formulaText.toString());
 
-      // Handle any dummy parameters
-      editorModel.updateParameterText(start, end, parameterText, (globalParameterIndex != -1));
-
       // Update for formula text-area
       functionTextArea.setText(formulaText.toString());
       functionTextArea.setCaretPosition(parameterText.length() + start);
@@ -413,6 +410,7 @@ public class FormulaEditorPanel extends JComponent implements FieldDefinitionSou
   private SelectFieldAction selectFieldsAction;
   private JToolBar operatorPanel;
   private DocumentSyncHandler docSyncHandler;
+  private ParameterUpdateHandler parameterUpdateHandler;
 
   public FormulaEditorPanel()
   {
@@ -509,7 +507,9 @@ public class FormulaEditorPanel extends JComponent implements FieldDefinitionSou
 
     functionInformationPanel = new FunctionInformationPanel();
     functionParameterEditor = new MultiplexFunctionParameterEditor();
-    functionParameterEditor.addParameterUpdateListener(new ParameterUpdateHandler());
+
+    parameterUpdateHandler = new ParameterUpdateHandler();
+    functionParameterEditor.addParameterUpdateListener(parameterUpdateHandler);
 
     functionTextArea = new JTextArea();
     this.setDocSyncHandler(new DocumentSyncHandler());
@@ -623,6 +623,11 @@ public class FormulaEditorPanel extends JComponent implements FieldDefinitionSou
     operatorButtonPanel.add(Box.createRigidArea(new Dimension(10, 1)));
     operatorButtonPanel.add(new ToolbarButton(selectFieldsAction));
     return operatorButtonPanel;
+  }
+
+  public ParameterUpdateHandler getParameterUpdateHandler()
+  {
+    return parameterUpdateHandler;
   }
 
   public String getFormulaText()

--- a/libraries/libformula-ui/source/org/pentaho/openformula/ui/model2/FormulaDocument.java
+++ b/libraries/libformula-ui/source/org/pentaho/openformula/ui/model2/FormulaDocument.java
@@ -731,27 +731,6 @@ public class FormulaDocument implements Document
     return (FormulaElement)rootElement.getElement(index);
   }
 
-  public void updateParameterText(final int start, final int end, String parameterText, final boolean hasDummyParams)
-  {
-    // For functions that have dummy parameters (ie like DRILLDOWN), we are always recreating the whole
-    // formula text.  So remove all elements from second position to last element.  We always remove
-    // elements from same position as the element list pops the element of the list causing all other elements
-    // to shift down.
-    if (hasDummyParams == false)
-    {
-      final int startIndex = (start == 0) ? rootElement.getElementIndex(start) : rootElement.getElementIndex(start - 1);
-      final int endIndex = rootElement.getElementIndex(end);
-
-      for (int i = startIndex + 1; i <= endIndex; i++)
-      {
-        rootElement.removeElement(startIndex + 1);
-      }
-
-      rootElement.revalidateNodePositions();
-      needRevalidateStructure = true;
-    }
-  }
-
   public void revalidateStructure()
   {
     if (needRevalidateStructure)

--- a/libraries/libformula-ui/test/org/pentaho/openformula/ui/FormulaEditorPanelTest.java
+++ b/libraries/libformula-ui/test/org/pentaho/openformula/ui/FormulaEditorPanelTest.java
@@ -126,7 +126,6 @@ public class FormulaEditorPanelTest extends TestCase
   }
 
 
-  // TODO: Fix this test case.
   public void testValidateAddingAConstantToSumFunction()
   {
     FormulaEditorPanel panel = new FormulaEditorPanel();
@@ -137,6 +136,7 @@ public class FormulaEditorPanelTest extends TestCase
 
     MultiplexFunctionParameterEditor functionParameterEditor = panel.getFunctionParameterEditor();
     DefaultFunctionParameterEditor activeEditor = functionParameterEditor.getDefaultEditor();
+    activeEditor.addParameterUpdateListener(panel.getParameterUpdateHandler());
 
     activeEditor.fireParameterUpdate(0, "1");
     activeEditor.fireParameterUpdate(1, "2");
@@ -375,6 +375,26 @@ public class FormulaEditorPanelTest extends TestCase
     activeEditor.fireParameterUpdate(1, "IF(1;2;3)");
 
     assertEquals("=IF(Logical;IF(1;2;3);Any)", panel.getFormulaText());
+  }
+
+  public void testDrilldownFormulaChangingBrowseLocation()
+  {
+    final String drillDownFormulaBase = "DRILLDOWN(\"local-sugar\"; NA(); {\"::pentaho-path\";";
+    FormulaEditorPanel panel = new FormulaEditorPanel();
+    panel.getFunctionTextArea().getDocument().removeDocumentListener(panel.getDocSyncHandler());
+
+    panel.setFormulaText("=" + drillDownFormulaBase + " \"/public/bi-developers/steel-wheels-old/reports/Top N Analysis.prpt\"})");
+
+    MultiplexFunctionParameterEditor functionParameterEditor = panel.getFunctionParameterEditor();
+    DefaultFunctionParameterEditor activeEditor = functionParameterEditor.getDefaultEditor();
+    activeEditor.addParameterUpdateListener(panel.getParameterUpdateHandler());
+
+    final String newDrillDownFormula = drillDownFormulaBase + " \"/public/bi-developers/steel-wheels-old/reports/Buyer Product Analysis.prpt\"})";
+    FormulaEditorPanel.ParameterUpdateHandler handler = panel.getParameterUpdateHandler();
+    ParameterUpdateEvent event = new ParameterUpdateEvent(activeEditor, -1, newDrillDownFormula, false);
+    handler.parameterUpdated(event);
+
+    assertEquals("=" + newDrillDownFormula, panel.getFormulaText());
   }
 
 


### PR DESCRIPTION
... due to better formula editor logic.  Made ParameterUpdateHandler accessible to test cases as the DRILLDOWN formula is not registered in function registry as it is an extension - so the handler does not get registered.  Having the handler available also lets me fix the testValidateAddingAConstantToSumFunction() failing as indicated in PRD-4564.
