### PR TITLE
SP-1127 - Backport of PRD-4980 - Objects not visible on the `No data` se...

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/output/RelationalGroupOutputHandler.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/output/RelationalGroupOutputHandler.java
@@ -67,7 +67,7 @@ public class RelationalGroupOutputHandler implements GroupOutputHandler
       outputFunction.addSubReportMarkers(renderer.endSection());
     }
 
-    if (numberOfRows == 0)
+    if (numberOfRows == 0 || outputFunction.getMetaData().isFeatureSupported(OutputProcessorFeature.DESIGNTIME))
     {
       // ups, we have no data. Lets signal that ...
       final NoDataBand noDataBand = event.getReport().getNoDataBand();


### PR DESCRIPTION
...ction of the report design canvas (5.0)

What was done:
1) added check to display no data in design mode
