### PR TITLE
PRD-4747: Sparklines used an xml-element that did not match the element-...

### DIFF
--- a/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/SparklineModule.java
+++ b/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/SparklineModule.java
@@ -22,6 +22,9 @@ import org.pentaho.reporting.engine.classic.core.metadata.ElementTypeRegistry;
 import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.BundleElementRegistry;
 import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.BundleStyleRegistry;
 import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.writer.BundleWriterHandlerRegistry;
+import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.xml.BarSparklineElementReadHandler;
+import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.xml.LineSparklineElementReadHandler;
+import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.xml.PieSparklineElementReadHandler;
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.xml.SparklineStyleSetWriteHandler;
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.xml.SparklineStylesReadHandler;
 import org.pentaho.reporting.libraries.base.boot.AbstractModule;
@@ -79,6 +82,10 @@ public class SparklineModule extends AbstractModule
     BundleElementRegistry.getInstance().registerGenericElement(LineSparklineType.INSTANCE);
     BundleElementRegistry.getInstance().registerGenericElement(BarSparklineType.INSTANCE);
     BundleElementRegistry.getInstance().registerGenericElement(PieSparklineType.INSTANCE);
+    // legacy element handling
+    BundleElementRegistry.getInstance().register(NAMESPACE, "line-spark", LineSparklineElementReadHandler.class);
+    BundleElementRegistry.getInstance().register(NAMESPACE, "pie-spark", PieSparklineElementReadHandler.class);
+    BundleElementRegistry.getInstance().register(NAMESPACE, "bar-spark", BarSparklineElementReadHandler.class);
     BundleWriterHandlerRegistry.getInstance().setNamespaceHasCData(NAMESPACE, false);
 
     BundleStyleRegistry.getInstance().register(SparklineStyleSetWriteHandler.class);

--- a/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/xml/BarSparklineElementReadHandler.java
+++ b/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/xml/BarSparklineElementReadHandler.java
@@ -21,7 +21,6 @@ import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.layout.el
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.BarSparklineType;
 import org.pentaho.reporting.libraries.xmlns.parser.ParseException;
 
-@Deprecated
 public class BarSparklineElementReadHandler extends AbstractElementReadHandler
 {
   public BarSparklineElementReadHandler()

--- a/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/xml/LineSparklineElementReadHandler.java
+++ b/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/xml/LineSparklineElementReadHandler.java
@@ -27,7 +27,6 @@ import org.pentaho.reporting.libraries.xmlns.parser.ParseException;
  *
  * @author Thomas Morgner
  */
-@Deprecated
 public class LineSparklineElementReadHandler extends AbstractElementReadHandler
 {
   public LineSparklineElementReadHandler()

--- a/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/xml/PieSparklineElementReadHandler.java
+++ b/engine/extensions/source/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/xml/PieSparklineElementReadHandler.java
@@ -21,7 +21,6 @@ import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.layout.el
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.PieSparklineType;
 import org.pentaho.reporting.libraries.xmlns.parser.ParseException;
 
-@Deprecated
 public class PieSparklineElementReadHandler extends AbstractElementReadHandler
 {
   public PieSparklineElementReadHandler()


### PR DESCRIPTION
...type name. Needed to add legacy mapping.
