### PR TITLE
PRD-5337 - Metadata for CDA data-factory is wrongfuly claiming experimen...

### DIFF
--- a/engine/extensions-cda/source/org/pentaho/reporting/engine/classic/extensions/datasources/cda/meta-datafactory.xml
+++ b/engine/extensions-cda/source/org/pentaho/reporting/engine/classic/extensions/datasources/cda/meta-datafactory.xml
@@ -1,7 +1,7 @@
 <meta-data xmlns="http://reporting.pentaho.org/namespaces/engine/classic/metadata/1.0">
 
   <data-factory name="org.pentaho.reporting.engine.classic.extensions.datasources.cda.CdaDataFactory"
-                expert="true" experimental="true"
+                expert="true" maturity-level="Community"
                 bundle-name="org.pentaho.reporting.engine.classic.extensions.datasources.cda.CdaDataFactoryBundle"/>
 
 </meta-data>

--- a/engine/extensions-openerp/src/org/pentaho/reporting/engine/classic/extensions/datasources/openerp/meta-datafactory.xml
+++ b/engine/extensions-openerp/src/org/pentaho/reporting/engine/classic/extensions/datasources/openerp/meta-datafactory.xml
@@ -1,7 +1,7 @@
 <meta-data xmlns="http://reporting.pentaho.org/namespaces/engine/classic/metadata/1.0">
 
   <data-factory name="org.pentaho.reporting.engine.classic.extensions.datasources.openerp.OpenERPDataFactory"
-                expert="true" experimental="false" maturity-level="Community"
+                expert="true" maturity-level="Community"
                 bundle-name="org.pentaho.reporting.engine.classic.extensions.datasources.openerp.OpenERPDataFactoryBundle"/>
 
 </meta-data>


### PR DESCRIPTION
...tal status for CDA datasource, but community supported is correct. Open-ERP no longer needs to specify deprecated "experimental" flag when maturity level is set.