### PR TITLE
PRD-4984 - Fixes for multiple entries

### DIFF
--- a/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/EmbeddedKettleDataSourceDialog.java
+++ b/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/EmbeddedKettleDataSourceDialog.java
@@ -110,6 +110,7 @@ public class EmbeddedKettleDataSourceDialog extends KettleDataSourceDialog
           datasourcePanel.removeAll();
           datasourcePanel.add(selectedQuery.createUI(), BorderLayout.CENTER);
           datasourcePanel.revalidate();
+          datasourcePanel.repaint();
         }
 
         editParameterAction.setEnabled(true);
@@ -257,7 +258,7 @@ public class EmbeddedKettleDataSourceDialog extends KettleDataSourceDialog
   protected EmbeddedKettleQueryEntry createNewQueryEntry(String queryName) throws KettleException
   {
     EmbeddedKettleQueryEntry entry =
-        EmbeddedKettleQueryEntry.createFromTemplate(queryName, datasourceId, getDesignTimeContext());
+        EmbeddedKettleQueryEntry.createFromTemplate(queryName, datasourceId);
     entry.addPropertyChangeListener("validated", new PreviewChangeListener());
     return entry;
   }
@@ -274,7 +275,7 @@ public class EmbeddedKettleDataSourceDialog extends KettleDataSourceDialog
     {
       EmbeddedKettleTransformationProducer prod = (EmbeddedKettleTransformationProducer) producer;
       EmbeddedKettleQueryEntry entry = EmbeddedKettleQueryEntry.createFromExisting(queryName, prod,
-              getDesignTimeContext().getDataFactoryContext(), getDesignTimeContext());
+              getDesignTimeContext().getDataFactoryContext());
       entry.addPropertyChangeListener("validated", new PreviewChangeListener());
       return entry;
     }

--- a/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/EmbeddedKettleQueryEntry.java
+++ b/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/EmbeddedKettleQueryEntry.java
@@ -29,7 +29,6 @@ import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.reporting.engine.classic.core.DataFactoryContext;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
-import org.pentaho.reporting.engine.classic.core.designtime.DesignTimeContext;
 import org.pentaho.reporting.engine.classic.extensions.datasources.kettle.AbstractKettleTransformationProducer;
 import org.pentaho.reporting.engine.classic.extensions.datasources.kettle.DocumentHelper;
 import org.pentaho.reporting.engine.classic.extensions.datasources.kettle.EmbeddedKettleTransformationProducer;
@@ -81,12 +80,10 @@ public class EmbeddedKettleQueryEntry extends KettleQueryEntry
 
   public static EmbeddedKettleQueryEntry createFromExisting(String name,
                                                             EmbeddedKettleTransformationProducer producer,
-                                                            DataFactoryContext dataFactoryContext,
-                                                            DesignTimeContext designTimeContext)
+                                                            DataFactoryContext dataFactoryContext)
       throws KettleException, ReportDataFactoryException
   {
-    XulDialogHelper dialogHelper =
-        new XulDialogHelper(designTimeContext, producer.loadTransformation(dataFactoryContext));
+    XulDialogHelper dialogHelper = new XulDialogHelper(producer.loadTransformation(dataFactoryContext));
     EmbeddedKettleQueryEntry entry = new EmbeddedKettleQueryEntry(name, producer.getPluginId(), dialogHelper);
     entry.setArguments(producer.getArguments());
     entry.setParameters(producer.getParameter());
@@ -94,12 +91,11 @@ public class EmbeddedKettleQueryEntry extends KettleQueryEntry
   }
 
   public static EmbeddedKettleQueryEntry createFromTemplate(String name,
-                                                            String pluginId,
-                                                            DesignTimeContext designTimeContext)
+                                                            String pluginId)
       throws KettleException
   {
 
-    XulDialogHelper dialogHelper = new XulDialogHelper(designTimeContext, loadTemplate(pluginId));
+    XulDialogHelper dialogHelper = new XulDialogHelper(loadTemplate(pluginId));
     return new EmbeddedKettleQueryEntry(name, pluginId, dialogHelper);
   }
 

--- a/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/KettleDataSourceDialog.java
+++ b/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/KettleDataSourceDialog.java
@@ -938,7 +938,12 @@ public class KettleDataSourceDialog extends CommonDialog
   protected boolean validateInputs(final boolean onConfirm)
   {
     getConfirmAction().setEnabled(queryNameList.getModel().getSize() > 0);
-    return super.validateInputs(onConfirm);
+    if (queryNameList.getModel().getSize() == 0)
+    {
+      return false;
+    }
+
+    return true;
   }
 
   protected KettleQueryEntry createNewQueryEntry(String queryName) throws KettleException

--- a/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/embedded/XulDialogHelper.java
+++ b/designer/datasource-editor-kettle/source/org/pentaho/reporting/ui/datasources/kettle/embedded/XulDialogHelper.java
@@ -35,7 +35,6 @@ import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.ui.trans.step.BaseStepGenericXulDialog;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
-import org.pentaho.reporting.engine.classic.core.designtime.DesignTimeContext;
 import org.pentaho.reporting.engine.classic.extensions.datasources.kettle.EmbeddedKettleDataFactoryMetaData;
 import org.pentaho.ui.xul.XulComponent;
 import org.pentaho.ui.xul.swing.tags.SwingDialog;
@@ -59,14 +58,12 @@ public class XulDialogHelper
   }
 
   private BaseStepGenericXulDialog dialog;
-  private DesignTimeContext context;
   private TransMeta transformation;
   private ArrayList<ChangeListener> changeListeners;
+  private JComponent editor;
 
-  public XulDialogHelper(final DesignTimeContext context,
-                         final TransMeta transformation)
+  public XulDialogHelper(final TransMeta transformation)
   {
-    this.context = context;
     this.transformation = transformation;
     this.changeListeners = new ArrayList<ChangeListener>();
   }
@@ -83,10 +80,16 @@ public class XulDialogHelper
 
   public JComponent createEditor() throws ReportDataFactoryException
   {
+    if (editor != null)
+    {
+      return editor;
+    }
+
     dialog = createDialog();
     if (dialog == null)
     {
-      return new JPanel();
+      editor = new JPanel();
+      return editor;
     }
 
     // validate is a hardcoded name inside the xul dialogs
@@ -100,6 +103,7 @@ public class XulDialogHelper
     SwingDialog parent = (SwingDialog) root.getParent();
     JComponent panel = parent.getContainer();
     dialog.setModalParent(panel);
+    editor = panel;
     return panel;
   }
 


### PR DESCRIPTION
Make sure that the Xul dialog per query-entry is always reused and repaint events happen correctly.
(cherry picked from commit a498844)
