### PR TITLE
[BACKLOG-5341] Added data service client to drivers folder

### DIFF
--- a/designer/report-designer-assembly/ivy.xml
+++ b/designer/report-designer-assembly/ivy.xml
@@ -152,7 +152,7 @@
       <artifact name="pdi-spark-plugin" type="zip"/>
     </dependency>
     <dependency org="pentaho" name="pdi-dataservice-client-plugin" rev="${dependency.pdi-dataservice-client-plugin.revision}"
-                conf="plugin->default" changing="true" transitive="false"/>
+                conf="drivers->default" changing="true" transitive="false"/>
 
     <!-- JSON dependencies -->
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="${dependency.json.simple.revision}"


### PR DESCRIPTION
@dkincade 

Jira:
http://jira.pentaho.com/browse/BACKLOG-5341

Master PR:
https://github.com/pentaho/pentaho-reporting/pull/676

DevCI:
I have tried building the project and it fails because it's looking for 6.1-SNAPSHOT dependencies that don't exist. Additionally, I have attempted to build the needed dependencies, but even with the release version set to 6.1-SNAPSHOT, some of them are still building 6.0-SNAPSHOTS.