### PR TITLE
SP-2007 - Backport of PRD-5478 - Page header missing in the second page of the excel export (5.4 Suite)

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/ReportStructureValidator.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/ReportStructureValidator.java
@@ -33,6 +33,7 @@ import org.pentaho.reporting.engine.classic.core.function.Expression;
 import org.pentaho.reporting.engine.classic.core.function.LayoutProcessorFunction;
 import org.pentaho.reporting.engine.classic.core.function.PageFunction;
 import org.pentaho.reporting.engine.classic.core.function.RowBandingFunction;
+import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
 import org.pentaho.reporting.engine.classic.core.util.AbstractStructureVisitor;
 import org.pentaho.reporting.engine.classic.core.wizard.RelationalAutoGeneratorPreProcessor;
 
@@ -96,6 +97,14 @@ public class ReportStructureValidator extends AbstractStructureVisitor
 
     if (element.getAttributeExpression(AttributeNames.Core.NAMESPACE, AttributeNames.Core.RICH_TEXT_TYPE) != null)
     {
+      valid = false;
+      return;
+    }
+
+    if ( element.getStyle().getBooleanStyleProperty( BandStyleKeys.PAGEBREAK_BEFORE ) ||
+        element.getStyle().getBooleanStyleProperty( BandStyleKeys.PAGEBREAK_AFTER ) ||
+        element.getStyleExpression( BandStyleKeys.PAGEBREAK_BEFORE ) != null ||
+        element.getStyleExpression( BandStyleKeys.PAGEBREAK_AFTER ) != null) {
       valid = false;
       return;
     }

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd5268Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd5268Test.java
@@ -49,10 +49,10 @@ public class Prd5268Test
 
 
   @Test
-  public void testSheetNamesInFastMode() throws Exception
+  public void testSheetNames() throws Exception
   {
     MasterReport report = createReport();
-    Assert.assertTrue(new ReportStructureValidator().isValidForFastProcessing(report));
+    Assert.assertFalse(new ReportStructureValidator().isValidForFastProcessing(report));
 
     ByteArrayOutputStream boutFast = new ByteArrayOutputStream();
     FastExcelReportUtil.processXlsx(report, boutFast);
@@ -68,7 +68,7 @@ public class Prd5268Test
   public void testSheetContent() throws Exception
   {
     MasterReport report = createReport();
-    Assert.assertTrue(new ReportStructureValidator().isValidForFastProcessing(report));
+    Assert.assertFalse(new ReportStructureValidator().isValidForFastProcessing(report));
 
     ByteArrayOutputStream boutFast = new ByteArrayOutputStream();
     FastExcelReportUtil.processXlsx(report, boutFast);


### PR DESCRIPTION
Backport of https://github.com/pentaho/pentaho-reporting/pull/647
@tmorgner
Please review.