### PR TITLE
[TEST] Increase unit test coverage for engine/extensions-scripting

### DIFF
--- a/engine/extensions-scripting/ivy.xml
+++ b/engine/extensions-scripting/ivy.xml
@@ -22,14 +22,17 @@
 		<!--  external dependencies -->
 		<dependency org="rhino" name="js" rev="1.7R1" conf="default_external->default"/>
 
-    <!-- Testing Dependencies -->
-    <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
-    <dependency org="org.hsqldb" name="hsqldb" rev="2.3.2" transitive="false" conf="test->default"/>
-    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
-    <dependency org="pentaho" name="simple-jndi" rev="${dependency.pentaho-simple-jndi.revision}" transitive="false" conf="test->default"/>
-    <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
-    <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"
-                transitive="false" conf="test->default"/>
+	    <!-- Testing Dependencies -->
+	    <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
+	    <dependency org="org.hsqldb" name="hsqldb" rev="2.3.2" transitive="false" conf="test->default"/>
+	    <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
+	    <dependency org="pentaho" name="simple-jndi" rev="${dependency.pentaho-simple-jndi.revision}" transitive="false" conf="test->default"/>
+	    <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
+	    <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"
+	                transitive="false" conf="test->default"/>
+	    <dependency org="org.mockito" name="mockito-all" rev="1.10.9" transitive="false" conf="test->default"/>
+	    <dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" conf="test->default"/>
+	    <dependency org="xerces" name="xercesImpl" rev="2.8.1" conf="test->default"/>
 	</dependencies>
 
 </ivy-module>

--- a/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactory.java
+++ b/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactory.java
@@ -1,21 +1,25 @@
 /*!
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-* Foundation.
-*
-* You should have received a copy of the GNU Lesser General Public License along with this
-* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-* or from the Free Software Foundation, Inc.,
-* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU Lesser General Public License for more details.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
-*/
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
 
 package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable;
+
+import java.util.LinkedHashMap;
+
+import javax.swing.table.TableModel;
 
 import org.apache.bsf.BSFException;
 import org.apache.bsf.BSFManager;
@@ -30,9 +34,6 @@ import org.pentaho.reporting.engine.classic.core.states.LegacyDataRowWrapper;
 import org.pentaho.reporting.libraries.base.config.Configuration;
 import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
-
-import javax.swing.table.TableModel;
-import java.util.LinkedHashMap;
 
 /**
  * A datafactory that uses a bean-scripting framework script to produce a tablemodel.
@@ -89,9 +90,8 @@ public class ScriptableDataFactory extends AbstractDataFactory {
   }
 
   public String[] getQueryNames() {
-    return queries.keySet().toArray( new String[ queries.size() ] );
+    return queries.keySet().toArray( new String[queries.size()] );
   }
-
 
   /**
    * Creates a new interpreter instance.
@@ -107,18 +107,18 @@ public class ScriptableDataFactory extends AbstractDataFactory {
   /**
    * Initializes the Bean-Scripting Framework manager.
    *
-   * @param interpreter the BSF-Manager that should be initialized.
-   * @throws BSFException if an error occured.
+   * @param interpreter
+   *          the BSF-Manager that should be initialized.
+   * @throws BSFException
+   *           if an error occurred.
    */
