### PR TITLE
BACKLOG-347 - CLONE - QuerylessDataFactory declares invalid metadata in ...

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/messages.properties
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/messages.properties
@@ -1413,3 +1413,5 @@ attribute.internal.fast-export-element-style-stash.grouping.ordinal=9900
 attribute.internal.fast-export-element-style-stash.ordinal=40
 attribute.internal.fast-export-element-style-stash.description=
 attribute.internal.fast-export-element-style-stash.deprecated=
+
+display-name=Engine metadata


### PR DESCRIPTION
...BI-server reporting plugin

What was done:
1) added missed display-name
