### PR TITLE
PRD-5166 - Allow longrun targets to skip the processing of modules that ...

### DIFF
--- a/build-res/report-shared-experimental.xml
+++ b/build-res/report-shared-experimental.xml
@@ -42,7 +42,9 @@
   <target name="continuous-junit" depends="clean-all,resolve,test,dist-source,dist,publish"/>
 
   <!-- Shared targets for splitting tests into fast and slow tests -->
-  <target name="longrun-test" depends="clean-all,resolve">
+  <target name="longrun-test" if="junit.longrun.forkmode">
+    <antcall target="clean-all"/>
+    <antcall target="resolve"/>
     <antcall target="test">
       <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
       <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>
@@ -50,7 +52,9 @@
   </target>
 
   <!-- Shared targets for splitting tests into fast and slow tests -->
-  <target name="longrun-cobertura" depends="clean-all,resolve">
+  <target name="longrun-cobertura" if="junit.longrun.forkmode">
+    <antcall target="clean-all"/>
+    <antcall target="resolve"/>
     <antcall target="cobertura">
       <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
       <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>

--- a/build-res/reporting-shared.xml
+++ b/build-res/reporting-shared.xml
@@ -42,14 +42,18 @@
   <target name="continuous-junit" depends="clean-all,resolve,test,dist-source,dist,publish"/>
 
 
-  <target name="longrun-test" depends="clean-all,resolve">
+  <target name="longrun-test" if="junit.longrun.forkmode">
+      <antcall target="clean-all"/>
+      <antcall target="resolve"/>
       <antcall target="test">
           <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
           <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>
       </antcall>
   </target>
 
-  <target name="longrun-cobertura" depends="clean-all,resolve">
+  <target name="longrun-cobertura" if="junit.longrun.forkmode">
+      <antcall target="clean-all"/>
+      <antcall target="resolve"/>
       <antcall target="cobertura">
           <param name="junit.sysprop.org.pentaho.reporting.engine.classic.test.ExecuteLongRunningTest" value="true"/>
           <param name="junit.forkmode" value="${junit.longrun.forkmode}"/>


### PR DESCRIPTION
...would only run ordinary tests. This makes CI config a bit easier.
