### PR TITLE
[BACKLOG-5341] Added data service client to drivers folder

### DIFF
--- a/designer/report-designer-assembly/ivy.xml
+++ b/designer/report-designer-assembly/ivy.xml
@@ -152,7 +152,7 @@
       <artifact name="pdi-spark-plugin" type="zip"/>
     </dependency>
     <dependency org="pentaho" name="pdi-dataservice-client-plugin" rev="${dependency.pdi-dataservice-client-plugin.revision}"
-                conf="plugin->default" changing="true" transitive="false"/>
+                conf="drivers->default" changing="true" transitive="false"/>
 
     <!-- JSON dependencies -->
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="${dependency.json.simple.revision}"


### PR DESCRIPTION
@mkambol @hudak @dkincade 

conf was changed to copy our driver into the jdbc folder with the other drivers. The plugin conf is no longer needed since a change was made awhile back that added the pdi-client via karaf, so now it gets pick up there.