### PR TITLE
PRD-5073 - Changes IntelliJ scope for platform jars to provided, so

### DIFF
--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/testsupport/TestSetupModule.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/testsupport/TestSetupModule.java
@@ -25,9 +25,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.Connection;
-import java.sql.DriverManager;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.pentaho.reporting.engine.classic.core.metadata.AttributeRegistry;
@@ -38,6 +39,7 @@ import org.pentaho.reporting.libraries.base.boot.AbstractModule;
 import org.pentaho.reporting.libraries.base.boot.ModuleInitializeException;
 import org.pentaho.reporting.libraries.base.boot.SubSystem;
 import org.pentaho.reporting.libraries.base.util.DebugLog;
+import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 
 public class TestSetupModule extends AbstractModule
 {
@@ -63,8 +65,9 @@ public class TestSetupModule extends AbstractModule
 
     try
     {
-      Class.forName("org.hsqldb.jdbcDriver");
-      populateDatabase();
+      Driver driver = ObjectUtilities.loadAndInstantiate
+          ("org.hsqldb.jdbcDriver", TestSetupModule.class, Driver.class);
+      populateDatabase(driver);
     }
     catch (Exception e)
     {
@@ -72,10 +75,13 @@ public class TestSetupModule extends AbstractModule
     }
   }
 
-  private void populateDatabase()
+  private void populateDatabase(Driver driver)
       throws SQLException, IOException
   {
-    final Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:SampleData", "sa", "");
+    Properties p = new Properties();
+    p.setProperty("user", "sa");
+    p.setProperty("password", "");
+    final Connection connection = driver.connect("jdbc:hsqldb:mem:SampleData", p);
     connection.setAutoCommit(false);
     try
     {

--- a/engine/extensions-sampledata/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/sampledata/DummyTest.java
+++ b/engine/extensions-sampledata/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/sampledata/DummyTest.java
@@ -1,11 +1,25 @@
 package org.pentaho.reporting.engine.classic.extensions.datasources.sampledata;
 
 import junit.framework.TestCase;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.libraries.base.boot.Module;
+import org.pentaho.reporting.libraries.base.boot.PackageManager;
 
 public class DummyTest extends TestCase
 {
   public void testNothing()
   {
-
+    ClassicEngineBoot.getInstance().start();
+    PackageManager packageManager = ClassicEngineBoot.getInstance().getPackageManager();
+    Module[] activeModules = packageManager.getActiveModules();
+    boolean found = false;
+    for (Module activeModule : activeModules)
+    {
+      if (SampleDataModule.class.getName().equals(activeModule.getModuleClass()))
+      {
+        found = true;
+      }
+    }
+    assertTrue(found);
   }
 }

--- a/libraries/libpensol/libpensol.iml
+++ b/libraries/libpensol/libpensol.iml
@@ -26,7 +26,7 @@
         <jarDirectory url="file://$MODULE_DIR$/lib/external" recursive="false" />
       </library>
     </orderEntry>
-    <orderEntry type="module-library">
+    <orderEntry type="module-library" scope="PROVIDED">
       <library>
         <CLASSES>
           <root url="file://$MODULE_DIR$/lib/platform" />


### PR DESCRIPTION
that they do not get inherited to sub-modules. Also made the sample-data
init-method more resilent to driver manager interference like the one
done by the pentaho-platform code.