-  protected void initializeInterpreter( final BSFManager interpreter )
-    throws BSFException {
+  protected void initializeInterpreter( final BSFManager interpreter ) throws BSFException {
     dataRowWrapper = new LegacyDataRowWrapper();
     interpreter.declareBean( "dataRow", dataRowWrapper, DataRow.class ); //$NON-NLS-1$
     interpreter.declareBean( "configuration", getConfiguration(), Configuration.class ); //$NON-NLS-1$
     interpreter.declareBean( "contextKey", getContextKey(), ResourceKey.class ); //$NON-NLS-1$
     interpreter.declareBean( "resourceManager", getResourceManager(), ResourceManager.class ); //$NON-NLS-1$
-    interpreter
-      .declareBean( "resourceBundleFactory", getResourceBundleFactory(), ResourceBundleFactory.class ); //$NON-NLS-1$
+    interpreter.declareBean( "resourceBundleFactory", getResourceBundleFactory(), ResourceBundleFactory.class ); //$NON-NLS-1$
     interpreter.declareBean( "dataFactoryContext", getDataFactoryContext(), ResourceBundleFactory.class ); //$NON-NLS-1$
     if ( script != null ) {
       interpreter.exec( getLanguage(), "startup-script", 1, 1, getScript() ); //$NON-NLS-1$
@@ -132,10 +132,13 @@ public class ScriptableDataFactory extends AbstractDataFactory {
    * The parameter-dataset may change between two calls, do not assume anything, and do not hold references to the
    * parameter-dataset or the position of the columns in the dataset.
    *
-   * @param query      the query string
-   * @param parameters the parameters for the query
+   * @param query
+   *          the query string
+   * @param parameters
+   *          the parameters for the query
    * @return the result of the query as table model.
-   * @throws ReportDataFactoryException if an error occured while performing the query.
+   * @throws ReportDataFactoryException
+   *           if an error occurred while performing the query.
    */
   public TableModel queryData( final String query, final DataRow parameters ) throws ReportDataFactoryException {
     final String queryScript = queries.get( query );
@@ -163,7 +166,6 @@ public class ScriptableDataFactory extends AbstractDataFactory {
     } catch ( Exception e ) {
       throw new ReportDataFactoryException( "Evaluation error", e );
     }
-
   }
 
   public ScriptableDataFactory clone() {
@@ -175,7 +177,7 @@ public class ScriptableDataFactory extends AbstractDataFactory {
   }
 
   /**
-   * Returns a copy of the data factory that is not affected by its anchestor and holds no connection to the anchestor
+   * Returns a copy of the data factory that is not affected by its ancestor and holds no connection to the ancestor
    * anymore. A data-factory will be derived at the beginning of the report processing.
    *
    * @return a copy of the data factory.

--- a/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactoryModule.java
+++ b/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactoryModule.java
@@ -1,19 +1,19 @@
 /*
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-* Foundation.
-*
-* You should have received a copy of the GNU Lesser General Public License along with this
-* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-* or from the Free Software Foundation, Inc.,
-* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU Lesser General Public License for more details.
-*
-* Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
-*/
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+ */
 
 package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable;
 
@@ -21,8 +21,7 @@ import org.pentaho.reporting.engine.classic.core.metadata.ElementMetaDataParser;
 import org.pentaho.reporting.engine.classic.core.modules.parser.base.DataFactoryReadHandlerFactory;
 import org.pentaho.reporting.engine.classic.core.modules.parser.base.DataFactoryXmlResourceFactory;
 import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser.ScriptableDataSourceReadHandler;
-import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser
-  .ScriptableDataSourceXmlFactoryModule;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser.ScriptableDataSourceXmlFactoryModule;
 import org.pentaho.reporting.libraries.base.boot.AbstractModule;
 import org.pentaho.reporting.libraries.base.boot.ModuleInitializeException;
 import org.pentaho.reporting.libraries.base.boot.SubSystem;
@@ -35,7 +34,7 @@ import org.pentaho.reporting.libraries.base.boot.SubSystem;
 public class ScriptableDataFactoryModule extends AbstractModule {
   public static final String NAMESPACE = "http://jfreereport.sourceforge.net/namespaces/datasources/scriptable";
   public static final String TAG_DEF_PREFIX =
-    "org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.tag-def.";
+      "org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.tag-def.";
 
   public ScriptableDataFactoryModule() throws ModuleInitializeException {
     loadModuleInfo();
@@ -46,17 +45,19 @@ public class ScriptableDataFactoryModule extends AbstractModule {
    * a modules lifetime. If the initializing cannot be completed, throw a ModuleInitializeException to indicate the
    * error,. The module will not be available to the system.
    *
-   * @param subSystem the subSystem.
-   * @throws ModuleInitializeException if an error ocurred while initializing the module.
+   * @param subSystem
+   *          the subSystem.
+   * @throws ModuleInitializeException
+   *           if an error occurred while initializing the module.
    */
   public void initialize( final SubSystem subSystem ) throws ModuleInitializeException {
     DataFactoryXmlResourceFactory.register( ScriptableDataSourceXmlFactoryModule.class );
 
-    DataFactoryReadHandlerFactory.getInstance()
-      .setElementHandler( NAMESPACE, "scriptable-datasource", ScriptableDataSourceReadHandler.class );
+    DataFactoryReadHandlerFactory.getInstance().setElementHandler( NAMESPACE, "scriptable-datasource",
+        ScriptableDataSourceReadHandler.class );
 
-    ElementMetaDataParser.initializeOptionalDataFactoryMetaData
-      ( "org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/meta-datafactory.xml" );
+    ElementMetaDataParser
+        .initializeOptionalDataFactoryMetaData( "org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/meta-datafactory.xml" );
 
   }
 }

--- a/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ScriptableDataSourceReadHandler.java
+++ b/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ScriptableDataSourceReadHandler.java
@@ -1,21 +1,23 @@
 /*!
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-* Foundation.
-*
-* You should have received a copy of the GNU Lesser General Public License along with this
-* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-* or from the Free Software Foundation, Inc.,
-* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU Lesser General Public License for more details.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
-*/
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
 
 package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser;
+
+import java.util.ArrayList;
 
 import org.pentaho.reporting.engine.classic.core.DataFactory;
 import org.pentaho.reporting.engine.classic.core.modules.parser.base.DataFactoryReadHandler;
@@ -27,8 +29,6 @@ import org.pentaho.reporting.libraries.xmlns.parser.PropertyReadHandler;
 import org.pentaho.reporting.libraries.xmlns.parser.XmlReadHandler;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-
-import java.util.ArrayList;
 
 public class ScriptableDataSourceReadHandler extends AbstractXmlReadHandler implements DataFactoryReadHandler {
   private ConfigReadHandler configReadHandler;
@@ -42,16 +42,19 @@ public class ScriptableDataSourceReadHandler extends AbstractXmlReadHandler impl
   /**
    * Returns the handler for a child element.
    *
-   * @param uri     the URI of the namespace of the current element.
-   * @param tagName the tag name.
-   * @param atts    the attributes.
+   * @param uri
+   *          the URI of the namespace of the current element.
+   * @param tagName
+   *          the tag name.
+   * @param atts
+   *          the attributes.
    * @return the handler or null, if the tagname is invalid.
-   * @throws SAXException if there is a parsing error.
+   * @throws SAXException
+   *           if there is a parsing error.
    */
-  protected XmlReadHandler getHandlerForChild( final String uri,
-                                               final String tagName,
-                                               final Attributes atts ) throws SAXException {
-    if ( isSameNamespace( uri ) == false ) {
+  protected XmlReadHandler getHandlerForChild( final String uri, final String tagName, final Attributes atts )
+    throws SAXException {
+    if ( !isSameNamespace( uri ) ) {
       return null;
     }
     if ( "config".equals( tagName ) ) {
@@ -71,7 +74,8 @@ public class ScriptableDataSourceReadHandler extends AbstractXmlReadHandler impl
   /**
    * Done parsing.
    *
-   * @throws SAXException if there is a parsing error.
+   * @throws SAXException
+   *           if there is a parsing error.
    */
   protected void doneParsing() throws SAXException {
     final ScriptableDataFactory srdf = new ScriptableDataFactory();
@@ -80,10 +84,10 @@ public class ScriptableDataSourceReadHandler extends AbstractXmlReadHandler impl
     }
 
     srdf.setLanguage( configReadHandler.getLanguage() );
-    if ( StringUtils.isEmpty( configReadHandler.getScript() ) == false ) {
+    if ( !StringUtils.isEmpty( configReadHandler.getScript() ) ) {
       srdf.setScript( configReadHandler.getScript() );
     }
-    if ( StringUtils.isEmpty( configReadHandler.getShutdownScript() ) == false ) {
+    if ( !StringUtils.isEmpty( configReadHandler.getShutdownScript() ) ) {
       srdf.setShutdownScript( configReadHandler.getShutdownScript() );
     }
     for ( int i = 0; i < queries.size(); i++ ) {
@@ -97,7 +101,8 @@ public class ScriptableDataSourceReadHandler extends AbstractXmlReadHandler impl
    * Returns the object for this element or null, if this element does not create an object.
    *
    * @return the object.
-   * @throws SAXException if an parser error occured.
+   * @throws SAXException
+   *           if an parser error occurred.
    */
   public Object getObject() throws SAXException {
     return dataFactory;

--- a/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/writer/ScriptableDataFactoryWriteHandler.java
+++ b/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/writer/ScriptableDataFactoryWriteHandler.java
@@ -1,21 +1,23 @@
 /*!
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-* Foundation.
-*
-* You should have received a copy of the GNU Lesser General Public License along with this
-* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-* or from the Free Software Foundation, Inc.,
-* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU Lesser General Public License for more details.
-*
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
-*/
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
 
 package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.writer;
+
+import java.io.IOException;
 
 import org.pentaho.reporting.engine.classic.core.DataFactory;
 import org.pentaho.reporting.engine.classic.core.modules.parser.extwriter.DataFactoryWriteHandler;
@@ -27,8 +29,6 @@ import org.pentaho.reporting.libraries.base.util.StringUtils;
 import org.pentaho.reporting.libraries.xmlns.common.AttributeList;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriterSupport;
-
-import java.io.IOException;
 
 /**
  * Creation-Date: Jan 19, 2007, 4:44:05 PM
@@ -42,15 +42,18 @@ public class ScriptableDataFactoryWriteHandler implements DataFactoryWriteHandle
   /**
    * Writes a data-source into a XML-stream.
    *
-   * @param reportWriter the writer context that holds all factories.
-   * @param xmlWriter    the XML writer that will receive the generated XML data.
-   * @param dataFactory  the data factory that should be written.
-   * @throws IOException           if any error occured
-   * @throws ReportWriterException if the data factory cannot be written.
+   * @param reportWriter
+   *          the writer context that holds all factories.
+   * @param xmlWriter
+   *          the XML writer that will receive the generated XML data.
+   * @param dataFactory
+   *          the data factory that should be written.
+   * @throws IOException
+   *           if any error occurred
+   * @throws ReportWriterException
+   *           if the data factory cannot be written.
    */
-  public void write( final ReportWriterContext reportWriter,
-                     final XmlWriter xmlWriter,
-                     final DataFactory dataFactory )
+  public void write( final ReportWriterContext reportWriter, final XmlWriter xmlWriter, final DataFactory dataFactory )
     throws IOException, ReportWriterException {
     final ScriptableDataFactory scriptableDataFactory = (ScriptableDataFactory) dataFactory;
 
@@ -60,21 +63,21 @@ public class ScriptableDataFactoryWriteHandler implements DataFactoryWriteHandle
     xmlWriter.writeTag( ScriptableDataFactoryModule.NAMESPACE, "scriptable-datasource", rootAttrs, XmlWriter.OPEN );
 
     final AttributeList configAttrs = new AttributeList();
-    configAttrs.setAttribute( ScriptableDataFactoryModule.NAMESPACE,
-      "language", String.valueOf( scriptableDataFactory.getLanguage() ) );
-    if ( StringUtils.isEmpty( scriptableDataFactory.getScript() ) == false ) {
-      configAttrs.setAttribute( ScriptableDataFactoryModule.NAMESPACE,
-        "script", String.valueOf( scriptableDataFactory.getScript() ) );
+    configAttrs.setAttribute( ScriptableDataFactoryModule.NAMESPACE, "language", String.valueOf( scriptableDataFactory
+        .getLanguage() ) );
+    if ( !StringUtils.isEmpty( scriptableDataFactory.getScript() ) ) {
+      configAttrs.setAttribute( ScriptableDataFactoryModule.NAMESPACE, "script", String.valueOf( scriptableDataFactory
+          .getScript() ) );
     }
-    if ( StringUtils.isEmpty( scriptableDataFactory.getScript() ) == false ) {
-      configAttrs.setAttribute( ScriptableDataFactoryModule.NAMESPACE,
-        "shutdown-script", String.valueOf( scriptableDataFactory.getShutdownScript() ) );
+    if ( !StringUtils.isEmpty( scriptableDataFactory.getShutdownScript() ) ) {
+      configAttrs.setAttribute( ScriptableDataFactoryModule.NAMESPACE, "shutdown-script", String
+          .valueOf( scriptableDataFactory.getShutdownScript() ) );
     }
     xmlWriter.writeTag( ScriptableDataFactoryModule.NAMESPACE, "config", configAttrs, XmlWriterSupport.CLOSE );
 
     final String[] queryNames = scriptableDataFactory.getQueryNames();
     for ( int i = 0; i < queryNames.length; i++ ) {
-      final String queryName = queryNames[ i ];
+      final String queryName = queryNames[i];
       final String query = scriptableDataFactory.getQuery( queryName );
       xmlWriter.writeTag( ScriptableDataFactoryModule.NAMESPACE, "query", "name", queryName, XmlWriterSupport.OPEN );
       xmlWriter.writeTextNormalized( query, false );

--- a/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/modules/rhino/RhinoModule.java
+++ b/engine/extensions-scripting/source/org/pentaho/reporting/engine/classic/extensions/modules/rhino/RhinoModule.java
@@ -1,30 +1,29 @@
 /*
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-* Foundation.
-*
-* You should have received a copy of the GNU Lesser General Public License along with this
-* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-* or from the Free Software Foundation, Inc.,
-* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* See the GNU Lesser General Public License for more details.
-*
-* Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
-*/
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+ */
 
 package org.pentaho.reporting.engine.classic.extensions.modules.rhino;
+
+import java.net.URL;
 
 import org.pentaho.reporting.engine.classic.core.metadata.ExpressionRegistry;
 import org.pentaho.reporting.libraries.base.boot.AbstractModule;
 import org.pentaho.reporting.libraries.base.boot.ModuleInitializeException;
 import org.pentaho.reporting.libraries.base.boot.SubSystem;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
-
-import java.net.URL;
-
 
 /**
  * The module definition for the bean scripting framework support module.
@@ -35,10 +34,10 @@ public class RhinoModule extends AbstractModule {
   /**
    * DefaultConstructor. Loads the module specification.
    *
-   * @throws ModuleInitializeException if an error occured.
+   * @throws ModuleInitializeException
+   *           if an error occurred.
    */
-  public RhinoModule()
-    throws ModuleInitializeException {
+  public RhinoModule() throws ModuleInitializeException {
     loadModuleInfo();
   }
 
@@ -47,21 +46,23 @@ public class RhinoModule extends AbstractModule {
    * a modules lifetime. If the initializing cannot be completed, throw a ModuleInitializeException to indicate the
    * error,. The module will not be available to the system.
    *
-   * @param subSystem the subSystem.
-   * @throws ModuleInitializeException if an error ocurred while initializing the module.
+   * @param subSystem
+   *          the subSystem.
+   * @throws ModuleInitializeException
+   *           if an error occurred while initializing the module.
    */
-  public void initialize( final SubSystem subSystem )
-    throws ModuleInitializeException {
+  public void initialize( final SubSystem subSystem ) throws ModuleInitializeException {
     try {
       final ClassLoader loader = ObjectUtilities.getClassLoader( getClass() );
       Class.forName( "org.mozilla.javascript.Context", false, loader );
     } catch ( Exception e ) {
-      throw new ModuleInitializeException( "Unable to load the Rhino scripting framework class. " +
-        "This class is required to execute the RhinoExpressions." );
+      throw new ModuleInitializeException( "Unable to load the Rhino scripting framework class. "
+          + "This class is required to execute the RhinoExpressions." );
     }
 
-    final URL expressionMetaSource = ObjectUtilities.getResource
-      ( "org/pentaho/reporting/engine/classic/extensions/modules/rhino/meta-expressions.xml", RhinoModule.class );
+    final URL expressionMetaSource =
+        ObjectUtilities.getResource(
+            "org/pentaho/reporting/engine/classic/extensions/modules/rhino/meta-expressions.xml", RhinoModule.class );
     if ( expressionMetaSource == null ) {
       throw new ModuleInitializeException( "Error: Could not find the expression meta-data description file" );
     }

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactoryModuleIT.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactoryModuleIT.java
@@ -1,0 +1,54 @@
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.metadata.DataFactoryMetaData;
+import org.pentaho.reporting.engine.classic.core.metadata.DataFactoryRegistry;
+import org.pentaho.reporting.libraries.base.boot.ModuleInfo;
+
+public class ScriptableDataFactoryModuleIT {
+
+  private static final String DATA_FACTORY_ID =
+      "org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactory";
+
+  @Test
+  public void testInitialize() throws Exception {
+    ClassicEngineBoot.getInstance().start();
+    ScriptableDataFactoryModule module = new ScriptableDataFactoryModule();
+    module.initialize( null );
+
+    assertThat( module.getDescription(), is( equalTo( "test description" ) ) );
+    assertThat( module.getMajorVersion(), is( equalTo( "1" ) ) );
+    assertThat( module.getMinorVersion(), is( equalTo( "1" ) ) );
+    assertThat( module.getPatchLevel(), is( equalTo( "0" ) ) );
+    assertThat( module.getName(), is( equalTo( "test-module-name" ) ) );
+    assertThat( module.getProducer(), is( equalTo( "test producer" ) ) );
+
+    ModuleInfo[] requiredModules = module.getRequiredModules();
+    assertThat( requiredModules.length, is( equalTo( 1 ) ) );
+    ModuleInfo requiredModule = requiredModules[0];
+    assertThat( requiredModule.getModuleClass(), is( equalTo( "test.required.module.class" ) ) );
+    assertThat( requiredModule.getMinorVersion(), is( equalTo( "2" ) ) );
+    assertThat( requiredModule.getMajorVersion(), is( equalTo( "2" ) ) );
+    assertThat( requiredModule.getPatchLevel(), is( equalTo( "1" ) ) );
+
+    ModuleInfo[] optionalModules = module.getOptionalModules();
+    assertThat( optionalModules.length, is( equalTo( 1 ) ) );
+    ModuleInfo optionalModule = optionalModules[0];
+    assertThat( optionalModule.getModuleClass(), is( equalTo( "test.optional.module.class" ) ) );
+    assertThat( optionalModule.getMinorVersion(), is( equalTo( "1" ) ) );
+    assertThat( optionalModule.getMajorVersion(), is( equalTo( "1" ) ) );
+    assertThat( optionalModule.getPatchLevel(), is( equalTo( "0" ) ) );
+
+    assertThat( DataFactoryRegistry.getInstance().isRegistered( DATA_FACTORY_ID ), is( equalTo( true ) ) );
+    DataFactoryMetaData meta = DataFactoryRegistry.getInstance().getMetaData( DATA_FACTORY_ID );
+    assertThat(
+        meta.getBundleLocation(),
+        is( equalTo( "org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactoryBundle" ) ) );
+    assertThat( meta.isExpert(), is( equalTo( true ) ) );
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactoryTest.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/ScriptableDataFactoryTest.java
@@ -1,0 +1,164 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.swing.table.TableModel;
+
+import org.apache.bsf.BSFException;
+import org.apache.bsf.BSFManager;
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.core.DataRow;
+import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
+
+public class ScriptableDataFactoryTest {
+
+  private static final String QUERY_NAME = "name";
+  private static final String QUERY_VALUE = "value";
+  private static final String LANGUAGE = "lang";
+
+  @Test
+  public void testSetQuery() {
+    ScriptableDataFactory dataFactory = new ScriptableDataFactory();
+
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    assertThat( dataFactory.getQuery( QUERY_NAME ), is( equalTo( QUERY_VALUE ) ) );
+
+    dataFactory.setQuery( QUERY_NAME, null );
+    assertThat( dataFactory.getQuery( QUERY_NAME ), is( nullValue() ) );
+  }
+
+  @Test( expected = ReportDataFactoryException.class )
+  public void testQueryDataReportDataFactoryException() throws Exception {
+    ScriptableDataFactory dataFactory = new ScriptableDataFactory();
+    dataFactory.queryData( QUERY_NAME, null );
+  }
+
+  @Test( expected = ReportDataFactoryException.class )
+  public void testQueryDataBSFException() throws Exception {
+    ScriptableDataFactory dataFactory = spy( new ScriptableDataFactory() );
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    dataFactory.setLanguage( LANGUAGE );
+    DataRow parameters = mock( DataRow.class );
+
+    doThrow( BSFException.class ).when( dataFactory ).createInterpreter();
+
+    dataFactory.queryData( QUERY_NAME, parameters );
+  }
+
+  @Test( expected = ReportDataFactoryException.class )
+  public void testQueryDataNotTableModel() throws Exception {
+    ScriptableDataFactory dataFactory = spy( new ScriptableDataFactory() );
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    dataFactory.setLanguage( LANGUAGE );
+    DataRow parameters = mock( DataRow.class );
+    BSFManager interpreter = mock( BSFManager.class );
+
+    when( dataFactory.createInterpreter() ).thenReturn( interpreter );
+    doReturn( "wrong_type" ).when( interpreter ).eval( LANGUAGE, "expression", 1, 1, QUERY_VALUE );
+
+    dataFactory.queryData( QUERY_NAME, parameters );
+  }
+
+  @Test
+  public void testQueryData() throws Exception {
+    ScriptableDataFactory dataFactory = spy( new ScriptableDataFactory() );
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    dataFactory.setLanguage( LANGUAGE );
+    DataRow parameters = mock( DataRow.class );
+    BSFManager interpreter = mock( BSFManager.class );
+    TableModel tableModel = mock( TableModel.class );
+
+    when( dataFactory.createInterpreter() ).thenReturn( interpreter );
+    doReturn( tableModel ).when( interpreter ).eval( LANGUAGE, "expression", 1, 1, QUERY_VALUE );
+
+    TableModel result = dataFactory.queryData( QUERY_NAME, parameters );
+
+    assertThat( result, is( equalTo( tableModel ) ) );
+  }
+
+  @Test
+  public void testClone() throws Exception {
+    ScriptableDataFactory dataFactory = new ScriptableDataFactory();
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+
+    ScriptableDataFactory clonedFactory = dataFactory.clone();
+
+    assertThat( clonedFactory, is( notNullValue() ) );
+    assertThat( clonedFactory.getQuery( QUERY_NAME ), is( equalTo( QUERY_VALUE ) ) );
+  }
+
+  @Test
+  public void testClose() throws Exception {
+    ScriptableDataFactory dataFactory = spy( new ScriptableDataFactory() );
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    dataFactory.setLanguage( LANGUAGE );
+    dataFactory.setShutdownScript( "test_shutdown_script" );
+
+    BSFManager interpreter = mock( BSFManager.class );
+    TableModel tableModel = mock( TableModel.class );
+
+    when( dataFactory.createInterpreter() ).thenReturn( interpreter );
+    doReturn( tableModel ).when( interpreter ).eval( LANGUAGE, "expression", 1, 1, QUERY_VALUE );
+    dataFactory.queryData( QUERY_NAME, null );
+    doReturn( null ).when( interpreter ).eval( LANGUAGE, "shutdown-script", 1, 1, "test_shutdown_script" );
+
+    dataFactory.close();
+    verify( interpreter ).eval( LANGUAGE, "shutdown-script", 1, 1, "test_shutdown_script" );
+  }
+
+  @Test
+  public void testIsQueryExecutable() {
+    ScriptableDataFactory dataFactory = new ScriptableDataFactory();
+
+    boolean result = dataFactory.isQueryExecutable( QUERY_NAME, null );
+    assertThat( result, is( equalTo( false ) ) );
+
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    result = dataFactory.isQueryExecutable( QUERY_NAME, null );
+    assertThat( result, is( equalTo( true ) ) );
+  }
+
+  @Test
+  public void testCancelRunningQuery() throws Exception {
+    ScriptableDataFactory dataFactory = spy( new ScriptableDataFactory() );
+    dataFactory.setQuery( QUERY_NAME, QUERY_VALUE );
+    dataFactory.setLanguage( LANGUAGE );
+
+    BSFManager interpreter = mock( BSFManager.class );
+    TableModel tableModel = mock( TableModel.class );
+
+    when( dataFactory.createInterpreter() ).thenReturn( interpreter );
+    doReturn( tableModel ).when( interpreter ).eval( LANGUAGE, "expression", 1, 1, QUERY_VALUE );
+    dataFactory.queryData( QUERY_NAME, null );
+
+    dataFactory.cancelRunningQuery();
+    verify( interpreter ).terminate();
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/module.properties
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/module.properties
@@ -1,0 +1,18 @@
+module.name: test-module-name
+module.producer: test producer
+module.description: test description
+module.version.major: 1
+module.version.minor: 1
+module.version.patchlevel: 0
+
+dependency.test.module: test.required.module.class
+dependency.test.dependency-type: required
+dependency.test.version.major: 2
+dependency.test.version.minor: 2
+dependency.test.version.patchlevel: 1
+
+dependency.test2.module: test.optional.module.class
+dependency.test2.dependency-type: optional
+dependency.test2.version.major: 1
+dependency.test2.version.minor: 1
+dependency.test2.version.patchlevel: 0

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ConfigReadHandlerTest.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ConfigReadHandlerTest.java
@@ -1,0 +1,61 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.apache.xerces.util.AttributesProxy;
+import org.apache.xerces.util.XMLAttributesImpl;
+import org.apache.xerces.xni.QName;
+import org.junit.Test;
+import org.pentaho.reporting.libraries.xmlns.parser.RootXmlReadHandler;
+import org.xml.sax.SAXException;
+
+public class ConfigReadHandlerTest {
+
+  private static final String URI = "test/uri";
+  private static final String LANG_VALUE = "language_value";
+  private static final String SCRIPT_VALUE = "script_value";
+  private static final String SHUTDOWN_SCRIPT_VALUE = "shutdown-script_value";
+  private static final String ATTR_TYPE = "string";
+
+  @Test
+  public void testStartParsing() throws SAXException {
+    XMLAttributesImpl attrs = new XMLAttributesImpl();
+    attrs.addAttribute( new QName( null, "language", null, URI ), ATTR_TYPE, LANG_VALUE );
+    attrs.addAttribute( new QName( null, "script", null, URI ), ATTR_TYPE, SCRIPT_VALUE );
+    attrs.addAttribute( new QName( null, "shutdown-script", null, URI ), ATTR_TYPE, SHUTDOWN_SCRIPT_VALUE );
+    AttributesProxy fAttributesProxy = new AttributesProxy( attrs );
+
+    RootXmlReadHandler rootXmlReadHandler = mock( RootXmlReadHandler.class );
+
+    ConfigReadHandler handler = new ConfigReadHandler();
+    handler.init( rootXmlReadHandler, URI, "tag" );
+    handler.startParsing( fAttributesProxy );
+
+    assertThat( handler.getLanguage(), is( equalTo( LANG_VALUE ) ) );
+    assertThat( handler.getScript(), is( equalTo( SCRIPT_VALUE ) ) );
+    assertThat( handler.getShutdownScript(), is( equalTo( SHUTDOWN_SCRIPT_VALUE ) ) );
+    assertThat( handler.getObject(), is( nullValue() ) );
+  }
+
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ScriptableDataSourceReadHandlerTest.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ScriptableDataSourceReadHandlerTest.java
@@ -1,0 +1,141 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.apache.xerces.util.AttributesProxy;
+import org.apache.xerces.util.XMLAttributesImpl;
+import org.apache.xerces.xni.QName;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactory;
+import org.pentaho.reporting.libraries.xmlns.parser.ParseException;
+import org.pentaho.reporting.libraries.xmlns.parser.PropertyReadHandler;
+import org.pentaho.reporting.libraries.xmlns.parser.RootXmlReadHandler;
+import org.pentaho.reporting.libraries.xmlns.parser.XmlReadHandler;
+import org.xml.sax.Locator;
+
+public class ScriptableDataSourceReadHandlerTest {
+
+  private static final String URI = "test/uri";
+  private static final String TAG_NAME = "tag";
+  private static final String LANG_VALUE = "language_value";
+  private static final String SCRIPT_VALUE = "script_value";
+  private static final String SHUTDOWN_SCRIPT_VALUE = "shutdown-script_value";
+  private static final String QUERY_NAME = "query_name";
+  private static final String ATTR_TYPE = "string";
+
+  private ScriptableDataSourceReadHandler handler = new ScriptableDataSourceReadHandler();
+  private RootXmlReadHandler rootXmlReadHandler = mock( RootXmlReadHandler.class );;
+
+  @Before
+  public void setUp() {
+    Locator locator = mock( Locator.class );
+    handler = new ScriptableDataSourceReadHandler();
+    doReturn( locator ).when( rootXmlReadHandler ).getDocumentLocator();
+  }
+
+  @Test
+  public void testGetHandlerForChild() throws Exception {
+    handler.init( rootXmlReadHandler, URI, TAG_NAME );
+
+    XmlReadHandler result = handler.getHandlerForChild( "__uri", "tagName", null );
+    assertThat( result, is( nullValue() ) );
+
+    result = handler.getHandlerForChild( URI, "tagName", null );
+    assertThat( result, is( nullValue() ) );
+
+    result = handler.getHandlerForChild( URI, "config", null );
+    assertThat( result, is( notNullValue() ) );
+    assertThat( result, is( instanceOf( ConfigReadHandler.class ) ) );
+
+    result = handler.getHandlerForChild( URI, "query", null );
+    assertThat( result, is( notNullValue() ) );
+    assertThat( result, is( instanceOf( PropertyReadHandler.class ) ) );
+  }
+
+  @Test( expected = ParseException.class )
+  public void testDoneParsingException() throws Exception {
+    handler.init( rootXmlReadHandler, URI, TAG_NAME );
+    handler.doneParsing();
+  }
+
+  @Test
+  public void testDoneParsingWithConfHandler() throws Exception {
+    XMLAttributesImpl attrs = new XMLAttributesImpl();
+    attrs.addAttribute( new QName( null, "language", null, URI ), ATTR_TYPE, LANG_VALUE );
+    AttributesProxy fAttributesProxy = new AttributesProxy( attrs );
+
+    handler.init( rootXmlReadHandler, URI, TAG_NAME );
+    ConfigReadHandler confHandler = (ConfigReadHandler) handler.getHandlerForChild( URI, "config", null );
+    confHandler.init( rootXmlReadHandler, URI, TAG_NAME );
+    confHandler.startParsing( fAttributesProxy );
+
+    handler.doneParsing();
+
+    assertThat( handler.getDataFactory(), is( notNullValue() ) );
+    assertThat( handler.getDataFactory(), is( instanceOf( ScriptableDataFactory.class ) ) );
+    ScriptableDataFactory sdf = (ScriptableDataFactory) handler.getDataFactory();
+    assertThat( sdf.getLanguage(), is( equalTo( LANG_VALUE ) ) );
+    assertThat( sdf.getScript(), is( nullValue() ) );
+    assertThat( sdf.getShutdownScript(), is( nullValue() ) );
+  }
+
+  @Test
+  public void testDoneParsing() throws Exception {
+    XMLAttributesImpl attrs = new XMLAttributesImpl();
+    attrs.addAttribute( new QName( null, "language", null, URI ), ATTR_TYPE, LANG_VALUE );
+    attrs.addAttribute( new QName( null, "script", null, URI ), ATTR_TYPE, SCRIPT_VALUE );
+    attrs.addAttribute( new QName( null, "shutdown-script", null, URI ), ATTR_TYPE, SHUTDOWN_SCRIPT_VALUE );
+    AttributesProxy fAttributesProxy = new AttributesProxy( attrs );
+
+    handler.init( rootXmlReadHandler, URI, TAG_NAME );
+    ConfigReadHandler confHandler = (ConfigReadHandler) handler.getHandlerForChild( URI, "config", null );
+    confHandler.init( rootXmlReadHandler, URI, TAG_NAME );
+    confHandler.startParsing( fAttributesProxy );
+    PropertyReadHandler queryHandler = (PropertyReadHandler) handler.getHandlerForChild( URI, "query", null );
+    queryHandler.init( rootXmlReadHandler, URI, TAG_NAME );
+    XMLAttributesImpl queryAttrs = new XMLAttributesImpl();
+    queryAttrs.addAttribute( new QName( null, "name", null, URI ), ATTR_TYPE, QUERY_NAME );
+    AttributesProxy queryAttrsProxy = new AttributesProxy( queryAttrs );
+    queryHandler.startElement( URI, TAG_NAME, queryAttrsProxy );
+    char[] chars = new char[] { 'b' };
+    queryHandler.characters( chars, 0, chars.length );
+    queryHandler.endElement( URI, TAG_NAME );
+
+    handler.doneParsing();
+
+    assertThat( handler.getDataFactory(), is( notNullValue() ) );
+    assertThat( handler.getDataFactory(), is( instanceOf( ScriptableDataFactory.class ) ) );
+    ScriptableDataFactory sdf = (ScriptableDataFactory) handler.getDataFactory();
+    assertThat( sdf.getLanguage(), is( equalTo( LANG_VALUE ) ) );
+    assertThat( sdf.getScript(), is( equalTo( SCRIPT_VALUE ) ) );
+    assertThat( sdf.getShutdownScript(), is( equalTo( SHUTDOWN_SCRIPT_VALUE ) ) );
+    assertThat( sdf.getQuery( QUERY_NAME ), is( equalTo( "b" ) ) );
+    assertThat( handler.getObject(), is( instanceOf( ScriptableDataFactory.class ) ) );
+    assertThat( (ScriptableDataFactory) handler.getObject(), is( equalTo( sdf ) ) );
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ScriptableDataSourceXmlFactoryModuleTest.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/parser/ScriptableDataSourceXmlFactoryModuleTest.java
@@ -1,0 +1,83 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.parser;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactoryModule;
+import org.pentaho.reporting.libraries.xmlns.parser.XmlDocumentInfo;
+import org.pentaho.reporting.libraries.xmlns.parser.XmlFactoryModule;
+import org.pentaho.reporting.libraries.xmlns.parser.XmlReadHandler;
+
+public class ScriptableDataSourceXmlFactoryModuleTest {
+
+  private ScriptableDataSourceXmlFactoryModule module = new ScriptableDataSourceXmlFactoryModule();
+
+  @Test
+  public void testGetDefaultNamespace() {
+    String result = module.getDefaultNamespace( null );
+    assertThat( result, is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+
+    XmlDocumentInfo documentInfo = mock( XmlDocumentInfo.class );
+    doReturn( "test_namespace" ).when( documentInfo ).getDefaultNameSpace();
+    result = module.getDefaultNamespace( documentInfo );
+    assertThat( result, is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+  }
+
+  @Test
+  public void testCreateReadHandler() {
+    XmlReadHandler result = module.createReadHandler( null );
+    assertThat( result, is( notNullValue() ) );
+    assertThat( result, is( instanceOf( ScriptableDataSourceReadHandler.class ) ) );
+  }
+
+  @Test
+  public void testGetDocumentSupport() {
+    XmlDocumentInfo documentInfo = mock( XmlDocumentInfo.class );
+    doReturn( null ).when( documentInfo ).getRootElementNameSpace();
+    doReturn( "test_elem" ).when( documentInfo ).getRootElement();
+
+    int result = module.getDocumentSupport( documentInfo );
+    assertThat( result, is( equalTo( XmlFactoryModule.NOT_RECOGNIZED ) ) );
+
+    doReturn( "test_namespace" ).when( documentInfo ).getRootElementNameSpace();
+    result = module.getDocumentSupport( documentInfo );
+    assertThat( result, is( equalTo( XmlFactoryModule.NOT_RECOGNIZED ) ) );
+
+    doReturn( ScriptableDataFactoryModule.NAMESPACE ).when( documentInfo ).getRootElementNameSpace();
+    result = module.getDocumentSupport( documentInfo );
+    assertThat( result, is( equalTo( XmlFactoryModule.NOT_RECOGNIZED ) ) );
+
+    doReturn( ScriptableDataFactoryModule.NAMESPACE ).when( documentInfo ).getRootElementNameSpace();
+    doReturn( "scriptable-datasource" ).when( documentInfo ).getRootElement();
+    result = module.getDocumentSupport( documentInfo );
+    assertThat( result, is( equalTo( XmlFactoryModule.RECOGNIZED_BY_NAMESPACE ) ) );
+
+    doReturn( null ).when( documentInfo ).getRootElementNameSpace();
+    doReturn( "scriptable-datasource" ).when( documentInfo ).getRootElement();
+    result = module.getDocumentSupport( documentInfo );
+    assertThat( result, is( equalTo( XmlFactoryModule.RECOGNIZED_BY_TAGNAME ) ) );
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/writer/ScriptableDataFactoryBundleWriteHandlerTest.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/writer/ScriptableDataFactoryBundleWriteHandlerTest.java
@@ -1,0 +1,105 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.writer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.writer.BundleWriterException;
+import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.writer.BundleWriterState;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactory;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactoryModule;
+import org.pentaho.reporting.libraries.docbundle.WriteableDocumentBundle;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeList;
+import org.pentaho.reporting.libraries.xmlns.writer.DefaultTagDescription;
+import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
+import org.pentaho.reporting.libraries.xmlns.writer.XmlWriterSupport;
+
+public class ScriptableDataFactoryBundleWriteHandlerTest {
+
+  private ScriptableDataFactoryBundleWriteHandler handler = spy( new ScriptableDataFactoryBundleWriteHandler() );
+
+  @Test
+  public void testWriteDataFactory() throws IOException, BundleWriterException {
+    WriteableDocumentBundle bundle = mock( WriteableDocumentBundle.class );
+    ScriptableDataFactory dataFactory = mock( ScriptableDataFactory.class );
+    BundleWriterState state = mock( BundleWriterState.class );
+    XmlWriter xmlWriter = mock( XmlWriter.class );
+
+    doReturn( "/" ).when( state ).getFileName();
+    doReturn( xmlWriter ).when( handler )
+        .createXmlWriter( any( OutputStream.class ), any( DefaultTagDescription.class ) );
+    doReturn( new String[] { "test_query_name" } ).when( dataFactory ).getQueryNames();
+    doReturn( "test_query" ).when( dataFactory ).getQuery( "test_query_name" );
+
+    doReturn( "lang_val" ).when( dataFactory ).getLanguage();
+    doReturn( "script_val" ).when( dataFactory ).getScript();
+    doReturn( "shutdown_script_val" ).when( dataFactory ).getShutdownScript();
+
+    String fileName = handler.writeDataFactory( bundle, dataFactory, state );
+
+    assertThat( fileName, is( equalTo( "datasources/scriptable-ds.xml" ) ) );
+
+    ArgumentCaptor<AttributeList> rootAttrsCaptor = ArgumentCaptor.forClass( AttributeList.class );
+    ArgumentCaptor<String> namespaceCaptor = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<Boolean> flagCaptor = ArgumentCaptor.forClass( Boolean.class );
+
+    verify( xmlWriter, times( 2 ) ).writeTag( namespaceCaptor.capture(), nameCaptor.capture(),
+        rootAttrsCaptor.capture(), flagCaptor.capture() );
+
+    List<String> namespaceResults = namespaceCaptor.getAllValues();
+    assertThat( namespaceResults.get( 0 ), is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+    assertThat( namespaceResults.get( 1 ), is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+
+    List<String> nameResults = nameCaptor.getAllValues();
+    assertThat( nameResults.get( 0 ), is( equalTo( "scriptable-datasource" ) ) );
+    assertThat( nameResults.get( 1 ), is( equalTo( "config" ) ) );
+
+    List<AttributeList> rootAttrResults = rootAttrsCaptor.getAllValues();
+    assertThat( rootAttrResults.get( 0 ).getAttribute( "http://www.w3.org/2000/xmlns/", "data" ),
+        is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+    assertThat( rootAttrResults.get( 1 ).getAttribute( ScriptableDataFactoryModule.NAMESPACE, "language" ),
+        is( equalTo( "lang_val" ) ) );
+    assertThat( rootAttrResults.get( 1 ).getAttribute( ScriptableDataFactoryModule.NAMESPACE, "script" ),
+        is( equalTo( "script_val" ) ) );
+    assertThat( rootAttrResults.get( 1 ).getAttribute( ScriptableDataFactoryModule.NAMESPACE, "shutdown-script" ),
+        is( equalTo( "shutdown_script_val" ) ) );
+
+    List<Boolean> flagResults = flagCaptor.getAllValues();
+    assertThat( flagResults.get( 0 ), is( equalTo( XmlWriter.OPEN ) ) );
+    assertThat( flagResults.get( 1 ), is( equalTo( XmlWriterSupport.CLOSE ) ) );
+
+    verify( xmlWriter, times( 1 ) ).writeTextNormalized( "test_query", false );
+    verify( xmlWriter, times( 2 ) ).writeCloseTag();
+    verify( xmlWriter, times( 1 ) ).close();
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/writer/ScriptableDataFactoryWriteHandlerTest.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/scriptable/writer/ScriptableDataFactoryWriteHandlerTest.java
@@ -1,0 +1,92 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.writer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.reporting.engine.classic.core.modules.parser.extwriter.ReportWriterContext;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactory;
+import org.pentaho.reporting.engine.classic.extensions.datasources.scriptable.ScriptableDataFactoryModule;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeList;
+import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
+import org.pentaho.reporting.libraries.xmlns.writer.XmlWriterSupport;
+
+public class ScriptableDataFactoryWriteHandlerTest {
+
+  private ScriptableDataFactoryWriteHandler handler = spy( new ScriptableDataFactoryWriteHandler() );
+
+  @Test
+  public void testWrite() throws Exception {
+    ReportWriterContext reportWriter = mock( ReportWriterContext.class );
+    XmlWriter xmlWriter = mock( XmlWriter.class );
+    ScriptableDataFactory dataFactory = mock( ScriptableDataFactory.class );
+
+    doReturn( new String[] { "test_query_name" } ).when( dataFactory ).getQueryNames();
+    doReturn( "test_query" ).when( dataFactory ).getQuery( "test_query_name" );
+
+    doReturn( "lang_val" ).when( dataFactory ).getLanguage();
+    doReturn( "script_val" ).when( dataFactory ).getScript();
+    doReturn( "shutdown_script_val" ).when( dataFactory ).getShutdownScript();
+
+    handler.write( reportWriter, xmlWriter, dataFactory );
+
+    ArgumentCaptor<AttributeList> rootAttrsCaptor = ArgumentCaptor.forClass( AttributeList.class );
+    ArgumentCaptor<String> namespaceCaptor = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass( String.class );
+    ArgumentCaptor<Boolean> flagCaptor = ArgumentCaptor.forClass( Boolean.class );
+
+    verify( xmlWriter, times( 2 ) ).writeTag( namespaceCaptor.capture(), nameCaptor.capture(),
+        rootAttrsCaptor.capture(), flagCaptor.capture() );
+
+    List<String> namespaceResults = namespaceCaptor.getAllValues();
+    assertThat( namespaceResults.get( 0 ), is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+    assertThat( namespaceResults.get( 1 ), is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+
+    List<String> nameResults = nameCaptor.getAllValues();
+    assertThat( nameResults.get( 0 ), is( equalTo( "scriptable-datasource" ) ) );
+    assertThat( nameResults.get( 1 ), is( equalTo( "config" ) ) );
+
+    List<AttributeList> rootAttrResults = rootAttrsCaptor.getAllValues();
+    assertThat( rootAttrResults.get( 0 ).getAttribute( "http://www.w3.org/2000/xmlns/", "data" ),
+        is( equalTo( ScriptableDataFactoryModule.NAMESPACE ) ) );
+    assertThat( rootAttrResults.get( 1 ).getAttribute( ScriptableDataFactoryModule.NAMESPACE, "language" ),
+        is( equalTo( "lang_val" ) ) );
+    assertThat( rootAttrResults.get( 1 ).getAttribute( ScriptableDataFactoryModule.NAMESPACE, "script" ),
+        is( equalTo( "script_val" ) ) );
+    assertThat( rootAttrResults.get( 1 ).getAttribute( ScriptableDataFactoryModule.NAMESPACE, "shutdown-script" ),
+        is( equalTo( "shutdown_script_val" ) ) );
+
+    List<Boolean> flagResults = flagCaptor.getAllValues();
+    assertThat( flagResults.get( 0 ), is( equalTo( XmlWriter.OPEN ) ) );
+    assertThat( flagResults.get( 1 ), is( equalTo( XmlWriterSupport.CLOSE ) ) );
+
+    verify( xmlWriter, times( 1 ) ).writeTextNormalized( "test_query", false );
+    verify( xmlWriter, times( 2 ) ).writeCloseTag();
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/modules/rhino/RhinoModuleIT.java
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/modules/rhino/RhinoModuleIT.java
@@ -1,0 +1,54 @@
+package org.pentaho.reporting.engine.classic.extensions.modules.rhino;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.metadata.ExpressionMetaData;
+import org.pentaho.reporting.engine.classic.core.metadata.ExpressionRegistry;
+import org.pentaho.reporting.libraries.base.boot.ModuleInfo;
+
+public class RhinoModuleIT {
+
+  private static final String EXPRESSION_ID =
+      "org.pentaho.reporting.engine.classic.extensions.modules.rhino.RhinoExpression";
+
+  @Test
+  public void testInitialize() throws Exception {
+    ClassicEngineBoot.getInstance().start();
+    RhinoModule module = new RhinoModule();
+    module.initialize( null );
+
+    assertThat( module.getDescription(), is( equalTo( "test rhino description" ) ) );
+    assertThat( module.getMajorVersion(), is( equalTo( "1" ) ) );
+    assertThat( module.getMinorVersion(), is( equalTo( "1" ) ) );
+    assertThat( module.getPatchLevel(), is( equalTo( "0" ) ) );
+    assertThat( module.getName(), is( equalTo( "test-rhino-module-name" ) ) );
+    assertThat( module.getProducer(), is( equalTo( "test rhino producer" ) ) );
+
+    ModuleInfo[] requiredModules = module.getRequiredModules();
+    assertThat( requiredModules.length, is( equalTo( 1 ) ) );
+    ModuleInfo requiredModule = requiredModules[0];
+    assertThat( requiredModule.getModuleClass(), is( equalTo( "test.required.module.class" ) ) );
+    assertThat( requiredModule.getMinorVersion(), is( equalTo( "2" ) ) );
+    assertThat( requiredModule.getMajorVersion(), is( equalTo( "2" ) ) );
+    assertThat( requiredModule.getPatchLevel(), is( equalTo( "1" ) ) );
+
+    ModuleInfo[] optionalModules = module.getOptionalModules();
+    assertThat( optionalModules.length, is( equalTo( 1 ) ) );
+    ModuleInfo optionalModule = optionalModules[0];
+    assertThat( optionalModule.getModuleClass(), is( equalTo( "test.optional.module.class" ) ) );
+    assertThat( optionalModule.getMinorVersion(), is( equalTo( "1" ) ) );
+    assertThat( optionalModule.getMajorVersion(), is( equalTo( "1" ) ) );
+    assertThat( optionalModule.getPatchLevel(), is( equalTo( "0" ) ) );
+
+    assertThat( ExpressionRegistry.getInstance().isExpressionRegistered( EXPRESSION_ID ), is( equalTo( true ) ) );
+    ExpressionMetaData meta = ExpressionRegistry.getInstance().getExpressionMetaData( EXPRESSION_ID );
+    assertThat( meta.getBundleLocation(),
+        is( equalTo( "org.pentaho.reporting.engine.classic.extensions.modules.rhino.RhinoExpressionBundle" ) ) );
+    assertThat( meta.getPropertyDescription( "expression" ), is( notNullValue() ) );
+  }
+}

--- a/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/modules/rhino/module.properties
+++ b/engine/extensions-scripting/test-src/org/pentaho/reporting/engine/classic/extensions/modules/rhino/module.properties
@@ -1,0 +1,23 @@
+#
+# Support for inline expressions using the BeanShell.
+#
+# External libraries: BeanShell > 1.2B6
+#
+module.name: test-rhino-module-name
+module.producer: test rhino producer
+module.description: test rhino description
+module.version.major: 1
+module.version.minor: 1
+module.version.patchlevel: 0
+
+dependency.test.module: test.required.module.class
+dependency.test.dependency-type: required
+dependency.test.version.major: 2
+dependency.test.version.minor: 2
+dependency.test.version.patchlevel: 1
+
+dependency.test2.module: test.optional.module.class
+dependency.test2.dependency-type: optional
+dependency.test2.version.major: 1
+dependency.test2.version.minor: 1
+dependency.test2.version.patchlevel: 0


### PR DESCRIPTION
1. Fixed checkstyle issues.
2. Increased coverage, as a result now:

    Unit tests coverage = 72.2%
    Integration tests coverage = 6.6%
    Overall coverage = 78.8%

3. Added hamcrest and mockito dependencies for testing purposes.

The extensions-scripting has org.pentaho.reporting.engine.classic.extensions.modules.rhino.RhinoExpression.java marked as deprecated. If we remove it we will increase overall coverage to 89.3%

@tmorgner @dkincade please review or find someone who can review this.