### PR TITLE
PRD-4924 - Report-Preprocessor-metadata missed an initialization and

### DIFF
--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/messages/messages.properties
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/messages/messages.properties
@@ -390,3 +390,5 @@ MigrateReportTask.Clear=Clear compatibility setting
 MigrateReportTask.Cancel=Cancel
 
 AlignmentUtilities.Undo=Align Elements
+
+ReportPreProcessorCellEditor.EditingInstanceMessage={0} (Configurable Instance)

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/util/table/expressions/ReportPreProcessorCellEditor.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/util/table/expressions/ReportPreProcessorCellEditor.java
@@ -55,14 +55,6 @@ import org.pentaho.reporting.libraries.designtime.swing.LibSwingUtil;
 import org.pentaho.reporting.libraries.designtime.swing.SmartComboBox;
 import org.pentaho.reporting.libraries.designtime.swing.ValuePassThroughCellEditor;
 
-/**
- * Todo: Document me!
- * <p/>
- * Date: 29.06.2009
- * Time: 15:46:15
- *
- * @author Thomas Morgner.
- */
 public class ReportPreProcessorCellEditor implements TableCellEditor
 {
   private static final String POPUP_EDITOR = "popupEditor";

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/util/table/expressions/ReportPreProcessorListCellRenderer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/util/table/expressions/ReportPreProcessorListCellRenderer.java
@@ -23,7 +23,10 @@ import javax.swing.DefaultListCellRenderer;
 import javax.swing.JLabel;
 import javax.swing.JList;
 
+import org.pentaho.reporting.designer.core.Messages;
+import org.pentaho.reporting.engine.classic.core.ReportPreProcessor;
 import org.pentaho.reporting.engine.classic.core.metadata.ReportPreProcessorMetaData;
+import org.pentaho.reporting.engine.classic.core.metadata.ReportPreProcessorRegistry;
 
 public class ReportPreProcessorListCellRenderer extends DefaultListCellRenderer
 {
@@ -45,9 +48,24 @@ public class ReportPreProcessorListCellRenderer extends DefaultListCellRenderer
       rendererComponent.setText(metaData.getDisplayName(Locale.getDefault()));
       rendererComponent.setToolTipText(metaData.getDeprecationMessage(Locale.getDefault()));
     }
-    else
+    else if (value instanceof ReportPreProcessor)
     {
-      rendererComponent.setText(" ");
+      String key = value.getClass().getName();
+      if (ReportPreProcessorRegistry.getInstance().isReportPreProcessorRegistered(key))
+      {
+        ReportPreProcessorMetaData metaData =
+            ReportPreProcessorRegistry.getInstance().getReportPreProcessorMetaData(key);
+        String displayName = metaData.getDisplayName(Locale.getDefault());
+        rendererComponent.setText(Messages.getString("ReportPreProcessorCellEditor.EditingInstanceMessage", displayName));
+        rendererComponent.setToolTipText(metaData.getDeprecationMessage(Locale.getDefault()));
+      }
+      else {
+        rendererComponent.setText(Messages.getString("ReportPreProcessorCellEditor.EditingInstanceMessage", key));
+        rendererComponent.setToolTipText(null);
+      }
+    }
+    else {
+      setText(" ");
     }
     return rendererComponent;
   }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/DefaultReportPreProcessorPropertyMetaData.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/DefaultReportPreProcessorPropertyMetaData.java
@@ -25,6 +25,7 @@ import java.io.ObjectOutputStream;
 
 import org.pentaho.reporting.engine.classic.core.Element;
 import org.pentaho.reporting.engine.classic.core.function.Expression;
+import org.pentaho.reporting.libraries.base.util.ArgumentNullException;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 
@@ -56,18 +57,9 @@ public class DefaultReportPreProcessorPropertyMetaData extends AbstractMetaData
                                                    final int compatibilityLevel)
   {
     super(name, bundleLocation, "property.", expert, preferred, hidden, deprecated, experimental, compatibilityLevel);
-    if (propertyRole == null)
-    {
-      throw new NullPointerException();
-    }
-    if (beanInfo == null)
-    {
-      throw new NullPointerException();
-    }
-    if (reportPreProcessorCore == null)
-    {
-      throw new NullPointerException();
-    }
+    ArgumentNullException.validate("propertyRole", propertyRole);
+    ArgumentNullException.validate("beanInfo", beanInfo);
+    ArgumentNullException.validate("reportPreProcessorCore", reportPreProcessorCore);
 
     this.beanInfo = beanInfo;
     this.reportPreProcessorCore = reportPreProcessorCore;
@@ -84,6 +76,10 @@ public class DefaultReportPreProcessorPropertyMetaData extends AbstractMetaData
 
   public Class getPropertyType()
   {
+    if (propertyDescriptor == null)
+    {
+      propertyDescriptor = beanInfo.getPropertyDescriptor(getName());
+    }
     return propertyDescriptor.getPropertyType();
   }
 

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd4924Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd4924Test.java
@@ -1,0 +1,65 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2013 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.bugs;
+
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.metadata.ReportPreProcessorMetaData;
+import org.pentaho.reporting.engine.classic.core.metadata.ReportPreProcessorPropertyMetaData;
+import org.pentaho.reporting.engine.classic.core.metadata.ReportPreProcessorRegistry;
+
+public class Prd4924Test
+{
+  @Before
+  public void setUp() throws Exception
+  {
+    ClassicEngineBoot.getInstance().start();
+  }
+
+  @Test
+  public void testGetPropertyType()
+  {
+    ReportPreProcessorMetaData[] metas =
+        ReportPreProcessorRegistry.getInstance().getAllReportPreProcessorMetaDatas();
+    for (ReportPreProcessorMetaData meta : metas)
+    {
+      ReportPreProcessorPropertyMetaData[] propertyDescriptions = meta.getPropertyDescriptions();
+      for (ReportPreProcessorPropertyMetaData propertyDescription : propertyDescriptions)
+      {
+        assertNotNull(propertyDescription.getPropertyType());
+      }
+    }
+  }
+
+  @Test
+  public void testGetBeanDescriptor()
+  {
+    ReportPreProcessorMetaData[] metas =
+        ReportPreProcessorRegistry.getInstance().getAllReportPreProcessorMetaDatas();
+    for (ReportPreProcessorMetaData meta : metas)
+    {
+      ReportPreProcessorPropertyMetaData[] propertyDescriptions = meta.getPropertyDescriptions();
+      for (ReportPreProcessorPropertyMetaData propertyDescription : propertyDescriptions)
+      {
+        assertNotNull(propertyDescription.getBeanDescriptor());
+      }
+    }
+  }
+}


### PR DESCRIPTION
 thus failed with an NPE. Also made the editor more user-friendly
  by indicating which instance is edited instead of showing a blank
  field.
