### PR TITLE
[BISERVER-11952] - Failed to import Samples (5.1)

### DIFF
--- a/.idea/runConfigurations/org_pentaho_reporting_engine_classic_core_in_core__Fast_.xml
+++ b/.idea/runConfigurations/org_pentaho_reporting_engine_classic_core_in_core__Fast_.xml
@@ -23,10 +23,16 @@
     </option>
     <envs />
     <patterns />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="" />
+      <option name="TRANSPORT" value="0" />
+      <option name="LOCAL" value="true" />
+    </RunnerSettings>
     <RunnerSettings RunnerId="JProfiler">
       <option name="WINDOW" value="false" />
     </RunnerSettings>
     <RunnerSettings RunnerId="Run" />
+    <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
     <method />
   </configuration>

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/ClassicEngineBootTest.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/ClassicEngineBootTest.java
@@ -49,6 +49,27 @@ public class ClassicEngineBootTest extends TestCase {
     Assert.assertEquals( "Newer patch version must be patch invalid", ClassicEngineBoot.VersionValidity.INVALID_PATCH, ClassicEngineBoot.getInstance().isValidVersion( 3, 3, 4, projectInfo ) );
   }
 
+  public void testTrunkIsValid() {
+    // Set current version to 3.3.3
+    final ProjectInformation projectInfo = Mockito.mock(ProjectInformation.class);
+    Mockito.when(projectInfo.getReleaseMajor()).thenReturn("999");
+    Mockito.when(projectInfo.getReleaseMinor()).thenReturn("999");
+    Mockito.when(projectInfo.getReleaseMilestone()).thenReturn("999");
+
+    final int[] trunk = parseVersionId(ClassicEngineBoot.VERSION_TRUNK);
+    Assert.assertEquals( "TRUNK version must be valid", ClassicEngineBoot.VersionValidity.VALID, ClassicEngineBoot.getInstance().isValidVersion( trunk[0], trunk[1], trunk[2], projectInfo ) );
+
+    Assert.assertEquals( "The same version must be valid", ClassicEngineBoot.VersionValidity.VALID, ClassicEngineBoot.getInstance().isValidVersion( 3, 3, 3, projectInfo ) );
+
+    Assert.assertEquals( "Older version must be valid", ClassicEngineBoot.VersionValidity.VALID, ClassicEngineBoot.getInstance().isValidVersion( 2, 2, 2, projectInfo ) );
+
+    Assert.assertEquals( "Newer major version must be release valid", ClassicEngineBoot.VersionValidity.VALID, ClassicEngineBoot.getInstance().isValidVersion( 4, 3, 3, projectInfo ) );
+
+    Assert.assertEquals( "Newer minor version must be release valid", ClassicEngineBoot.VersionValidity.VALID, ClassicEngineBoot.getInstance().isValidVersion( 3, 4, 3, projectInfo ) );
+
+    Assert.assertEquals( "Newer patch version must be patch valid", ClassicEngineBoot.VersionValidity.VALID, ClassicEngineBoot.getInstance().isValidVersion( 3, 3, 4, projectInfo ) );
+  }
+
   private int[] parseVersionId( int versionId ) {
     if (versionId <= 0 || versionId > 999000000) {
       versionId = ClassicEngineBoot.VERSION_TRUNK;

--- a/libraries/libbase/source/org/pentaho/reporting/libraries/base/versioning/VersionHelper.java
+++ b/libraries/libbase/source/org/pentaho/reporting/libraries/base/versioning/VersionHelper.java
@@ -165,9 +165,9 @@ public class VersionHelper
       version = "TRUNK.development";
       title = projectInformation.getInternalName();
       productId = projectInformation.getInternalName();
-      releaseMajor = "0";
-      releaseMinor = "0";
-      releaseMilestone = "0";
+      releaseMajor = "999";
+      releaseMinor = "999";
+      releaseMilestone = "999";
       releaseCandidateToken = "snapshot";
       releaseBuildNumber = "0";
       releaseNumber = createReleaseVersion();
@@ -198,9 +198,9 @@ public class VersionHelper
         version = "TRUNK.development";
       }
 
-      releaseMajor = "0";
-      releaseMinor = "0";
-      releaseMilestone = "0";
+      releaseMajor = "999";
+      releaseMinor = "999";
+      releaseMilestone = "999";
       releaseCandidateToken = "snapshot";
       releaseBuildNumber = "0";
       if (version.startsWith("TRUNK") == false)


### PR DESCRIPTION
fix isValidVersion - made TRUNK version of reports always valid
VersionHelper treated "trunk" as 0 instead of 999.999.999
