### PR TITLE
[BISERVER-11565] - File upload names fail if the name has double quotes

### DIFF
--- a/libraries/libpensol/ivy.xml
+++ b/libraries/libpensol/ivy.xml
@@ -44,5 +44,12 @@
 		<!--  test dependencies -->
 		<dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default" />
 		<dependency org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" conf="test->default"/>
+
+		<dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-core" rev="1.16"
+								conf="test->default"/>
+		<dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-grizzly" rev="1.16"
+								conf="test->default"/>
+		<dependency org="asm" name="asm" rev="3.1" conf="test->default"/>
+		<dependency org="com.google.gwt" name="gwt-servlet" rev="2.5.1" conf="test->default"/>
 	</dependencies>
 </ivy-module>

--- a/libraries/libpensol/test/org/pentaho/platform/web/http/api/resources/RepositoryPublishResourceRevealer.java
+++ b/libraries/libpensol/test/org/pentaho/platform/web/http/api/resources/RepositoryPublishResourceRevealer.java
@@ -1,0 +1,37 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+/**
+ * A dummy class to make package-local method public
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryPublishResourceRevealer extends RepositoryPublishResource {
+
+  @Override
+  public boolean invalidPath( String path ) {
+    char[] prohibited = new char[] { '\n', '\t', '\r' };
+    for ( char c : prohibited ) {
+      if ( path.contains( Character.toString( c ) ) ) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/libraries/libpensol/test/org/pentaho/reporting/libraries/pensol/PublishRestUtilTestIT.java
+++ b/libraries/libpensol/test/org/pentaho/reporting/libraries/pensol/PublishRestUtilTestIT.java
@@ -1,0 +1,81 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.pensol;
+
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.api.json.JSONConfiguration;
+import com.sun.jersey.multipart.impl.MultiPartWriter;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.pentaho.reporting.libraries.pensol.resources.TestRepositoryPublishResource;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PublishRestUtilTestIT extends JerseyTest {
+
+  @Override
+  protected AppDescriptor configure() {
+    ClientConfig config = new DefaultClientConfig();
+    config.getClasses().add( MultiPartWriter.class );
+    config.getClasses().add( TestRepositoryPublishResource.class );
+    config.getFeatures().put( JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE );
+
+    return new WebAppDescriptor.Builder( "org.pentaho.reporting.libraries.pensol.resources" )
+      .contextPath( "api" )
+      .clientConfig( config )
+      .build();
+  }
+
+  @Test
+  public void publishedSuccessfully() throws Exception {
+    testPublish( TestRepositoryPublishResource.RETURN_200, 200 );
+  }
+
+  @Test
+  public void publishUnauthorized() throws Exception {
+    testPublish( TestRepositoryPublishResource.RETURN_401, 401 );
+  }
+
+  @Test
+  public void publishInvalid() throws Exception {
+    testPublish( TestRepositoryPublishResource.RETURN_422, 422 );
+  }
+
+  @Test
+  public void publishCrashingServer() throws Exception {
+    testPublish( TestRepositoryPublishResource.RETURN_500, 500 );
+  }
+
+  private void testPublish( String filename, int expectedCode ) throws Exception {
+    URI uri = resource().getURI();
+    String baseUrl = "http://" + uri.getHost() + ":" + uri.getPort();
+
+    PublishRestUtil util = new PublishRestUtil( baseUrl, "", "" );
+    int code = util.publishFile( "", filename, new ByteArrayInputStream( new byte[ 0 ] ), true );
+
+    Assert.assertEquals( expectedCode, code );
+  }
+}

--- a/libraries/libpensol/test/org/pentaho/reporting/libraries/pensol/resources/TestRepositoryPublishResource.java
+++ b/libraries/libpensol/test/org/pentaho/reporting/libraries/pensol/resources/TestRepositoryPublishResource.java
@@ -1,0 +1,66 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.pensol.resources;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.web.http.api.resources.RepositoryPublishResourceRevealer;
+import org.pentaho.platform.web.http.api.resources.services.RepositoryPublishService;
+
+import javax.ws.rs.Path;
+import java.io.InputStream;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+@Path( "/repo/publish" )
+public class TestRepositoryPublishResource extends RepositoryPublishResourceRevealer implements Answer<Void> {
+
+  public static final String RETURN_200 = "Return200";
+  public static final String RETURN_401 = "Return403";
+  public static final String RETURN_422 = "Return\n422";
+  public static final String RETURN_500 = "Return500";
+
+  public TestRepositoryPublishResource() throws Exception {
+    repositoryPublishService = mock( RepositoryPublishService.class );
+    doAnswer( this ).when( repositoryPublishService )
+      .publishFile( anyString(), any( InputStream.class ), anyBoolean() );
+  }
+
+
+  @Override
+  public Void answer( InvocationOnMock invocation ) throws Throwable {
+    Object[] arguments = invocation.getArguments();
+    // path starts with / --> exclude the first char
+    String path = ( (String) arguments[ 0 ] ).substring( 1 );
+    switch( path ) {
+      case RETURN_401:
+        throw new PentahoAccessControlException();
+      case RETURN_500:
+        throw new RuntimeException();
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
- use new endpoint, allowing encoded names
- add integration tests
- add jersey-test-framework as test dependency

@tmorgner, review it please.
This PR uses the endpoint which was introduced by https://github.com/pentaho/pentaho-platform/pull/2655

I added ```jersey-test-framework``` as test dependency (copied from ```platform```).