### PR TITLE
[BACKLOG-5203] Change the level of logging for Report Designer

### DIFF
--- a/designer/report-designer-assembly/resource/resources/log4j.xml
+++ b/designer/report-designer-assembly/resource/resources/log4j.xml
@@ -54,7 +54,7 @@
   </appender>
 
   <category name="org.pentaho">
-    <priority value="DEBUG"/>
+    <priority value="WARN"/>
   </category>
 
   <category name="org.pentaho.ui.xul">


### PR DESCRIPTION
	- on startup, and with log level set to DEBUG, PRD dumps > 3k lines to the log