### PR TITLE
PRD-4755 modify launcher to include plugin directory

### DIFF
--- a/designer/report-designer-assembly/resource.mac/Contents/Resources/Java/launcher.properties
+++ b/designer/report-designer-assembly/resource.mac/Contents/Resources/Java/launcher.properties
@@ -1,6 +1,6 @@
 main=org.pentaho.reporting.designer.core.ReportDesigner
 libraries=../../lib:../../lib/jdbc:../../lib/ext
-classpath=../../resources
+classpath=../../resources:../../plugins
 
 system-property.pentaho.installed.licenses.file=${PENTAHO_INSTALLED_LICENSE_PATH}
 uninstall-security-manager=false


### PR DESCRIPTION
Big-Data plugins fail to register on the Mac and if working directory is not set to install dir
