### PR TITLE
[CLEANUP] Fixed unit test that would fail based on timezone where executed

### DIFF
--- a/libraries/libformat/test/org/pentaho/reporting/libraries/formatting/DateFormatTest.java
+++ b/libraries/libformat/test/org/pentaho/reporting/libraries/formatting/DateFormatTest.java
@@ -17,25 +17,26 @@
 
 package org.pentaho.reporting.libraries.formatting;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
-
-public class DateFormatTest
-{
+public class DateFormatTest {
   @Test
   public void testTimeZoneIsApplied() {
-    FastDateFormat fd = new FastDateFormat("yyyy-MM-dd HH:mm:ss,SSS ZZZ", Locale.ENGLISH, TimeZone.getTimeZone("PST"));
-    Assert.assertEquals("2009-01-06 00:40:31,000 -0800", fd.format(new Date(1231231231000l)));
+    FastDateFormat fd =
+      new FastDateFormat( "yyyy-MM-dd HH:mm:ss,SSS ZZZ", Locale.ENGLISH, TimeZone.getTimeZone( "PST" ) );
+    Assert.assertEquals( "2009-01-06 00:40:31,000 -0800", fd.format( new Date( 1231231231000l ) ) );
   }
 
   @Test
   public void testTimeZoneIsAppliedOnPreset() {
-    FastDateFormat fd = new FastDateFormat(DateFormat.FULL, DateFormat.FULL, Locale.ENGLISH, TimeZone.getTimeZone("PST"));
-    Assert.assertEquals("Tuesday, January 6, 2009 12:40:31 AM PST", fd.format(new Date(1231231231000l)));
+    FastDateFormat fd =
+      new FastDateFormat( DateFormat.FULL, DateFormat.FULL, Locale.ENGLISH, TimeZone.getTimeZone( "PST" ) );
+    Assert.assertEquals( "Tuesday, January 6, 2009 12:40:31 AM PST", fd.format( new Date( 1231231231000l ) ) );
   }
 }

--- a/libraries/libformat/test/org/pentaho/reporting/libraries/formatting/MessageFormatTest.java
+++ b/libraries/libformat/test/org/pentaho/reporting/libraries/formatting/MessageFormatTest.java
@@ -17,31 +17,40 @@
 
 package org.pentaho.reporting.libraries.formatting;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
-
-public class MessageFormatTest
-{
-  public MessageFormatTest()
-  {
+public class MessageFormatTest {
+  public MessageFormatTest() {
   }
 
   @Test
-  public void testNonCrash()
-  {
-    FastMessageFormat messageFormat = new FastMessageFormat("{0,date,dd MMM yyyy}");
-    Assert.assertEquals("26 Nov 1973", messageFormat.format(new Object[]{new Date(123123123123l)}));
+  public void testNonCrash() {
+    FastMessageFormat messageFormat = new FastMessageFormat( "{0,date,dd MMM yyyy}" );
+    final Date tempDate = new Date( 123123123123l );
+    final Object[] tempDateArray = { tempDate };
+    final String tempDateString = messageFormat.format( tempDateArray );
+
+    // Added check for 25 or 26 Nov to handle the different timezones
+    boolean result = "26 Nov 1973".equals( tempDateString );
+    if ( !result ) {
+      result = "25 Nov 1973".equals( tempDateString );
+    }
+    Assert
+      .assertTrue( "Resuls should equal '25 Nov 1973' or '26 Nov 1973' depending on timezone: actual=" + tempDateString,
+        result );
   }
 
   @Test
   public void testLocaleAndTimezoneApplied() {
-    FastMessageFormat messageFormat = new FastMessageFormat("{0,date,full} {1,number,#,###.##}", Locale.GERMAN, TimeZone.getTimeZone("PST"));
-    Assert.assertEquals("Sonntag, 25. November 1973 16:52 Uhr PST 1.234,57",
-        messageFormat.format(new Object[]{new Date(123123123123l), new Double(1234.567)}));
+    FastMessageFormat messageFormat =
+      new FastMessageFormat( "{0,date,full} {1,number,#,###.##}", Locale.GERMAN, TimeZone.getTimeZone( "PST" ) );
+    Assert.assertEquals( "Sonntag, 25. November 1973 16:52 Uhr PST 1.234,57",
+      messageFormat.format( new Object[] { new Date( 123123123123l ), new Double( 1234.567 ) } ) );
 
   }
 


### PR DESCRIPTION
When running the MessageFormatTest.testNoCrash() unit test, the test would fail with a date that was 1 day off because the message was output as "25 Nov 1973" (25 Nov 1973 19:52:03 EST). Updated the test to check for either 25 or 26 of Nov since the purpose of the test was testing the default constructor.