### PR TITLE
[SP-1623] - Regression of PDI-12579 - PDI Report Wizard doesn't display ...

### DIFF
--- a/designer/wizard-xul/source/org/pentaho/reporting/engine/classic/wizard/ui/xul/util/SourceFieldDefinition.java
+++ b/designer/wizard-xul/source/org/pentaho/reporting/engine/classic/wizard/ui/xul/util/SourceFieldDefinition.java
@@ -17,15 +17,12 @@
 
 package org.pentaho.reporting.engine.classic.wizard.ui.xul.util;
 
-import java.beans.PropertyChangeListener;
-
 import org.pentaho.reporting.engine.classic.core.MetaAttributeNames;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.DataSchema;
 import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributeContext;
-import org.pentaho.ui.xul.XulEventSource;
-
-public class SourceFieldDefinition implements XulEventSource
+//
+public class SourceFieldDefinition 
 {
   private String displayName;
   private String fieldName;
@@ -75,14 +72,6 @@ public class SourceFieldDefinition implements XulEventSource
   public String getFieldName()
   {
     return fieldName;
-  }
-
-  public void addPropertyChangeListener(final PropertyChangeListener listener)
-  {
-  }
-
-  public void removePropertyChangeListener(final PropertyChangeListener listener)
-  {
   }
 
 }


### PR DESCRIPTION
...the field names properly (5.2 Suite)

The cause of the issue is that SwtList component does not properly sets Label for items (updateLabel() method)
However taking into account the risk of modifying the core Xul functionality it's been decided to
did the changes in SourceFieldDefinition class.

The fix is to remove an empty implementation of XulEvenSource making Xul process the added ListItems differently.

Tested manually. There are no unit tests since this is pure UI change.
