### PR TITLE
[PRD-5343] - Libpensol now refreshes local tree cache when a new File is created in a JCR repository

### DIFF
--- a/libraries/libpensol/source/org/pentaho/reporting/libraries/pensol/JCRSolutionFileModel.java
+++ b/libraries/libpensol/source/org/pentaho/reporting/libraries/pensol/JCRSolutionFileModel.java
@@ -436,6 +436,13 @@ public class JCRSolutionFileModel implements SolutionFileModel
         throw new FileSystemException("ERROR_FAILED", status);
       }
     }
+
+    try {
+      // Perhaps a New file was created. Refresh local tree model.
+      this.refresh();
+    } catch ( IOException e ) {
+      // Ignore if unable to refresh
+    }
   }
 
   public String[] getChilds(final FileName name) throws FileSystemException

--- a/libraries/libpensol/source/org/pentaho/reporting/libraries/pensol/PentahoSolutionFileProvider.java
+++ b/libraries/libpensol/source/org/pentaho/reporting/libraries/pensol/PentahoSolutionFileProvider.java
@@ -51,6 +51,7 @@ public class PentahoSolutionFileProvider extends AbstractOriginatingFileProvider
       Capability.GET_LAST_MODIFIED,
       Capability.LIST_CHILDREN,
       Capability.READ_CONTENT,
+      Capability.WRITE_CONTENT,
       Capability.CREATE,
       Capability.FS_ATTRIBUTES,
       Capability.URI ) );


### PR DESCRIPTION
- Libpensol now refreshes local tree cache when a new File is created in a JCR repository
- Added WRITE_CONTENT capability to the libpensol PentahoSolutionFileProvider