### PR TITLE
PRD-5166 - The Publishing step must not pass references down to the next...

### DIFF
--- a/build-res/reporting-shared.xml
+++ b/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-cda/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-cda/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-external/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-external/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-jdbc/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-jdbc/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-kettle/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-kettle/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-mondrian/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-mondrian/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-olap4j/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-olap4j/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-openerp/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-openerp/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-pmd/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-pmd/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-reflection/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-reflection/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-scriptable/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-scriptable/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-table/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-table/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/datasource-editor-xpath/build-res/reporting-shared.xml
+++ b/designer/datasource-editor-xpath/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer-assembly/build-res/reporting-shared.xml
+++ b/designer/report-designer-assembly/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer-extension-connectioneditor/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-connectioneditor/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer-extension-legacy-charts/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-legacy-charts/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer-extension-pentaho/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-pentaho/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer-extension-toc/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-toc/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer-extension-wizard/build-res/reporting-shared.xml
+++ b/designer/report-designer-extension-wizard/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/report-designer/build-res/reporting-shared.xml
+++ b/designer/report-designer/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/designer/wizard-xul/build-res/reporting-shared.xml
+++ b/designer/wizard-xul/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/core/build-res/reporting-shared.xml
+++ b/engine/core/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/demo/build-res/reporting-shared.xml
+++ b/engine/demo/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-cda/build-res/reporting-shared.xml
+++ b/engine/extensions-cda/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-docsupport/build-res/reporting-shared.xml
+++ b/engine/extensions-docsupport/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-drilldown/build-res/reporting-shared.xml
+++ b/engine/extensions-drilldown/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-kettle/build-res/reporting-shared.xml
+++ b/engine/extensions-kettle/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-mondrian/build-res/reporting-shared.xml
+++ b/engine/extensions-mondrian/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-olap4j/build-res/reporting-shared.xml
+++ b/engine/extensions-olap4j/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-openerp/build-res/reporting-shared.xml
+++ b/engine/extensions-openerp/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-pentaho-metadata/build-res/reporting-shared.xml
+++ b/engine/extensions-pentaho-metadata/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-reportdesigner-parser/build-res/reporting-shared.xml
+++ b/engine/extensions-reportdesigner-parser/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-sampledata/build-res/reporting-shared.xml
+++ b/engine/extensions-sampledata/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-scripting/build-res/reporting-shared.xml
+++ b/engine/extensions-scripting/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-toc/build-res/reporting-shared.xml
+++ b/engine/extensions-toc/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions-xpath/build-res/reporting-shared.xml
+++ b/engine/extensions-xpath/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/extensions/build-res/reporting-shared.xml
+++ b/engine/extensions/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/legacy-charts/build-res/reporting-shared.xml
+++ b/engine/legacy-charts/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/legacy-functions/build-res/reporting-shared.xml
+++ b/engine/legacy-functions/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/samples/build-res/reporting-shared.xml
+++ b/engine/samples/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/sdk/build-res/reporting-shared.xml
+++ b/engine/sdk/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/server/build-res/reporting-shared.xml
+++ b/engine/server/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/testcases/build-res/reporting-shared.xml
+++ b/engine/testcases/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/tools/build-res/reporting-shared.xml
+++ b/engine/tools/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/engine/wizard-core/build-res/reporting-shared.xml
+++ b/engine/wizard-core/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/configuration-editor/build-res/reporting-shared.xml
+++ b/libraries/configuration-editor/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/flute/build-res/reporting-shared.xml
+++ b/libraries/flute/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libbase/build-res/reporting-shared.xml
+++ b/libraries/libbase/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libcss/build-res/reporting-shared.xml
+++ b/libraries/libcss/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libdocbundle/build-res/reporting-shared.xml
+++ b/libraries/libdocbundle/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libfonts/build-res/reporting-shared.xml
+++ b/libraries/libfonts/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libformat/build-res/reporting-shared.xml
+++ b/libraries/libformat/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libformula-ui/build-res/reporting-shared.xml
+++ b/libraries/libformula-ui/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libformula/build-res/reporting-shared.xml
+++ b/libraries/libformula/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libloader/build-res/reporting-shared.xml
+++ b/libraries/libloader/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libpensol/build-res/reporting-shared.xml
+++ b/libraries/libpensol/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libpixie/build-res/reporting-shared.xml
+++ b/libraries/libpixie/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/librepository/build-res/reporting-shared.xml
+++ b/libraries/librepository/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libserializer/build-res/reporting-shared.xml
+++ b/libraries/libserializer/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libsparkline/build-res/reporting-shared.xml
+++ b/libraries/libsparkline/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libswing/build-res/reporting-shared.xml
+++ b/libraries/libswing/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>

--- a/libraries/libxml/build-res/reporting-shared.xml
+++ b/libraries/libxml/build-res/reporting-shared.xml
@@ -86,7 +86,7 @@
     <if>
       <equals arg1="${tests.publish}" arg2="true"/>
       <then>
-        <antcall target="publish-nojar.test" inheritRefs="false" inheritAll="false">
+        <antcall target="publish-nojar.internal">
           <param name="ivy.artifact.id" value="${ivy.artifact.id}-test"/>
         </antcall>
       </then>


### PR DESCRIPTION
... level, or ivy stores the wrong metadata in ant's references pool.

(Hopefully the last one)
