### PR TITLE
[BACKLOG-5456] - Small improvements for PRD

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/alignment/AbstractAlignmentProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/process/alignment/AbstractAlignmentProcessor.java
@@ -727,11 +727,7 @@ public abstract class AbstractAlignmentProcessor implements TextAlignmentProcess
    */
   // package local visibility for testing purposes
   static void shiftArray( Object[] array, int startIndex, int amount, int offset ) {
-    int endIndex = startIndex + amount - 1;
-    int destEndIndex = endIndex + offset;
-    for ( int i = endIndex, j = destEndIndex; i >= startIndex; i--, j-- ) {
-      array[ j ] = array[ i ];
-    }
+    System.arraycopy( array, startIndex, array, startIndex + offset, amount );
   }
 
   /**

--- a/libraries/libbase/source/org/pentaho/reporting/libraries/base/boot/DefaultObjectFactory.java
+++ b/libraries/libbase/source/org/pentaho/reporting/libraries/base/boot/DefaultObjectFactory.java
@@ -48,7 +48,7 @@ public class DefaultObjectFactory implements ObjectFactory {
       final Class clazz = (Class) Class.forName( value, false, classLoader );
       final Annotation annotation = clazz.getAnnotation( SingletonHint.class );
       if ( annotation == null ) {
-        final T retval = ObjectUtilities.loadAndInstantiate( value, interfaceClass, interfaceClass );
+        final T retval = ObjectUtilities.instantiateSafe( clazz, interfaceClass );
         if ( retval == null ) {
           throw new ObjectFactoryException( interfaceClass.getName(), value );
         }
@@ -60,7 +60,7 @@ public class DefaultObjectFactory implements ObjectFactory {
         return (T) o;
       }
 
-      final T retval = ObjectUtilities.loadAndInstantiate( value, interfaceClass, interfaceClass );
+      final T retval = ObjectUtilities.instantiateSafe( clazz, interfaceClass );
       if ( retval == null ) {
         throw new ObjectFactoryException( interfaceClass.getName(), value );
       }

--- a/libraries/libbase/source/org/pentaho/reporting/libraries/base/config/DefaultConfiguration.java
+++ b/libraries/libbase/source/org/pentaho/reporting/libraries/base/config/DefaultConfiguration.java
@@ -17,11 +17,11 @@
 
 package org.pentaho.reporting.libraries.base.config;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Properties;
-import java.util.TreeSet;
 
 /**
  * Default configuration.
@@ -74,17 +74,26 @@ public class DefaultConfiguration extends Properties
    * @return the properties as iterator.
    */
   public Iterator<String> findPropertyKeys( final String prefix ) {
-    final TreeSet<String> collector = new TreeSet<String>();
-    final Enumeration enum1 = keys();
+    String[] array = new String[ size() ];
+    int found = 0;
+    Enumeration enum1 = keys();
     while ( enum1.hasMoreElements() ) {
-      final String key = (String) enum1.nextElement();
+      String key = (String) enum1.nextElement();
       if ( key.startsWith( prefix ) ) {
-        if ( collector.contains( key ) == false ) {
-          collector.add( key );
-        }
+        array[ found ] = key;
+        found++;
       }
     }
-    return Collections.unmodifiableSet( collector ).iterator();
+    if ( found == 0 ) {
+      return Collections.emptyIterator();
+    } else if ( found == 1 ) {
+      return Collections.singleton( array[ 0 ] ).iterator();
+    } else {
+      String[] returned = new String[ found ];
+      System.arraycopy( array, 0, returned, 0, found );
+      Arrays.sort( returned );
+      return Arrays.asList( returned ).iterator();
+    }
   }
 
   public Enumeration<String> getConfigProperties() {

--- a/libraries/libbase/testcases/org/pentaho/reporting/libraries/base/boot/ObjectFactoryTest.java
+++ b/libraries/libbase/testcases/org/pentaho/reporting/libraries/base/boot/ObjectFactoryTest.java
@@ -1,22 +1,39 @@
 package org.pentaho.reporting.libraries.base.boot;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 import org.pentaho.reporting.libraries.base.LibBaseBoot;
 
 import java.util.ArrayList;
 
-public class ObjectFactoryTest extends TestCase {
+import static org.junit.Assert.assertTrue;
+
+public class ObjectFactoryTest {
+
+  private ObjectFactory objectFactory;
+
+  @Before
+  public void setUp() {
+    objectFactory = LibBaseBoot.getInstance().getObjectFactory();
+  }
+
+  @Test
   public void testSingletonCreation() {
-    final ObjectFactory objectFactory = LibBaseBoot.getInstance().getObjectFactory();
-    final ObjectFactorySingleton objectFactorySingleton1 = objectFactory.get( ObjectFactorySingleton.class );
-    final ObjectFactorySingleton objectFactorySingleton2 = objectFactory.get( ObjectFactorySingleton.class );
+    ObjectFactorySingleton objectFactorySingleton1 = objectFactory.get( ObjectFactorySingleton.class );
+    ObjectFactorySingleton objectFactorySingleton2 = objectFactory.get( ObjectFactorySingleton.class );
     assertTrue( objectFactorySingleton1 == objectFactorySingleton2 );
   }
 
+  @Test
   public void testNotSingletonCreation() {
-    final ObjectFactory objectFactory = LibBaseBoot.getInstance().getObjectFactory();
-    final ArrayList objectFactorySingleton1 = objectFactory.get( ArrayList.class );
-    final ArrayList objectFactorySingleton2 = objectFactory.get( ArrayList.class );
+    ArrayList objectFactorySingleton1 = objectFactory.get( ArrayList.class );
+    ArrayList objectFactorySingleton2 = objectFactory.get( ArrayList.class );
     assertTrue( objectFactorySingleton1 != objectFactorySingleton2 );
+  }
+
+
+  @Test( expected = ObjectFactoryException.class )
+  public void throwsException_WhenCannotCast_SingletonToList() {
+    objectFactory.get( ObjectFactorySingleton.class, ArrayList.class.getName() );
   }
 }

--- a/libraries/libbase/testcases/org/pentaho/reporting/libraries/base/config/DefaultConfigurationTest.java
+++ b/libraries/libbase/testcases/org/pentaho/reporting/libraries/base/config/DefaultConfigurationTest.java
@@ -1,0 +1,84 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.base.config;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class DefaultConfigurationTest {
+
+  private DefaultConfiguration cfg;
+
+  @Before
+  public void setUp() throws Exception {
+    cfg = new DefaultConfiguration();
+  }
+
+
+  @Test
+  public void findPropertyKeys_EmptyIterator_WhenEmptyConfig() {
+    assertFalse( cfg.findPropertyKeys( "" ).hasNext() );
+  }
+
+  @Test
+  public void findPropertyKeys_EmptyIterator_WhenDoesNotMatch() {
+    cfg.setConfigProperty( "a", "a" );
+    assertFalse( cfg.findPropertyKeys( "q" ).hasNext() );
+  }
+
+
+  @Test
+  public void findPropertyKeys_ReturnsInSortedOrder() {
+    cfg.setConfigProperty( "b", "b" );
+    cfg.setConfigProperty( "a", "a" );
+    cfg.setConfigProperty( "c", "c" );
+
+    Iterator<String> keys = cfg.findPropertyKeys( "" );
+    assertReturnedSeries( keys, "a", "b", "c" );
+  }
+
+  @Test
+  public void findPropertyKeys_ReturnsValuesStartedWithPrefix() {
+    cfg.setConfigProperty( "a", "a" );
+    cfg.setConfigProperty( "b", "b" );
+    cfg.setConfigProperty( "aa", "aa" );
+
+    Iterator<String> keys = cfg.findPropertyKeys( "a" );
+    assertReturnedSeries( keys, "a", "aa" );
+  }
+
+  private void assertReturnedSeries( Iterator<String> iterator, String... expected ) {
+    int cnt = 0;
+    while ( iterator.hasNext() && cnt < expected.length ) {
+      assertEquals( expected[ cnt++ ], iterator.next() );
+    }
+    assertFalse(
+      String.format( "Elements checked: %d\nArray:\n\t%s\n", cnt, Arrays.toString( expected ) ),
+      iterator.hasNext()
+    );
+  }
+
+}


### PR DESCRIPTION
- improve DefaultConfiguration.findPropertyKeys()
  - Set is useless as Hashtable.keys() cannot return duplicate values
  - replace TreeSet with array
  - add tests
- avoid redundant Class.forName() calls in DefaultObjectFactory.get()
  - introduce ObjectUtilities.instantiateSafe()
  - update tests
- use System.arrayCopy() in AbstractAlignmentProcessor.shiftArray()

@tmorgner, review it please when you have time. 
Nothing serious here, just sent all my catches