### PR TITLE
PRD-4699 - Updated the build.xml to override the subfloor.xml way of setting the version number in the MANIFEST.MF

### DIFF
--- a/designer/report-designer/build.xml
+++ b/designer/report-designer/build.xml
@@ -50,28 +50,6 @@
     <!-- Override default dist target to do a dist-full instead -->
     <target name="dist" depends="dist-full"/>
     
-    <!--=======================================================================
-    	  set-build.id
-    
-      	Sets a property build.id to the either "development" or the svn revision
-      	if in release mode
-      	
-      	NOTE: OVERRIDE to fix issues with svn.revision in a git environment [PRD-4699]
-      	====================================================================-->
-    <target name="set-build.id" unless="build.id" depends="install-antcontrib">
-      <if>
-        <istrue value="${release}" />
-        <then>
-          <antcallback target="svn-revision" return="svn.revision" />
-          <property name="build.id" value="${svn.revision}" />
-        </then>
-        <else>
-          <property name="build.id" value="development" />
-        </else>
-      </if>
-    </target>
-
-
   <!--=======================================================================
       generate.manifest
       


### PR DESCRIPTION
PRD-4699 - Updated the build.xml to override the subfloor.xml way of setting the version number in the MANIFEST.MF

The version number being set in the report-designer.jar is being displayed on the splash screen and the help->about screen. The update will cause this to be "5.0.0" for the 5.0.0 release and "TRUNK-SNAPSHOT" or "4.0-SNAPSHOT" depending upon the project.revision property.
