### PR TITLE
[BACKLOG-5384] Fixed source path for integration tests

### DIFF
--- a/engine/core/build.properties
+++ b/engine/core/build.properties
@@ -4,7 +4,6 @@ ivy.artifact.id=pentaho-reporting-engine-classic-core
 impl.title=Pentaho Reporting Engine Classic Core
 impl.productID=pentaho-reporting-engine-classic
 src.dir=${basedir}/source
-inttestsrc.dir=${basedir}/test
 project.use-full-dist=true
 javadoc.packagenames=org.pentaho.*
 tests.publish=true


### PR DESCRIPTION
"test-src" is default source folder for integration tests also.
Now integration tests metrics work.

@tmorgner @lucboudreau please review