### PR TITLE
PRD-5166 - The Publishing step must not pass references down to the next...

### DIFF
--- a/designer/datasource-editor-cda/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-cda/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-external/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-external/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-jdbc/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-jdbc/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-kettle/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-kettle/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-mondrian/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-mondrian/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-olap4j/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-olap4j/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-openerp/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-openerp/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-pmd/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-pmd/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-reflection/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-reflection/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-scriptable/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-scriptable/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-table/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-table/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/datasource-editor-xpath/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-xpath/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer-assembly/build-res/reporting-shared.xml
+++ b/designer/report-designer-assembly/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer-extension-connectioneditor/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-connectioneditor/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer-extension-legacy-charts/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-legacy-charts/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer-extension-pentaho/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-pentaho/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer-extension-toc/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-toc/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer-extension-wizard/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-wizard/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/report-designer/build-res/reporting-shared.xml
+++ b/designer/report-designer/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/designer/wizard-xul/build-res/reporting-shared.xml
+++ b/designer/wizard-xul/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/core/build-res/reporting-shared.xml
+++ b/engine/core/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/demo/build-res/reporting-shared.xml
+++ b/engine/demo/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-cda/build-res/reporting-shared.xml
+++ b/engine/extensions-cda/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-docsupport/build-res/reporting-shared.xml
+++ b/engine/extensions-docsupport/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-drilldown/build-res/reporting-shared.xml
+++ b/engine/extensions-drilldown/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-kettle/build-res/reporting-shared.xml
+++ b/engine/extensions-kettle/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-mondrian/build-res/reporting-shared.xml
+++ b/engine/extensions-mondrian/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-olap4j/build-res/reporting-shared.xml
+++ b/engine/extensions-olap4j/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-openerp/build-res/reporting-shared.xml
+++ b/engine/extensions-openerp/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-pentaho-metadata/build-res/reporting-shared.xml
+++ b/engine/extensions-pentaho-metadata/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-reportdesigner-parser/build-res/reporting-shared.xml
+++ b/engine/extensions-reportdesigner-parser/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-sampledata/build-res/reporting-shared.xml
+++ b/engine/extensions-sampledata/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-scripting/build-res/reporting-shared.xml
+++ b/engine/extensions-scripting/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-toc/build-res/reporting-shared.xml
+++ b/engine/extensions-toc/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions-xpath/build-res/reporting-shared.xml
+++ b/engine/extensions-xpath/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/extensions/build-res/reporting-shared.xml
+++ b/engine/extensions/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/legacy-charts/build-res/reporting-shared.xml
+++ b/engine/legacy-charts/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/legacy-functions/build-res/reporting-shared.xml
+++ b/engine/legacy-functions/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/samples/build-res/reporting-shared.xml
+++ b/engine/samples/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/sdk/build-res/reporting-shared.xml
+++ b/engine/sdk/build-res/reporting-shared.xml
@@ -41,8 +41,20 @@
       ====================================================================-->
   <target name="continuous-junit" depends="clean-all,resolve,test,dist-source,dist,publish"/>
 
-  <!-- Override default dist target to do a dist-full instead -->
-  <target name="dist" depends="dist-full"/>
+
+  <target name="longrun-test" depends="clean-all,resolve">
+      <antcall target="test">
+          <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
+          <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>
+      </antcall>
+  </target>
+
+  <target name="longrun-cobertura" depends="clean-all,resolve">
+      <antcall target="cobertura">
+          <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
+          <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>
+      </antcall>
+  </target>
 
 
   <!--=======================================================================
@@ -66,18 +78,22 @@
     <ivy:settings url="${ivy.settingsurl}" />
   </target>
 
-  <target name="longrun-test" depends="clean-all,resolve">
-      <antcall target="test">
-          <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
-          <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>
-      </antcall>
+
+  <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
+    <if>
+      <equals arg1="${tests.publish}" arg2="true"/>
+      <then>
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+          <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
+        </antcall>
+      </then>
+    </if>
   </target>
 
