### PR TITLE
Removing SLF4J JCL Bindings as they conflict with the SLF4J Log4J

### DIFF
--- a/designer/datasource-editor-cda/ivy.xml
+++ b/designer/datasource-editor-cda/ivy.xml
@@ -23,7 +23,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-external/ivy.xml
+++ b/designer/datasource-editor-external/ivy.xml
@@ -23,7 +23,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-jdbc/ivy.xml
+++ b/designer/datasource-editor-jdbc/ivy.xml
@@ -50,7 +50,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-kettle/ivy.xml
+++ b/designer/datasource-editor-kettle/ivy.xml
@@ -42,7 +42,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-mondrian/ivy.xml
+++ b/designer/datasource-editor-mondrian/ivy.xml
@@ -26,7 +26,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-olap4j/ivy.xml
+++ b/designer/datasource-editor-olap4j/ivy.xml
@@ -31,7 +31,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-openerp/ivy.xml
+++ b/designer/datasource-editor-openerp/ivy.xml
@@ -22,7 +22,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-pmd/ivy.xml
+++ b/designer/datasource-editor-pmd/ivy.xml
@@ -67,7 +67,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-reflection/ivy.xml
+++ b/designer/datasource-editor-reflection/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-scriptable/ivy.xml
+++ b/designer/datasource-editor-scriptable/ivy.xml
@@ -28,7 +28,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-table/ivy.xml
+++ b/designer/datasource-editor-table/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/datasource-editor-xpath/ivy.xml
+++ b/designer/datasource-editor-xpath/ivy.xml
@@ -23,7 +23,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/report-designer-assembly/ivy.xml
+++ b/designer/report-designer-assembly/ivy.xml
@@ -41,7 +41,7 @@
 		<dependency org="pentaho" name="pentaho-application-launcher" rev="${dependency.launcher.revision}" transitive="true" changing="true" conf="runtime->default" />
 
         <!-- slf4j impl requires at least log4j 1.2.12-->
-        <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.5.8" />
+        <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.7.3" />
         <dependency org="log4j" name="log4j" rev="1.2.15"/>
 
 		<!-- driver dependencies -->

--- a/designer/report-designer-extension-connectioneditor/ivy.xml
+++ b/designer/report-designer-extension-connectioneditor/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/report-designer-extension-legacy-charts/ivy.xml
+++ b/designer/report-designer-extension-legacy-charts/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/report-designer-extension-pentaho/ivy.xml
+++ b/designer/report-designer-extension-pentaho/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/report-designer-extension-toc/ivy.xml
+++ b/designer/report-designer-extension-toc/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/report-designer-extension-wizard/ivy.xml
+++ b/designer/report-designer-extension-wizard/ivy.xml
@@ -22,7 +22,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/report-designer/ivy.xml
+++ b/designer/report-designer/ivy.xml
@@ -61,7 +61,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/designer/wizard-xul/ivy.xml
+++ b/designer/wizard-xul/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/core/ivy.xml
+++ b/engine/core/ivy.xml
@@ -81,7 +81,7 @@
       <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
       <dependency org="org.mockito" name="mockito-all" rev="1.9.5-rc1" transitive="false" conf="test->default"/>
       <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
-      <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+      <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
       <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4" transitive="false" changing="false" conf="test->default"/>
       <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
       <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>

--- a/engine/extensions-charting/ivy.xml
+++ b/engine/extensions-charting/ivy.xml
@@ -24,7 +24,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/extensions-docsupport/ivy.xml
+++ b/engine/extensions-docsupport/ivy.xml
@@ -22,7 +22,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/extensions-kettle/ivy.xml
+++ b/engine/extensions-kettle/ivy.xml
@@ -81,7 +81,7 @@
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test"
                 rev="${project.revision}" transitive="false" changing="true" conf="test->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
   </dependencies>
 </ivy-module>

--- a/engine/extensions-mondrian/ivy.xml
+++ b/engine/extensions-mondrian/ivy.xml
@@ -46,7 +46,7 @@
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test"
                 rev="${project.revision}" transitive="false" changing="true" conf="test->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
   </dependencies>
 </ivy-module>

--- a/engine/extensions-olap4j/ivy.xml
+++ b/engine/extensions-olap4j/ivy.xml
@@ -42,7 +42,7 @@
 		<dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default" />
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test"
                 rev="${project.revision}" transitive="false" changing="true" conf="test->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
 	</dependencies>
 </ivy-module>

--- a/engine/extensions-openerp/ivy.xml
+++ b/engine/extensions-openerp/ivy.xml
@@ -34,7 +34,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/extensions-reportdesigner-parser/ivy.xml
+++ b/engine/extensions-reportdesigner-parser/ivy.xml
@@ -26,7 +26,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/extensions-scripting/ivy.xml
+++ b/engine/extensions-scripting/ivy.xml
@@ -25,7 +25,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/extensions/ivy.xml
+++ b/engine/extensions/ivy.xml
@@ -36,7 +36,7 @@
 
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
     <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4" transitive="false" changing="false" conf="test->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}" transitive="false"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>

--- a/engine/legacy-charts/ivy.xml
+++ b/engine/legacy-charts/ivy.xml
@@ -31,7 +31,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/legacy-functions/ivy.xml
+++ b/engine/legacy-functions/ivy.xml
@@ -27,7 +27,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"

--- a/engine/server/ivy.xml
+++ b/engine/server/ivy.xml
@@ -56,7 +56,7 @@
       <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
       <dependency org="org.mockito" name="mockito-all" rev="1.9.5-rc1" transitive="false" conf="test->default"/>
       <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
-      <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+      <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
       <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
       <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
 

--- a/engine/testcases/ivy.xml
+++ b/engine/testcases/ivy.xml
@@ -43,7 +43,7 @@
 		<dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}" transitive="false"/>
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="test->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="test->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
     <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4" transitive="false" changing="false" conf="test->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="test->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>

--- a/engine/tools/ivy.xml
+++ b/engine/tools/ivy.xml
@@ -52,7 +52,7 @@
     <!-- Testing Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="default_external->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0" transitive="false" conf="default_external->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" transitive="false" conf="default_external->default"/>
+    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="default_external->default"/>
     <dependency org="simple-jndi" name="simple-jndi" rev="0.11.3" transitive="false" conf="default_external->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="default_external->default"/>
 	</dependencies>

--- a/libraries/libloader/ivy.xml
+++ b/libraries/libloader/ivy.xml
@@ -43,6 +43,6 @@
 
 		<!-- testing dependencies -->
 		<dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default" />
-		<dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" conf="test->default" />
+		<dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" conf="test->default" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
Removing SLF4J JCL Bindings as they conflict with the SLF4J Log4J
- Instances of slf4j-jcl are replaced simply by the slf4j-api which contains a default LogBack binding.
- Finally, the SLF4J dependencies have been upgraded to match the version in use by the Pentaho Platform
