### PR TITLE
PRD-5045 - Performance of reports with large number of empty bands

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/model/RenderBox.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/model/RenderBox.java
@@ -90,6 +90,9 @@ public abstract class RenderBox extends RenderNode
   private long contentAge;
   private long overflowAreaWidth;
   private long overflowAreaHeight;
+  private long processKeyStepAge;
+  private ReportStateKey processKeyCached;
+  private boolean processKeyFinish;
 
   /**
    * Is the amount of space reserved for orphans beginning at the y-position of the box.
@@ -1586,5 +1589,27 @@ public abstract class RenderBox extends RenderNode
   {
     setFlag(FLAG_BOX_PREVENT_PAGINATION, preventPagination);
     updateChangeTracker();
+  }
+
+  public void setProcessKeyCached(final ReportStateKey processKeyCached)
+  {
+    this.processKeyStepAge = getChangeTracker();
+    this.processKeyCached = processKeyCached;
+    this.processKeyFinish = isFinishedPaginate();
+  }
+
+  public long getProcessKeyStepAge()
+  {
+    return processKeyStepAge;
+  }
+
+  public ReportStateKey getProcessKeyCached()
+  {
+    return processKeyCached;
+  }
+
+  public boolean isProcessKeyFinish()
+  {
+    return processKeyFinish;
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/CountBoxesStep.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/CountBoxesStep.java
@@ -65,6 +65,11 @@ public class CountBoxesStep extends IterateSimpleStructureProcessStep
     return totalCount;
   }
 
+  public int getTotalCount()
+  {
+    return totalCount;
+  }
+
   public void process(final LogicalPageBox box)
   {
     if (!enabled)

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/FindOldestProcessKeyStep.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/FindOldestProcessKeyStep.java
@@ -32,9 +32,16 @@ public class FindOldestProcessKeyStep extends IterateSimpleStructureProcessStep
 
   public ReportStateKey find(final RenderBox box)
   {
+    if (box.getProcessKeyStepAge() == box.getChangeTracker() &&
+        box.isProcessKeyFinish() == box.isFinishedPaginate())
+    {
+      return box.getProcessKeyCached();
+    }
+
     key = null;
     finishedPaginate = box.isFinishedPaginate();
     startProcessing(box);
+    box.setProcessKeyCached(key);
     return key;
   }
 
@@ -60,11 +67,19 @@ public class FindOldestProcessKeyStep extends IterateSimpleStructureProcessStep
 
   protected boolean startBox(final RenderBox box)
   {
+    if (box.getProcessKeyStepAge() == box.getChangeTracker() &&
+        box.isProcessKeyFinish() == box.isFinishedPaginate())
+    {
+      key = box.getProcessKeyCached();
+      return false;
+    }
+
     processOtherNode(box);
     if (finishedPaginate == true)
     {
       box.setFinishedPaginate(finishedPaginate);
     }
+    box.setProcessKeyCached(key);
     return true;
   }
 }


### PR DESCRIPTION
can be greatly improved by caching the sub-tree access in the layout
model more efficiently.
