### PR TITLE
PRD-4897 - Make word-wrap the default, to keep in sync with

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/style/ElementDefaultStyleSheet.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/style/ElementDefaultStyleSheet.java
@@ -70,6 +70,7 @@ public class ElementDefaultStyleSheet extends ElementStyleSheet
     setStyleProperty(TextStyleKeys.TRIM_TEXT_CONTENT, Boolean.FALSE);
     setStyleProperty(TextStyleKeys.TEXT_WRAP, TextWrap.WRAP);
     setStyleProperty(TextStyleKeys.DIRECTION, TextDirection.LTR);
+    setStyleProperty(TextStyleKeys.WORDBREAK, Boolean.TRUE);
 
     setStyleProperty(ElementStyleKeys.PAINT, ElementDefaultStyleSheet.DEFAULT_PAINT);
     setStyleProperty(ElementStyleKeys.STROKE, ElementDefaultStyleSheet.DEFAULT_STROKE);


### PR DESCRIPTION
the past releases even on the new text-layouting.
