### PR TITLE
PRD-4891 - Overlay renderers abused the graphics by not taking the

### DIFF
--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/AbstractRenderComponent.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/AbstractRenderComponent.java
@@ -1044,7 +1044,7 @@ public abstract class AbstractRenderComponent extends JComponent
     {
     }
 
-    public void validate(final ReportDocumentContext context, final double zoomFactor)
+    public void validate(final ReportDocumentContext context, final double zoomFactor, final Point2D sectionOffset)
     {
     }
 
@@ -1372,10 +1372,7 @@ public abstract class AbstractRenderComponent extends JComponent
       final OverlayRenderer renderer = renderers[i];
       final Graphics2D selectionG2 = (Graphics2D) g.create();
 
-      // TODO: Check if this is a no-op due to negative offset
-      selectionG2.translate(0, -offset.getY() * scaleFactor);
-
-      renderer.validate(getRenderContext(), scaleFactor);
+      renderer.validate(getRenderContext(), scaleFactor, offset);
       renderer.draw(selectionG2, new Rectangle2D.Double(getLeftBorder(), getTopBorder(), getWidth(), getHeight()), this);
       selectionG2.dispose();
     }

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/GuidelineOverlayRenderer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/GuidelineOverlayRenderer.java
@@ -20,6 +20,7 @@ package org.pentaho.reporting.designer.core.editor.report;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.ImageObserver;
 
@@ -28,14 +29,6 @@ import org.pentaho.reporting.designer.core.model.lineal.GuideLine;
 import org.pentaho.reporting.designer.core.model.lineal.LinealModel;
 import org.pentaho.reporting.designer.core.settings.WorkspaceSettings;
 
-/**
- * Todo: Document me!
- * <p/>
- * Date: 26.04.2009
- * Time: 21:04:40
- *
- * @author Thomas Morgner.
- */
 public class GuidelineOverlayRenderer implements OverlayRenderer
 {
   private double scaleFactor;
@@ -48,7 +41,7 @@ public class GuidelineOverlayRenderer implements OverlayRenderer
     this.verticalLinealModel = verticalLinealModel;
   }
 
-  public void validate(final ReportDocumentContext context, final double zoomFactor)
+  public void validate(final ReportDocumentContext context, final double zoomFactor, final Point2D sectionOffset)
   {
     this.scaleFactor = zoomFactor;
   }

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/OverlappingElementOverlayRenderer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/OverlappingElementOverlayRenderer.java
@@ -19,6 +19,7 @@ package org.pentaho.reporting.designer.core.editor.report;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.ImageObserver;
 
@@ -37,6 +38,7 @@ public class OverlappingElementOverlayRenderer implements OverlayRenderer
   private Element rootElement;
   private double zoomFactor;
   private Rectangle2D elementBounds;
+  private double offset;
 
   public OverlappingElementOverlayRenderer(final Element defaultElement)
   {
@@ -44,9 +46,10 @@ public class OverlappingElementOverlayRenderer implements OverlayRenderer
     this.rootElement = defaultElement;
   }
 
-  public void validate(final ReportDocumentContext context, final double zoomFactor)
+  public void validate(final ReportDocumentContext context, final double zoomFactor, final Point2D sectionOffset)
   {
     this.zoomFactor = zoomFactor;
+    this.offset = sectionOffset.getY();
   }
 
   public void draw(final Graphics2D graphics, final Rectangle2D bounds, final ImageObserver obs)
@@ -55,6 +58,8 @@ public class OverlappingElementOverlayRenderer implements OverlayRenderer
     {
       return;
     }
+
+    graphics.translate(0, -offset);
 
     draw(rootElement, graphics);
   }

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/OverlayRenderer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/OverlayRenderer.java
@@ -18,6 +18,7 @@
 package org.pentaho.reporting.designer.core.editor.report;
 
 import java.awt.Graphics2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.ImageObserver;
 
@@ -32,6 +33,6 @@ import org.pentaho.reporting.designer.core.editor.ReportDocumentContext;
  */
 public interface OverlayRenderer
 {
-  public void validate(final ReportDocumentContext context, final double zoomFactor);
+  public void validate(final ReportDocumentContext context, final double zoomFactor, Point2D sectionOffset);
   public void draw(final Graphics2D graphics, final Rectangle2D bounds, final ImageObserver obs);
 }

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/SelectionOverlayRenderer.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/report/SelectionOverlayRenderer.java
@@ -18,6 +18,7 @@
 package org.pentaho.reporting.designer.core.editor.report;
 
 import java.awt.Graphics2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.ImageObserver;
 
@@ -27,19 +28,12 @@ import org.pentaho.reporting.designer.core.model.ModelUtility;
 import org.pentaho.reporting.engine.classic.core.Element;
 import org.pentaho.reporting.engine.classic.core.Section;
 
-/**
- * Todo: Document me!
- * <p/>
- * Date: 26.04.2009
- * Time: 20:51:09
- *
- * @author Thomas Morgner.
- */
 public class SelectionOverlayRenderer implements OverlayRenderer
 {
   private Section rootElement;
   private ReportDocumentContext context;
   private double zoomFactor;
+  private double offset;
 
   public SelectionOverlayRenderer(final Element defaultElement)
   {
@@ -49,8 +43,9 @@ public class SelectionOverlayRenderer implements OverlayRenderer
     }
   }
 
-  public void validate(final ReportDocumentContext context, final double zoomFactor)
+  public void validate(final ReportDocumentContext context, final double zoomFactor, final Point2D sectionOffset)
   {
+    this.offset = sectionOffset.getY();
     this.context = context;
     this.zoomFactor = zoomFactor;
   }
@@ -62,7 +57,7 @@ public class SelectionOverlayRenderer implements OverlayRenderer
       return;
     }
 
-    graphics.translate(bounds.getX(), bounds.getY());
+    graphics.translate(bounds.getX(), bounds.getY() - offset);
     
     for (final Element visualElement : context.getSelectionModel().getSelectedElementsOfType(Element.class))
     {


### PR DESCRIPTION
 section's global offset into account. The offset is the space consumed
 by all previous bands on that report.
