### PR TITLE
PRD-5120 - Provide base class for common usage scenarios in datasources

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/AbstractDataFactory.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/AbstractDataFactory.java
@@ -30,7 +30,7 @@ import org.pentaho.reporting.libraries.base.config.Configuration;
 import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 
-public abstract class AbstractDataFactory implements DataFactoryDesignTimeSupport, Cloneable
+public abstract class AbstractDataFactory implements DataFactoryDesignTimeSupport, Cloneable, DataFactoryMetaProvider
 {
   private transient Configuration configuration;
   private transient ResourceManager resourceManager;
@@ -135,7 +135,7 @@ public abstract class AbstractDataFactory implements DataFactoryDesignTimeSuppor
     {
       return (DataFactory) super.clone();
     }
-    catch (CloneNotSupportedException e)
+    catch (final CloneNotSupportedException e)
     {
       throw new IllegalStateException(e);
     }
@@ -149,6 +149,21 @@ public abstract class AbstractDataFactory implements DataFactoryDesignTimeSuppor
   public DataFactoryMetaData getMetaData()
   {
     return DataFactoryRegistry.getInstance().getMetaData(getClass().getName());
+  }
+
+  public String getDisplayConnectionName()
+  {
+    return null;
+  }
+
+  public Object getQueryHash(final String query, final DataRow dataRow) throws ReportDataFactoryException
+  {
+    return null;
+  }
+
+  public String[] getReferencedFields(final String query, final DataRow dataRow) throws ReportDataFactoryException
+  {
+    return null;
   }
 
   protected static class DataRowWrapper implements DataRow

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/AbstractNamedDataFactory.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/AbstractNamedDataFactory.java
@@ -1,0 +1,77 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core;
+
+import java.util.LinkedHashMap;
+import javax.swing.table.TableModel;
+
+public abstract class AbstractNamedDataFactory<T> extends AbstractDataFactory
+{
+  private LinkedHashMap<String, T> queries;
+
+  public AbstractNamedDataFactory()
+  {
+    queries = new LinkedHashMap<String, T>();
+  }
+
+  protected T mapQuery(final String query) throws ReportDataFactoryException
+  {
+    T t = queries.get(query);
+    if (t == null)
+    {
+      throw new ReportDataFactoryException("No such Query");
+    }
+    return t;
+  }
+
+  public final TableModel queryData(final String query, final DataRow parameters) throws ReportDataFactoryException
+  {
+    return queryDataInternal(mapQuery(query), parameters);
+  }
+
+  protected abstract TableModel queryDataInternal(final T query,
+                                                  final DataRow parameters) throws ReportDataFactoryException;
+
+  public boolean isQueryExecutable(final String query, final DataRow parameters)
+  {
+    return queries.containsKey(query);
+  }
+
+  public String[] getQueryNames()
+  {
+    return queries.keySet().toArray(new String[queries.size()]);
+  }
+
+  public final String[] getReferencedFields(final String query, final DataRow dataRow) throws ReportDataFactoryException
+  {
+    final T queryObject = mapQuery(query);
+    return getReferencedFieldsInternal(queryObject, dataRow);
+  }
+
+  protected abstract String[] getReferencedFieldsInternal(T query, DataRow dataRow)
+      throws ReportDataFactoryException;
+
+  public final Object getQueryHash(final String query, final DataRow dataRow) throws ReportDataFactoryException
+  {
+    final T queryObject = mapQuery(query);
+    return getQueryHashInternal(queryObject, dataRow);
+  }
+
+  protected abstract Object getQueryHashInternal(final T queryObject, final DataRow dataRow)
+      throws ReportDataFactoryException;
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/DataFactoryMetaProvider.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/DataFactoryMetaProvider.java
@@ -1,0 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core;
+
+public interface DataFactoryMetaProvider
+{
+  public Object getQueryHash(final String query, final DataRow dataRow) throws ReportDataFactoryException;
+  public String[] getReferencedFields(final String query, final DataRow dataRow) throws ReportDataFactoryException;
+  public String getDisplayConnectionName();
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/DefaultDataFactoryCore.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/DefaultDataFactoryCore.java
@@ -17,12 +17,18 @@
 
 package org.pentaho.reporting.engine.classic.core.metadata;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.pentaho.reporting.engine.classic.core.DataFactory;
+import org.pentaho.reporting.engine.classic.core.DataFactoryMetaProvider;
 import org.pentaho.reporting.engine.classic.core.DataRow;
+import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 
 public class DefaultDataFactoryCore implements DataFactoryCore
 {
+  private static final Log logger = LogFactory.getLog(DefaultDataFactoryCore.class);
+
   public DefaultDataFactoryCore()
   {
   }
@@ -32,6 +38,17 @@ public class DefaultDataFactoryCore implements DataFactoryCore
                                       final String query,
                                       final DataRow parameter)
   {
+    if (element instanceof DataFactoryMetaProvider)
+    {
+      try {
+        DataFactoryMetaProvider p = (DataFactoryMetaProvider) element;
+        return p.getReferencedFields(query, parameter);
+      }
+      catch (final ReportDataFactoryException e)
+      {
+        logger.info("Unable to compute design-time data: Referenced fields", e);
+      }
+    }
     return null;
   }
 
@@ -46,6 +63,11 @@ public class DefaultDataFactoryCore implements DataFactoryCore
   public String getDisplayConnectionName(final DataFactoryMetaData metaData,
                                          final DataFactory dataFactory)
   {
+    if (dataFactory instanceof DataFactoryMetaProvider)
+    {
+      DataFactoryMetaProvider p = (DataFactoryMetaProvider) dataFactory;
+      return p.getDisplayConnectionName();
+    }
     return null;
   }
 
@@ -53,6 +75,17 @@ public class DefaultDataFactoryCore implements DataFactoryCore
                              final DataFactory dataFactory,
                              final String queryName, final DataRow parameter)
   {
+    if (dataFactory instanceof DataFactoryMetaProvider)
+    {
+      try {
+        DataFactoryMetaProvider p = (DataFactoryMetaProvider) dataFactory;
+        return p.getReferencedFields(queryName, parameter);
+      }
+      catch (final ReportDataFactoryException e)
+      {
+        logger.info("Unable to compute design-time data: Query Hash", e);
+      }
+    }
     return null;
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/AbstractScriptableDataFactory.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/AbstractScriptableDataFactory.java
@@ -1,0 +1,209 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.misc.datafactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import javax.swing.table.TableModel;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.reporting.engine.classic.core.AbstractDataFactory;
+import org.pentaho.reporting.engine.classic.core.DataFactoryContext;
+import org.pentaho.reporting.engine.classic.core.DataRow;
+import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
+
+public abstract class AbstractScriptableDataFactory extends AbstractDataFactory
+{
+  private static final Log logger = LogFactory.getLog(AbstractScriptableDataFactory.class);
+  private final DataFactoryScriptingSupport scriptingSupport;
+
+  protected AbstractScriptableDataFactory()
+  {
+    scriptingSupport = new DataFactoryScriptingSupport();
+  }
+
+  public final TableModel queryData(final String query, final DataRow parameters) throws ReportDataFactoryException
+  {
+    if (query == null)
+    {
+      throw new NullPointerException("Query is null."); //$NON-NLS-1$
+    }
+    final String realQuery = scriptingSupport.computeQuery(query, parameters);
+    if (realQuery == null)
+    {
+      throw new ReportDataFactoryException("Query '" + query + "' is not recognized."); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    return queryDataInternal(realQuery, parameters);
+  }
+
+  protected abstract TableModel queryDataInternal(final String realQuery, final DataRow parameters) throws ReportDataFactoryException;
+
+  public boolean isQueryExecutable(final String query, final DataRow dataRow)
+  {
+    return scriptingSupport.containsQuery(query);
+  }
+
+  /**
+   * Sets a query that uses no scripting for customization.
+   *
+   * @param name        the logical name
+   * @param queryString the SQL string that will be executed.
+   */
+  public void setQuery(final String name, final String queryString)
+  {
+    setQuery(name, queryString, null, null);
+  }
+
+  public void setQuery(final String name, final String queryString,
+                       final String queryScriptLanguage, final String queryScript)
+  {
+    if (name == null)
+    {
+      throw new NullPointerException();
+    }
+
+    scriptingSupport.setQuery(name, queryString, queryScriptLanguage, queryScript);
+  }
+
+  public void remove(final String name)
+  {
+    scriptingSupport.remove(name);
+  }
+
+  public String getGlobalScriptLanguage()
+  {
+    return scriptingSupport.getGlobalScriptLanguage();
+  }
+
+  public void setGlobalScriptLanguage(final String scriptLanguage)
+  {
+    scriptingSupport.setGlobalScriptLanguage(scriptLanguage);
+  }
+
+  public String getGlobalScript()
+  {
+    return scriptingSupport.getGlobalScript();
+  }
+
+  public void setGlobalScript(final String globalScript)
+  {
+    scriptingSupport.setGlobalScript(globalScript);
+  }
+
+  public String getScriptingLanguage(final String name)
+  {
+    return scriptingSupport.getScriptingLanguage(name);
+  }
+
+  public String getScript(final String name)
+  {
+    return scriptingSupport.getScript(name);
+  }
+
+  public String getQuery(final String name)
+  {
+    return scriptingSupport.getQuery(name);
+  }
+
+  public String[] getQueryNames()
+  {
+    return scriptingSupport.getQueryNames();
+  }
+
+  public void initialize(final DataFactoryContext dataFactoryContext) throws ReportDataFactoryException
+  {
+    super.initialize(dataFactoryContext);
+    scriptingSupport.initialize(this, dataFactoryContext);
+  }
+
+  public final String[] getReferencedFields(final String query,
+                                            final DataRow parameter)
+  {
+    try
+    {
+      final String[] additionalFields = scriptingSupport.computeAdditionalQueryFields(query, parameter);
+      if (additionalFields == null)
+      {
+        return null;
+      }
+
+      final String realQuery = scriptingSupport.computeQuery(query, parameter);
+      if (realQuery == null)
+      {
+        throw new ReportDataFactoryException("Query '" + query + "' is not recognized."); //$NON-NLS-1$ //$NON-NLS-2$
+      }
+
+      String[] referencedFieldsInternal = getReferencedFieldsInternal(realQuery, parameter);
+      if (referencedFieldsInternal == null)
+      {
+        return null;
+      }
+
+      final LinkedHashSet<String> fields = new LinkedHashSet<String>();
+      fields.addAll(Arrays.asList(referencedFieldsInternal));
+      fields.addAll(Arrays.asList(additionalFields));
+      return fields.toArray(new String[fields.size()]);
+    }
+    catch (final ReportDataFactoryException rx)
+    {
+      logger.debug("Failed to compute referenced fields", rx); // NON-NLS
+      return null;
+    }
+  }
+
+  protected abstract String[] getReferencedFieldsInternal(final String query,
+                                                          final DataRow parameters) throws ReportDataFactoryException;
+
+  public final Object getQueryHash(final String query, final DataRow parameter)
+  {
+    try
+    {
+      final String realQuery = scriptingSupport.computeQuery(query, parameter);
+      if (realQuery == null)
+      {
+        throw new ReportDataFactoryException("Query '" + query + "' is not recognized."); //$NON-NLS-1$ //$NON-NLS-2$
+      }
+
+      Object queryHashInternal = getQueryHashInternal(realQuery, parameter);
+      if (queryHashInternal == null)
+      {
+        return null;
+      }
+
+      final ArrayList<Object> queryHash = new ArrayList<Object>();
+      queryHash.add(getClass().getName());
+      queryHash.add(queryHashInternal);
+      queryHash.add(scriptingSupport.getScriptingLanguage(query));
+      queryHash.add(scriptingSupport.getScript(query));
+      return queryHash;
+    }
+    catch (final ReportDataFactoryException rx)
+    {
+      logger.debug("Failed to compute query hash", rx); // NON-NLS
+      return null;
+    }
+  }
+
+  protected abstract Object getQueryHashInternal(final String realQuery,
+                                                 final DataRow parameter) throws ReportDataFactoryException;
+
+
+}


### PR DESCRIPTION
Merging pending API fix. This simplifies the SDK and subsequently the story around implementing datasources that use a symbolic name to reference the query data. Creates two new classes - AbstractNamedDataFactory without scripting and AbstractScriptableDataFactory for scripting support.
