### PR TITLE
SP-1760 - Backport of PRD-5393 - Regression: Report breaks after setting property widow-orphan-opt-out to false on the Group. (5.3 Suite)

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/layout/CommonStyleReadHandler.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/layout/CommonStyleReadHandler.java
@@ -101,7 +101,7 @@ public class CommonStyleReadHandler extends AbstractXmlReadHandler implements St
     final String widowsOrphanOptOut = attrs.getValue(getUri(), ElementStyleKeys.WIDOW_ORPHAN_OPT_OUT.getName());
     if (widowsOrphanOptOut != null)
     {
-      styleSheet.setStyleProperty(ElementStyleKeys.WIDOW_ORPHAN_OPT_OUT, ReportParserUtil.parseBoolean(widows, getLocator()));
+      styleSheet.setStyleProperty(ElementStyleKeys.WIDOW_ORPHAN_OPT_OUT, ReportParserUtil.parseBoolean(widowsOrphanOptOut, getLocator()));
     }
 
     final String orphans = attrs.getValue(getUri(), ElementStyleKeys.ORPHANS.getName());


### PR DESCRIPTION
cherry-pick https://github.com/pentaho/pentaho-reporting/pull/591