### PR TITLE
[BACKLOG-5384] Fixed using line separator for ImageMapWriterTest

### DIFF
--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/imagemap/parser/ImageMapWriterTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/imagemap/parser/ImageMapWriterTest.java
@@ -137,7 +137,8 @@ public class ImageMapWriterTest {
     expectedValue.append( MAP_ENTRY_VALUE );
     expectedValue.append( "\" shape=\"" );
     expectedValue.append( DEFAULT_SHAPE );
-    expectedValue.append( "\" coords=\"5.0,10.0,20.0,50.0\" /></map>\r\n" );
+    expectedValue.append( "\" coords=\"5.0,10.0,20.0,50.0\" /></map>" );
+    expectedValue.append( org.pentaho.reporting.libraries.base.util.StringUtils.getLineSeparator() );
 
     String result = ImageMapWriter.writeImageMapAsString( imageMap );
     assertThat( result, is( equalTo( expectedValue.toString() ) ) );


### PR DESCRIPTION
Fix for http://devci.pentaho.com/job/master-snapshot/job/reporting-libraries/13/changes
@tmorgner Could you review this fix?