### PR TITLE
[CLEANUP] - More test fixes

### DIFF
--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd5321Test.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/bugs/Prd5321Test.java
@@ -215,7 +215,7 @@ public class Prd5321Test {
 
   @Test
   public void testTextRenderingComplex() throws Exception {
-    if (DebugReportRunner.isRunFromAnt()) {
+    if (DebugReportRunner.isSafeToTestComplexText()) {
       return;
     }
 

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/layout/table/TableLayoutTest.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/layout/table/TableLayoutTest.java
@@ -166,6 +166,9 @@ public class TableLayoutTest extends TestCase {
   }
 
   public void testFixedSizeTableCellsRelativeSizeComplex() throws Exception {
+    if (DebugReportRunner.isSafeToTestComplexText()) {
+      return;
+    }
 
     final Band tableCell1 =
       TableTestUtil.createCell( 0, 0, 100, 10, TableTestUtil.createDataItem( "Text", -100, -100 ) );
@@ -368,7 +371,7 @@ public class TableLayoutTest extends TestCase {
   }
 
   public void testFixedSizeTableCellsRelativeSizeCanvasComplex() throws Exception {
-    if (DebugReportRunner.isRunFromAnt()) {
+    if (DebugReportRunner.isSafeToTestComplexText()) {
       return;
     }
     final Band tableCell1 = TableTestUtil.createCell( 0, 0, 100, 10,

--- a/engine/core/test/org/pentaho/reporting/engine/classic/core/testsupport/DebugReportRunner.java
+++ b/engine/core/test/org/pentaho/reporting/engine/classic/core/testsupport/DebugReportRunner.java
@@ -726,8 +726,14 @@ public class DebugReportRunner {
   }
 
   public static boolean isSafeToTestComplexText() {
+    // this property is undefined by default. This is safer than testing for existing Ant properties
+    // or other hacks. You will have to explicitly enable this property in the system properties or
+    // system configuration to test complex text code on your machine.
+    //
+    // Note that the results of the layout is machine dependent, so a failure may not be an error, but
+    // the result of a difference in fonts or settings.
     return "true".equals( ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty
-      ( "dont.try.this.at.home.-.testing.complex.text" ) );
+      ( "junit.enable-platform-dependent-tests" ) );
   }
 
   public static File createTestOutputFile( String name ) {
@@ -738,9 +744,5 @@ public class DebugReportRunner {
       return file;
     }
     return new File( file, name );
-  }
-
-  public static boolean isRunFromAnt() {
-    return !"@@invalid@@".equals(System.getProperty("ant.project.invoked-targets", "@@invalid@@"));
   }
 }

--- a/engine/extensions-kettle/ivy.xml
+++ b/engine/extensions-kettle/ivy.xml
@@ -51,6 +51,7 @@
     </dependency>
     <dependency org="commons-net" name="commons-net" rev="1.4.1" conf="default_external->default"/>
     <dependency org="org.apache.commons"  name="commons-vfs2" rev="2.0" transitive="false" conf="default_external->default"/>
+    <dependency org="com.google.guava" name="guava" rev="17.0" transitive="false" conf="default_external->default"/>
     <dependency org="commons-digester" name="commons-digester" rev="1.8" transitive="false" conf="default_external->default"/>
 	  <dependency org="commons-beanutils" name="commons-beanutils" rev="1.7.0" transitive="false" conf="default_external->default"/>
     <dependency org="ognl" name="ognl" rev="2.6.9" transitive="false" conf="default_external->default"/>

--- a/engine/extensions-kettle/ivy.xml
+++ b/engine/extensions-kettle/ivy.xml
@@ -50,7 +50,7 @@
       <exclude org="xml-apis" module="xml-apis"/>
     </dependency>
     <dependency org="commons-net" name="commons-net" rev="1.4.1" conf="default_external->default"/>
-    <dependency org="commons-vfs" name="commons-vfs" rev="1.0" transitive="false" conf="default_external->default"/>
+    <dependency org="org.apache.commons"  name="commons-vfs2" rev="2.0" transitive="false" conf="default_external->default"/>
     <dependency org="commons-digester" name="commons-digester" rev="1.8" transitive="false" conf="default_external->default"/>
 	  <dependency org="commons-beanutils" name="commons-beanutils" rev="1.7.0" transitive="false" conf="default_external->default"/>
     <dependency org="ognl" name="ognl" rev="2.6.9" transitive="false" conf="default_external->default"/>


### PR DESCRIPTION
CI did not pick up my exclusion, so now I use the conservative measure of demanding a specific system property to be set before the dangerous tests are run. Ant, or any normal developer, will not have the system property set, so the tests are skipped. 

Kettle tests were failing as we did not pull in VFS2 and Guava via Ivy. The tests are much happier now.