### PR TITLE
PRD-5250 - RTF images must be marked as scaled to match up with the size...

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/rtf/config-description.xml
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/rtf/config-description.xml
@@ -3,8 +3,7 @@
 
   <key name="org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.EnableImages" global="false" hidden="false">
     <description>Defines, whether the RTF-Export should try to contain images.
-Currently, this is not a safe method, you might easily encounter
-OutOfMemoryExceptions, so use that option with care.</description>
+Currently, this is not a safe method, you might easily encounter OutOfMemoryExceptions, so use that option with care.</description>
     <enum>
       <text>true</text>
       <text>false</text>
@@ -15,7 +14,21 @@ OutOfMemoryExceptions, so use that option with care.</description>
     <class instanceof="org.pentaho.reporting.libraries.base.boot.Module"/>
   </key>
   <key name="org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.ShapeAsContent" global="false" hidden="false">
-    <description></description>
+    <description>Defines whether shapes shall be exported as images to the RTF document. Regardless of this setting, certain shapes will be treated as background and border definitions.</description>
+    <enum>
+      <text>true</text>
+      <text>false</text>
+    </enum>
+  </key>
+  <key name="org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.StrictLayout" global="false" hidden="false">
+    <description>Defines whether a stricter, but more accurate layout algorithm should be applied. Setting this property to false will greatly reduce the table complexity.</description>
+    <enum>
+      <text>true</text>
+      <text>false</text>
+    </enum>
+  </key>
+  <key name="org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.DeviceResolution" global="false" hidden="false">
+    <description>Adjusts the resolution of the images embedded in the RTF document. By default we use 96 DPI, which is the common default among all browsers.</description>
     <text/>
   </key>
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/rtf/configuration.properties
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/rtf/configuration.properties
@@ -18,3 +18,5 @@ org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.EnableImages=
 # true, the content ends up as image.
 #
 org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.ShapeAsContent=true
+
+org.pentaho.reporting.engine.classic.core.modules.output.table.rtf.DeviceResolution=300

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/rtf/helper/RTFTextExtractor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/rtf/helper/RTFTextExtractor.java
@@ -46,6 +46,7 @@ import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
 import org.pentaho.reporting.engine.classic.core.style.StyleSheet;
 import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 import org.pentaho.reporting.engine.classic.core.util.geom.StrictBounds;
+import org.pentaho.reporting.engine.classic.core.util.geom.StrictGeomUtility;
 import org.pentaho.reporting.libraries.base.util.FastStack;
 import org.pentaho.reporting.libraries.fonts.itext.BaseFontFontMetrics;
 import org.pentaho.reporting.libraries.resourceloader.factory.drawable.DrawableWrapper;
@@ -367,6 +368,9 @@ public class RTFTextExtractor extends DefaultTextExtractor
 
   protected void processRenderableContent(final RenderableReplacedContentBox node)
   {
+    float targetWidth = (float) StrictGeomUtility.toExternalValue(node.getWidth());
+    float targetHeight = (float) StrictGeomUtility.toExternalValue(node.getHeight());
+
     try
     {
       final RenderableReplacedContent rpc = node.getContent();
@@ -384,6 +388,8 @@ public class RTFTextExtractor extends DefaultTextExtractor
           currentContext.add(getText());
           clearText();
         }
+
+        image.scaleToFit(targetWidth, targetHeight);
         currentContext.add(image);
       }
       else if (rawObject instanceof DrawableWrapper)
@@ -408,6 +414,7 @@ public class RTFTextExtractor extends DefaultTextExtractor
           currentContext.add(getText());
           clearText();
         }
+        image.scaleToFit(targetWidth, targetHeight);
         currentContext.add(image);
       }
     }


### PR DESCRIPTION
... as calculated by the layouter. Otherwise high-resolution images will appear larger than they are.
