### PR TITLE
PRD-4863 - Report Design Wizard window is cut off on Ubuntu12

### DIFF
--- a/designer/wizard-xul/source/org/pentaho/reporting/engine/classic/wizard/ui/xul/components/AbstractWizardStep.java
+++ b/designer/wizard-xul/source/org/pentaho/reporting/engine/classic/wizard/ui/xul/components/AbstractWizardStep.java
@@ -29,8 +29,10 @@ import org.pentaho.ui.xul.binding.BindingFactory;
 import org.pentaho.ui.xul.components.XulImage;
 import org.pentaho.ui.xul.components.XulLabel;
 import org.pentaho.ui.xul.containers.XulGrid;
+import org.pentaho.ui.xul.containers.XulHbox;
 import org.pentaho.ui.xul.containers.XulRow;
 import org.pentaho.ui.xul.containers.XulRows;
+import org.pentaho.ui.xul.containers.XulVbox;
 import org.pentaho.ui.xul.dom.Document;
 
 public abstract class AbstractWizardStep extends XulEventSourceAdapter implements WizardStep
@@ -41,10 +43,9 @@ public abstract class AbstractWizardStep extends XulEventSourceAdapter implement
   public static final String PREVIEWABLE_PROPERTY_NAME = "previewable"; //$NON-NLS-1$
   public static final String FINISHABLE_PROPERTY_NAME = "finishable"; //$NON-NLS-1$
 
-  public static final String STEP_GRID_ID = "step_grid"; //$NON-NLS-1$
-  public static final String STEP_ROWS_ID = "step_rows"; //$NON-NLS-1$
+  public static final String STEP_CONTAINER ="step_container";
 
-  public static final String XUL_ROW_TYPE = "row"; //$NON-NLS-1$
+  public static final String XUL_HBOX_TYPE = "hbox"; //$NON-NLS-1$
   public static final String XUL_IMAGE_TYPE = "image";  //$NON-NLS-1$
   public static final String XUL_LABEL_TYPE = "label"; //$NON-NLS-1$
 
@@ -163,31 +164,25 @@ public abstract class AbstractWizardStep extends XulEventSourceAdapter implement
    */
   public void createPresentationComponent(final XulDomContainer mainWizardContainer) throws XulException
   {
+    final XulVbox stepContainer = (XulVbox) mainWizardContainer.getDocumentRoot().getElementById(STEP_CONTAINER);
 
-    // get the grid itself so we can update it later
-    final XulGrid stepGrid = (XulGrid) mainWizardContainer.getDocumentRoot().getElementById(STEP_GRID_ID);
-
-    // grab the rows and add a new row to it
-    final XulRows stepRows = (XulRows) mainWizardContainer.getDocumentRoot().getElementById(STEP_ROWS_ID);
-    final XulRow stepRow = (XulRow) mainWizardContainer.getDocumentRoot().createElement(XUL_ROW_TYPE);
-    stepRows.addChild(stepRow);
+    XulHbox row = (XulHbox) mainWizardContainer.getDocumentRoot().createElement(XUL_HBOX_TYPE);
 
     // Create and add the activeImage to the row (goes in the first column)
     stepImage = (XulImage) mainWizardContainer.getDocumentRoot().createElement(XUL_IMAGE_TYPE);
     stepImage.setSrc(STEP_IMAGE_SRC);
     stepImage.setId(this.getStepName());
     stepImage.setVisible(false);
-    stepRow.addChild(stepImage);
+    row.addChild(stepImage);
 
     // Create and add the text label to the row (goes in the second column)
     stepLabel = (XulLabel) mainWizardContainer.getDocumentRoot().createElement(XUL_LABEL_TYPE);
     stepLabel.setValue(this.getStepName());
     stepLabel.setFlex(1);
     stepLabel.setDisabled(true);
-    stepRow.addChild(stepLabel);
+    row.addChild(stepLabel);
 
-
-    stepGrid.update();
+    stepContainer.addChild(row);
   }
 
   /* (non-Javadoc)

--- a/designer/wizard-xul/source/org/pentaho/reporting/engine/classic/wizard/ui/xul/res/main_wizard_panel.xul
+++ b/designer/wizard-xul/source/org/pentaho/reporting/engine/classic/wizard/ui/xul/res/main_wizard_panel.xul
@@ -15,19 +15,12 @@
 	  <vbox background="images/rdw_bg.png" width="200" height="400" padding="0" spacing="0">
 	  	<hbox flex="1" padding="0">
   		  <spacer width="2"/>
-  		  <vbox flex="1" padding="0">
-		  	<spacer height="10"/>
-		    <grid id="step_grid" flex="1" >
-		      <columns>
-		        <column flex="0" />
-		        <column flex="1" />
-		      </columns>
-		      <rows id="step_rows" />
-		    </grid>
-		  </vbox>
-		</hbox>
+  		  <vbox id="step_container" flex="1" padding="0">
+		  	  <spacer height="10"/>
+		    </vbox>
+	  	</hbox>
 	  </vbox>
-   	<deck id="content_deck" flex="1" />
+   	<deck id="content_deck" flex="1" height="400"/>
   </hbox>
   <spacer flex="1"/>
   <hbox id="controller_panel" bgcolor="#ffffff" padding="4"/>


### PR DESCRIPTION
I added height attribute to show buttons in ubuntu.
I replaced the grid on the vertical panel for rendering content correctly.