-  <target name="longrun-cobertura" depends="clean-all,resolve">
-      <antcall target="cobertura">
-          <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
-          <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>
-      </antcall>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/server/build-res/reporting-shared.xml
+++ b/engine/server/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/testcases/build-res/reporting-shared.xml
+++ b/engine/testcases/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/tools/build-res/reporting-shared.xml
+++ b/engine/tools/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/engine/wizard-core/build-res/reporting-shared.xml
+++ b/engine/wizard-core/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/configuration-editor/build-res/reporting-shared.xml
+++ b/libraries/configuration-editor/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/flute/build-res/reporting-shared.xml
+++ b/libraries/flute/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libbase/build-res/reporting-shared.xml
+++ b/libraries/libbase/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libcss/build-res/reporting-shared.xml
+++ b/libraries/libcss/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libdocbundle/build-res/reporting-shared.xml
+++ b/libraries/libdocbundle/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libfonts/build-res/reporting-shared.xml
+++ b/libraries/libfonts/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libformat/build-res/reporting-shared.xml
+++ b/libraries/libformat/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libformula-ui/build-res/reporting-shared.xml
+++ b/libraries/libformula-ui/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libformula/build-res/reporting-shared.xml
+++ b/libraries/libformula/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libloader/build-res/reporting-shared.xml
+++ b/libraries/libloader/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libpensol/build-res/reporting-shared.xml
+++ b/libraries/libpensol/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libpixie/build-res/reporting-shared.xml
+++ b/libraries/libpixie/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/librepository/build-res/reporting-shared.xml
+++ b/libraries/librepository/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libserializer/build-res/reporting-shared.xml
+++ b/libraries/libserializer/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libsparkline/build-res/reporting-shared.xml
+++ b/libraries/libsparkline/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libswing/build-res/reporting-shared.xml
+++ b/libraries/libswing/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>

--- a/libraries/libxml/build-res/reporting-shared.xml
+++ b/libraries/libxml/build-res/reporting-shared.xml
@@ -80,33 +80,20 @@
 
 
   <!-- Fixes antcall not passing down the ivy-refs and thus making ivy resolve again for no reason at all -->
-  <target name="publish-nojar" depends="install-antcontrib,create-pom,ivy.deliver,publish-nojar.internal">
+  <target name="publish-nojar" depends="install-antcontrib,create-pom">
+    <antcall target="publish-nojar.internal" inheritRefs="false" inheritAll="false"/>
+
     <if>
-      <equals arg1="${tests.publish}" arg2="true" />
+      <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.internal" inheritrefs="true">
+        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>
     </if>
   </target>
 
-  <!-- Sample fix for publishing ivy and pom artifacts in one transaction. -->
-  <target name="[REMOVE-ME]publish-nojar.internal" depends="install-antcontrib,resolve,create-pom">
-    <sequential>
-      <copy file="${dist.dir}/pom.xml" tofile="${dist.dir}/${ivy.artifact.id}-${project.revision}.pom"/>
-      <ivy:deliver conf="*(public)" deliverpattern="${dist.dir}/ivy.xml"/>
-      <ivy:publish resolver="${ivy.repository.id}"
-                   srcivypattern="${dist.dir}/${ivy.artifact.id}-[revision](-[classifier]).ivy.xml"
-                   pubrevision="${project.revision}" overwrite="true" forcedeliver="false" warnonmissing="yes"
-                   haltonmissing="no">
-        <artifacts pattern="${dist.dir}/[artifact]-[revision](-[classifier]).[ext]"/>
-        <artifact name="${ivy.artifact.id}" type="ivy" ext="ivy.xml"/>
-        <artifact name="${ivy.artifact.id}" type="pom" ext="pom"/>
-      </ivy:publish>
-    </sequential>
-
-    <antcall target="maven-publish.post"/>
-  </target>
+  <!-- Don't produce source.zip or source.tar.gz files - no one is consuming them anyway -->
+  <target name="dist-source" depends="source.jar"/>
 
 </project>


### PR DESCRIPTION
... level, or ivy stores the wrong metadata in ant's references pool.
