### PR TITLE
[PRD-5556] - Running PRPT in the background increases memory usage

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -21,6 +21,7 @@
         <option name="GENERATE_FINAL_LOCALS" value="true" />
         <option name="GENERATE_FINAL_PARAMETERS" value="true" />
         <option name="INSERT_OVERRIDE_ANNOTATION" value="false" />
+        <option name="LAYOUT_STATIC_IMPORTS_SEPARATELY" value="false" />
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="666" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="666" />
         <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -28,13 +29,11 @@
         </option>
         <option name="IMPORT_LAYOUT_TABLE">
           <value>
-            <package name="" withSubpackages="true" static="true" />
-            <emptyLine />
             <package name="java" withSubpackages="true" static="false" />
-            <emptyLine />
             <package name="javax" withSubpackages="true" static="false" />
             <emptyLine />
             <package name="" withSubpackages="true" static="false" />
+            <emptyLine />
           </value>
         </option>
         <option name="STATIC_FIELDS_ORDER_WEIGHT" value="2" />
@@ -115,6 +114,8 @@
         </codeStyleSettings>
         <codeStyleSettings language="JAVA">
           <option name="WHILE_ON_NEW_LINE" value="true" />
+          <option name="CATCH_ON_NEW_LINE" value="true" />
+          <option name="FINALLY_ON_NEW_LINE" value="true" />
           <option name="SPACE_WITHIN_PARENTHESES" value="true" />
           <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
           <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
@@ -125,20 +126,18 @@
           <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
           <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
           <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true" />
-          <option name="SPACE_WITHIN_BRACKETS" value="true" />
-          <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
           <option name="METHOD_PARAMETERS_WRAP" value="5" />
           <option name="EXTENDS_KEYWORD_WRAP" value="1" />
           <option name="IF_BRACE_FORCE" value="3" />
           <option name="DOWHILE_BRACE_FORCE" value="3" />
           <option name="WHILE_BRACE_FORCE" value="3" />
           <option name="FOR_BRACE_FORCE" value="3" />
-          <option name="SPACE_WITHIN_ANNOTATION_PARENTHESES" value="true" />
           <option name="PARENT_SETTINGS_INSTALLED" value="true" />
           <indentOptions>
             <option name="INDENT_SIZE" value="2" />
-            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="CONTINUATION_INDENT_SIZE" value="2" />
             <option name="TAB_SIZE" value="2" />
+            <option name="USE_RELATIVE_INDENTS" value="true" />
           </indentOptions>
           <arrangement>
             <rules>

--- a/.idea/runConfigurations/ReportDesigner.xml
+++ b/.idea/runConfigurations/ReportDesigner.xml
@@ -7,7 +7,7 @@
       </pattern>
     </extension>
     <option name="MAIN_CLASS_NAME" value="org.pentaho.reporting.designer.core.ReportDesigner" />
-    <option name="VM_PARAMETERS" value="-Dorg.pentaho.reporting.engine.classic.core.DebugDataSources=true" />
+    <option name="VM_PARAMETERS" value="-Dorg.pentaho.reporting.engine.classic.core.DebugDataSources=true -Xmx800m" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="file://$MODULE_DIR$/stage-winlinux/report-designer" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />

--- a/engine/core/devresource/simplelog.properties
+++ b/engine/core/devresource/simplelog.properties
@@ -36,6 +36,7 @@ org.apache.commons.logging.simplelog.log.org.pentaho.reporting.libraries.fonts.r
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.libraries.fonts.registry.DefaultFontStorage=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.Element=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.MasterReport$DocumentBundleChangeHandler=warn
+org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.cache.CachingDataFactory=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.metadata.parser=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.metadata.DefaultElementMetaData=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.layout.AbstractRenderer=warn
@@ -66,10 +67,11 @@ org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.co
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.SimpleSQLReportDataFactory=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.JndiConnectionProvider=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.parser.base.PasswordEncryptionService=warn
-org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.output.pageable.base.PageableRenderer=debug
+org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.output.pageable.base.PageableRenderer=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.output.pageable.xml.internal.XmlDocumentWriter=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.output.table.base.AbstractTableOutputProcessor=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.modules.output.table.xml.internal.XmlDocumentWriter=warn
+org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.sorting.SortingDataFactory=warn
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.states.CascadingDataFactory=error
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.states.datarow.FastGlobalView=error
 org.apache.commons.logging.simplelog.log.org.pentaho.reporting.engine.classic.core.states.datarow.PaddingController=warn

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/CachableTableModel.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/CachableTableModel.java
@@ -64,18 +64,18 @@ public class CachableTableModel extends AbstractTableModel implements MetaTableM
     for ( int i = 0; i < columnCount; i++ ) {
       final DataAttributes originalColAttrs = metaTableModel.getColumnAttributes( i );
 
-      if (isSaneMetaData( metaTableModel, i )) {
-        columnAttributes.add( ImmutableDataAttributes.create( originalColAttrs, dataAttributeContext ));
+      if ( isSaneMetaData( metaTableModel, i ) ) {
+        columnAttributes.add( ImmutableDataAttributes.create( originalColAttrs, dataAttributeContext ) );
       } else {
         final String columnName = metaTableModel.getColumnName( i );
         final Class columnType = metaTableModel.getColumnClass( i );
         final DefaultDataAttributes attributes = new DefaultDataAttributes();
         attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
-                                     DefaultConceptQueryMapper.INSTANCE, columnName );
+          DefaultConceptQueryMapper.INSTANCE, columnName );
         attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
-                                     DefaultConceptQueryMapper.INSTANCE, columnType );
+          DefaultConceptQueryMapper.INSTANCE, columnType );
         attributes.merge( originalColAttrs, dataAttributeContext );
-        columnAttributes.add( ImmutableDataAttributes.create( attributes, dataAttributeContext ));
+        columnAttributes.add( ImmutableDataAttributes.create( attributes, dataAttributeContext ) );
       }
     }
 
@@ -101,19 +101,17 @@ public class CachableTableModel extends AbstractTableModel implements MetaTableM
     final DataAttributes originalColAttrs = metaTableModel.getColumnAttributes( i );
 
     final String nameFromMeta =
-      (String) originalColAttrs.getMetaAttribute
-                         ( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
-                           String.class, dataAttributeContext );
+      (String) originalColAttrs.getMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
+        String.class, dataAttributeContext );
     if ( !ObjectUtilities.equal( columnName, nameFromMeta ) ) {
       return false;
     }
 
     final Class colTypeFromMeta =
-      (Class<?>) originalColAttrs.getMetaAttribute
-                         ( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
-                           Class.class, dataAttributeContext );
+      (Class<?>) originalColAttrs.getMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
+        Class.class, dataAttributeContext );
 
-    if ( !ObjectUtilities.equal( columnType, colTypeFromMeta) ) {
+    if ( !ObjectUtilities.equal( columnType, colTypeFromMeta ) ) {
       return false;
     }
     return true;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/CachableTableModel.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/CachableTableModel.java
@@ -22,7 +22,6 @@ import java.awt.Shape;
 import java.awt.Stroke;
 import java.util.ArrayList;
 import java.util.Date;
-
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 
@@ -34,9 +33,12 @@ import org.pentaho.reporting.engine.classic.core.wizard.DefaultConceptQueryMappe
 import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributeContext;
 import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
+import org.pentaho.reporting.engine.classic.core.wizard.ImmutableDataAttributes;
 import org.pentaho.reporting.libraries.base.util.GenericObjectTable;
+import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 
 public class CachableTableModel extends AbstractTableModel implements MetaTableModel {
+
   private GenericObjectTable<DefaultDataAttributes> cellAttributes;
   private GenericObjectTable<Object> cellValues;
   private ArrayList<DataAttributes> columnAttributes;
@@ -48,66 +50,109 @@ public class CachableTableModel extends AbstractTableModel implements MetaTableM
     columnAttributes = new ArrayList<DataAttributes>();
     if ( model instanceof MetaTableModel ) {
       final MetaTableModel metaTableModel = (MetaTableModel) model;
-      for ( int i = 0; i < model.getColumnCount(); i++ ) {
-        final String columnName = model.getColumnName( i );
-        final Class columnType = model.getColumnClass( i );
-        final DefaultDataAttributes attributes = new DefaultDataAttributes();
-        attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
-            new DefaultConceptQueryMapper(), columnName );
-        attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
-            new DefaultConceptQueryMapper(), columnType );
-        attributes.merge( metaTableModel.getColumnAttributes( i ), dataAttributeContext );
-        columnAttributes.add( attributes );
-      }
-
-      if ( metaTableModel.isCellDataAttributesSupported() ) {
-        cellAttributes = new GenericObjectTable<DefaultDataAttributes>( model.getRowCount(), model.getColumnCount() );
-        for ( int row = 0; row < model.getRowCount(); row += 1 ) {
-          for ( int columns = 0; columns < model.getColumnCount(); columns += 1 ) {
-            final DefaultDataAttributes attributes = new DefaultDataAttributes();
-            attributes.merge( metaTableModel.getCellDataAttributes( row, columns ), dataAttributeContext );
-            cellAttributes.setObject( row, columns, attributes );
-          }
-        }
-      }
-
-      final DefaultDataAttributes attributes = new DefaultDataAttributes();
-      attributes.merge( metaTableModel.getTableAttributes(), dataAttributeContext );
-      tableAttributes = attributes;
+      initFromMetaModel( metaTableModel );
     } else {
-      for ( int i = 0; i < model.getColumnCount(); i++ ) {
-        final String columnName = model.getColumnName( i );
-        final Class columnType = model.getColumnClass( i );
-        final DefaultDataAttributes attributes = new DefaultDataAttributes();
-        attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
-            new DefaultConceptQueryMapper(), columnName );
-        attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
-            new DefaultConceptQueryMapper(), columnType );
-        columnAttributes.add( attributes );
-      }
-      tableAttributes = EmptyDataAttributes.INSTANCE;
+      initDefaultMetaData( model );
     }
 
+    initData( model );
+
+  }
+
+  protected void initFromMetaModel( final MetaTableModel metaTableModel ) {
+    final int columnCount = metaTableModel.getColumnCount();
+    for ( int i = 0; i < columnCount; i++ ) {
+      final DataAttributes originalColAttrs = metaTableModel.getColumnAttributes( i );
+
+      if (isSaneMetaData( metaTableModel, i )) {
+        columnAttributes.add( ImmutableDataAttributes.create( originalColAttrs, dataAttributeContext ));
+      } else {
+        final String columnName = metaTableModel.getColumnName( i );
+        final Class columnType = metaTableModel.getColumnClass( i );
+        final DefaultDataAttributes attributes = new DefaultDataAttributes();
+        attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
+                                     DefaultConceptQueryMapper.INSTANCE, columnName );
+        attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
+                                     DefaultConceptQueryMapper.INSTANCE, columnType );
+        attributes.merge( originalColAttrs, dataAttributeContext );
+        columnAttributes.add( ImmutableDataAttributes.create( attributes, dataAttributeContext ));
+      }
+    }
+
+    if ( metaTableModel.isCellDataAttributesSupported() ) {
+      cellAttributes = new GenericObjectTable<DefaultDataAttributes>( metaTableModel.getRowCount(), columnCount );
+      for ( int row = 0; row < metaTableModel.getRowCount(); row += 1 ) {
+        for ( int columns = 0; columns < columnCount; columns += 1 ) {
+          final DefaultDataAttributes attributes = new DefaultDataAttributes();
+          attributes.merge( metaTableModel.getCellDataAttributes( row, columns ), dataAttributeContext );
+          cellAttributes.setObject( row, columns, attributes );
+        }
+      }
+    }
+
+    final DefaultDataAttributes attributes = new DefaultDataAttributes();
+    attributes.merge( metaTableModel.getTableAttributes(), dataAttributeContext );
+    tableAttributes = attributes;
+  }
+
+  private boolean isSaneMetaData( final MetaTableModel metaTableModel, int i ) {
+    final String columnName = metaTableModel.getColumnName( i );
+    final Class columnType = metaTableModel.getColumnClass( i );
+    final DataAttributes originalColAttrs = metaTableModel.getColumnAttributes( i );
+
+    final String nameFromMeta =
+      (String) originalColAttrs.getMetaAttribute
+                         ( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
+                           String.class, dataAttributeContext );
+    if ( !ObjectUtilities.equal( columnName, nameFromMeta ) ) {
+      return false;
+    }
+
+    final Class colTypeFromMeta =
+      (Class<?>) originalColAttrs.getMetaAttribute
+                         ( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
+                           Class.class, dataAttributeContext );
+
+    if ( !ObjectUtilities.equal( columnType, colTypeFromMeta) ) {
+      return false;
+    }
+    return true;
+  }
+
+  protected void initData( final TableModel model ) {
     cellValues =
-        new GenericObjectTable<Object>( Math.max( 1, model.getRowCount() ), Math.max( 1, model.getColumnCount() ) );
+      new GenericObjectTable<Object>( Math.max( 1, model.getRowCount() ), Math.max( 1, model.getColumnCount() ) );
     for ( int row = 0; row < model.getRowCount(); row += 1 ) {
       for ( int columns = 0; columns < model.getColumnCount(); columns += 1 ) {
         cellValues.setObject( row, columns, model.getValueAt( row, columns ) );
       }
     }
+  }
 
+  protected void initDefaultMetaData( final TableModel model ) {
+    for ( int i = 0; i < model.getColumnCount(); i++ ) {
+      final String columnName = model.getColumnName( i );
+      final Class columnType = model.getColumnClass( i );
+      final DefaultDataAttributes attributes = new DefaultDataAttributes();
+      attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
+                                   DefaultConceptQueryMapper.INSTANCE, columnName );
+      attributes.setMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
+                                   DefaultConceptQueryMapper.INSTANCE, columnType );
+      columnAttributes.add( attributes );
+    }
+    tableAttributes = EmptyDataAttributes.INSTANCE;
   }
 
   public String getColumnName( final int column ) {
     final DataAttributes attributes = columnAttributes.get( column );
-    return (String) attributes.getMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.NAME,
-        String.class, dataAttributeContext );
+    return (String) attributes.getMetaAttribute( MetaAttributeNames.Core.NAMESPACE,
+                                                 MetaAttributeNames.Core.NAME, String.class, dataAttributeContext );
   }
 
   public Class getColumnClass( final int columnIndex ) {
     final DataAttributes attributes = columnAttributes.get( columnIndex );
-    return (Class) attributes.getMetaAttribute( MetaAttributeNames.Core.NAMESPACE, MetaAttributeNames.Core.TYPE,
-        Class.class, dataAttributeContext );
+    return (Class) attributes.getMetaAttribute( MetaAttributeNames.Core.NAMESPACE,
+                                                MetaAttributeNames.Core.TYPE, Class.class, dataAttributeContext );
   }
 
   public DataAttributes getCellDataAttributes( final int row, final int column ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/DataCacheKey.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/DataCacheKey.java
@@ -77,15 +77,19 @@ public class DataCacheKey {
   public void makeReadOnly() {
     // Make the following maps immutable. This method should be called after
     // the parameters & attributes have been seeded.
-    if (parameter.isEmpty()) {
-      parameter = Collections.emptyMap();
-    } else {
-      parameter = Collections.unmodifiableMap( parameter );
-    }
-    if (attributes.isEmpty()) {
-      attributes = Collections.emptyMap();
-    } else {
-      attributes = Collections.unmodifiableMap( attributes );
+    parameter = toImmutable( parameter );
+    attributes = toImmutable( attributes );
+  }
+
+  private static Map<String, Object> toImmutable( Map<String, Object> map ) {
+    switch ( map.size() ) {
+      case 0:
+        return Collections.emptyMap();
+      case 1:
+        Map.Entry<String, Object> entry = map.entrySet().iterator().next();
+        return Collections.singletonMap( entry.getKey(), entry.getValue() );
+      default:
+        return Collections.unmodifiableMap( map );
     }
   }
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/DataCacheKey.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/cache/DataCacheKey.java
@@ -45,7 +45,7 @@ public class DataCacheKey {
     if ( key == null ) {
       throw new NullPointerException();
     }
-    parameter.put( key, value );
+    attributes.put( key, value );
   }
 
   public boolean equals( final Object o ) {
@@ -77,8 +77,16 @@ public class DataCacheKey {
   public void makeReadOnly() {
     // Make the following maps immutable. This method should be called after
     // the parameters & attributes have been seeded.
-    parameter = Collections.unmodifiableMap( parameter );
-    attributes = Collections.unmodifiableMap( attributes );
+    if (parameter.isEmpty()) {
+      parameter = Collections.emptyMap();
+    } else {
+      parameter = Collections.unmodifiableMap( parameter );
+    }
+    if (attributes.isEmpty()) {
+      attributes = Collections.emptyMap();
+    } else {
+      attributes = Collections.unmodifiableMap( attributes );
+    }
   }
 
   private boolean equalsMap( final Map<String, Object> values, final Map<String, Object> otherValues ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/classic-engine.properties
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/classic-engine.properties
@@ -391,3 +391,6 @@ org.pentaho.reporting.engine.classic.core.wizard.ContextAwareDataSchemaModelFact
 #
 # A flag indicating that regardless of the element size
 org.pentaho.reporting.engine.classic.core.layout.AlwaysPrintFirstLineOfText=true
+
+# Normalizes data attributes so that the bulk of the data can be shared.
+org.pentaho.reporting.engine.classic.core.wizard.DataAttributeCache=org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributeCache

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/function/sys/StyleResolvingEvaluator.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/function/sys/StyleResolvingEvaluator.java
@@ -43,7 +43,6 @@ import org.pentaho.reporting.engine.classic.core.style.css.CSSStyleResolver;
 import org.pentaho.reporting.engine.classic.core.style.resolver.StyleResolver;
 import org.pentaho.reporting.engine.classic.core.util.DoubleKeyedCounter;
 import org.pentaho.reporting.engine.classic.core.util.InstanceID;
-import org.pentaho.reporting.libraries.base.config.Configuration;
 import org.pentaho.reporting.libraries.base.config.ExtendedConfiguration;
 import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
@@ -238,22 +237,22 @@ public class StyleResolvingEvaluator extends AbstractElementFormatFunction imple
 
   protected void recordCacheHit( final ReportElement e ) {
     super.recordCacheHit( e );
-    if (collectDetailedStatistics) {
+    if ( collectDetailedStatistics ) {
       statisticsHit.increaseCounter( e.getElementType().getMetaData().getName(), e.getChangeTracker() );
     }
   }
 
   protected void recordCacheMiss( final ReportElement e ) {
     super.recordCacheMiss( e );
-    if (collectDetailedStatistics) {
+    if ( collectDetailedStatistics ) {
       statisticsMiss.increaseCounter( e.getElementType().getMetaData().getName(), e.getChangeTracker() );
     }
   }
 
   protected void reportCachePerformance() {
     super.reportCachePerformance();
-    if (collectDetailedStatistics) {
-      logger.debug(statisticsHit.printStatistic() + "\n" + statisticsMiss.printStatistic());
+    if ( collectDetailedStatistics ) {
+      logger.debug( statisticsHit.printStatistic() + "\n" + statisticsMiss.printStatistic() );
     }
   }
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/output/OutputProcessorFeature.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/output/OutputProcessorFeature.java
@@ -37,130 +37,136 @@ public abstract class OutputProcessorFeature implements Serializable {
     }
   }
 
-  public static final BooleanOutputProcessorFeature PRD_3750 = new BooleanOutputProcessorFeature(
-      "prd-3750-compatibility" );
+  public static final BooleanOutputProcessorFeature PRD_3750 =
+    new BooleanOutputProcessorFeature( "prd-3750-compatibility" );
 
-  public static final BooleanOutputProcessorFeature COMPLEX_TEXT = new BooleanOutputProcessorFeature(
-      "complex-text-layout" );
+  public static final BooleanOutputProcessorFeature COMPLEX_TEXT =
+    new BooleanOutputProcessorFeature( "complex-text-layout" );
 
-  public static final BooleanOutputProcessorFeature STRICT_COMPATIBILITY = new BooleanOutputProcessorFeature(
-      "strict-compatibility" );
+  public static final BooleanOutputProcessorFeature STRICT_COMPATIBILITY =
+    new BooleanOutputProcessorFeature( "strict-compatibility" );
 
-  public static final BooleanOutputProcessorFeature DESIGNTIME = new BooleanOutputProcessorFeature( "designtime" );
+  public static final BooleanOutputProcessorFeature DESIGNTIME =
+    new BooleanOutputProcessorFeature( "designtime" );
 
-  public static final BooleanOutputProcessorFeature UNALIGNED_PAGEBANDS = new BooleanOutputProcessorFeature(
-      "unaligned-pagebands" );
+  public static final BooleanOutputProcessorFeature UNALIGNED_PAGEBANDS =
+    new BooleanOutputProcessorFeature( "unaligned-pagebands" );
 
-  public static final BooleanOutputProcessorFeature PAGEBREAKS = new BooleanOutputProcessorFeature( "page-breaks" );
+  public static final BooleanOutputProcessorFeature PAGEBREAKS =
+    new BooleanOutputProcessorFeature( "page-breaks" );
 
-  public static final BooleanOutputProcessorFeature ITERATIVE_RENDERING = new BooleanOutputProcessorFeature(
-      "iterative-rendering" );
+  public static final BooleanOutputProcessorFeature ITERATIVE_RENDERING =
+    new BooleanOutputProcessorFeature( "iterative-rendering" );
 
-  public static final BooleanOutputProcessorFeature FAST_FONTRENDERING = new BooleanOutputProcessorFeature(
-      "fast-font-rendering" );
+  public static final BooleanOutputProcessorFeature FAST_FONTRENDERING =
+    new BooleanOutputProcessorFeature( "fast-font-rendering" );
 
-  public static final BooleanOutputProcessorFeature STRICT_TEXT_PROCESSING = new BooleanOutputProcessorFeature(
-      "strict-text-processing" );
+  public static final BooleanOutputProcessorFeature STRICT_TEXT_PROCESSING =
+    new BooleanOutputProcessorFeature( "strict-text-processing" );
 
-  public static final BooleanOutputProcessorFeature SPACING_SUPPORTED = new BooleanOutputProcessorFeature(
-      "spacing-supported" );
+  public static final BooleanOutputProcessorFeature SPACING_SUPPORTED =
+    new BooleanOutputProcessorFeature( "spacing-supported" );
 
   /**
    * Defines, whether the output target allows the use of water-mark sections. All table-exports and the plain-text
    * export will ignore the watermark section.
    */
-  public static final BooleanOutputProcessorFeature WATERMARK_SECTION = new BooleanOutputProcessorFeature(
-      "watermark-section" );
+  public static final BooleanOutputProcessorFeature WATERMARK_SECTION =
+    new BooleanOutputProcessorFeature( "watermark-section" );
 
   /**
    * Defines, whether the output target allows the generation of page-sections. Page-sections can be suppressed for
    * table-targets.
    */
-  public static final BooleanOutputProcessorFeature PAGE_SECTIONS = new BooleanOutputProcessorFeature( "page-sections" );
+  public static final BooleanOutputProcessorFeature PAGE_SECTIONS =
+    new BooleanOutputProcessorFeature( "page-sections" );
 
   /**
    * Defines, whether the output target allows background images. The 'excel' export and the plain-text export are known
    * to ignore background images.
    */
-  public static final BooleanOutputProcessorFeature BACKGROUND_IMAGE = new BooleanOutputProcessorFeature(
-      "background-image" );
+  public static final BooleanOutputProcessorFeature BACKGROUND_IMAGE =
+    new BooleanOutputProcessorFeature( "background-image" );
 
   /**
-   * Defines, whether the output uses fractional metrics. Integer metrics might be faster, but they are also inaccurate.
+   * Defines, whether the output uses fractional metrics. Integer metrics might be faster, but they are also
+   * inaccurate.
    */
-  public static final BooleanOutputProcessorFeature FONT_FRACTIONAL_METRICS = new BooleanOutputProcessorFeature(
-      "font-fractional-metrics" );
+  public static final BooleanOutputProcessorFeature FONT_FRACTIONAL_METRICS =
+    new BooleanOutputProcessorFeature( "font-fractional-metrics" );
 
   /**
    * Defines, whether the output target allows the configuration of anti-aliasing of fonts.
    * <p/>
    * The Graphics2D is one of the targets that support this feature, while the PDF-export ignores aliasing requests.
    */
-  public static final BooleanOutputProcessorFeature FONT_SUPPORTS_ANTI_ALIASING = new BooleanOutputProcessorFeature(
-      "font-anti-aliasing" );
+  public static final BooleanOutputProcessorFeature FONT_SUPPORTS_ANTI_ALIASING =
+    new BooleanOutputProcessorFeature( "font-anti-aliasing" );
 
   /**
    * Defines, whether the output system will support paddings. If this feature indicator is set, all the paddings will
    * automatically compute to zero. The output targets will not generate paddings, even if the report-element explicitly
    * defined them.
    */
-  public static final BooleanOutputProcessorFeature DISABLE_PADDING = new BooleanOutputProcessorFeature(
-      "disable-padding" );
+  public static final BooleanOutputProcessorFeature DISABLE_PADDING =
+    new BooleanOutputProcessorFeature( "disable-padding" );
 
   /**
    * Defines, that the output system will try to emulate paddings. This is a technical key indicating that the generated
    * output-format is not capable to express paddings. The table-export will therefore generate artifical boundaries to
    * generate the visual effect of the defined paddings.
    */
-  public static final BooleanOutputProcessorFeature EMULATE_PADDING = new BooleanOutputProcessorFeature(
-      "emulate-padding" );
+  public static final BooleanOutputProcessorFeature EMULATE_PADDING =
+    new BooleanOutputProcessorFeature( "emulate-padding" );
 
   /**
    * Defines the minimum size for the font smoothing. Fonts below that size will not have aliasing enabled, as this may
    * render the font unreadable.
    */
-  public static final NumericOutputProcessorFeature FONT_SMOOTH_THRESHOLD = new NumericOutputProcessorFeature(
-      "font-smooth-threshold" );
+  public static final NumericOutputProcessorFeature FONT_SMOOTH_THRESHOLD =
+    new NumericOutputProcessorFeature( "font-smooth-threshold" );
 
   /**
    * Defines the device resolution in Pixel-per-inch. This is a hint to make scaling of images more effective. LibLayout
    * still uses the default 72dpi resolution defined by Java for all computations.
    */
-  public static final NumericOutputProcessorFeature DEVICE_RESOLUTION = new NumericOutputProcessorFeature(
-      "device-resolution" );
+  public static final NumericOutputProcessorFeature DEVICE_RESOLUTION =
+    new NumericOutputProcessorFeature( "device-resolution" );
 
-  public static final NumericOutputProcessorFeature DEFAULT_FONT_SIZE = new NumericOutputProcessorFeature(
-      "default-font-size" );
+  public static final NumericOutputProcessorFeature DEFAULT_FONT_SIZE =
+    new NumericOutputProcessorFeature( "default-font-size" );
 
-  public static final BooleanOutputProcessorFeature IMAGE_RESOLUTION_MAPPING = new BooleanOutputProcessorFeature(
-      "image-resolution-mapping" );
+  public static final BooleanOutputProcessorFeature IMAGE_RESOLUTION_MAPPING =
+    new BooleanOutputProcessorFeature( "image-resolution-mapping" );
 
-  public static final BooleanOutputProcessorFeature PREFER_NATIVE_SCALING = new BooleanOutputProcessorFeature(
-      "prefer-native-scaling" );
+  public static final BooleanOutputProcessorFeature PREFER_NATIVE_SCALING =
+    new BooleanOutputProcessorFeature( "prefer-native-scaling" );
 
-  public static final BooleanOutputProcessorFeature DETECT_EXTRA_CONTENT = new BooleanOutputProcessorFeature(
-      "detect-extra-content" );
+  public static final BooleanOutputProcessorFeature DETECT_EXTRA_CONTENT =
+    new BooleanOutputProcessorFeature( "detect-extra-content" );
 
   /**
    * If this feature is active, the line-height of any text will be based on the common lineheight, and not on the
    * maximum lineheight.
    */
-  public static final BooleanOutputProcessorFeature LEGACY_LINEHEIGHT_CALC = new BooleanOutputProcessorFeature(
-      "legacy-lineheight-calculation" );
+  public static final BooleanOutputProcessorFeature LEGACY_LINEHEIGHT_CALC =
+    new BooleanOutputProcessorFeature( "legacy-lineheight-calculation" );
 
-  public static final BooleanOutputProcessorFeature EMBED_ALL_FONTS = new BooleanOutputProcessorFeature(
-      "embed-all-fonts" );
+  public static final BooleanOutputProcessorFeature EMBED_ALL_FONTS =
+    new BooleanOutputProcessorFeature( "embed-all-fonts" );
 
-  public static final BooleanOutputProcessorFeature ASSUME_OVERFLOW_X = new BooleanOutputProcessorFeature(
-      "assume-overflow-x" );
-  public static final BooleanOutputProcessorFeature ASSUME_OVERFLOW_Y = new BooleanOutputProcessorFeature(
-      "assume-overflow-y" );
-  public static final BooleanOutputProcessorFeature DIRECT_RICHTEXT_RENDERING = new BooleanOutputProcessorFeature(
-      "direct-rich-text-rendering" );
+  public static final BooleanOutputProcessorFeature ASSUME_OVERFLOW_X =
+    new BooleanOutputProcessorFeature( "assume-overflow-x" );
+  public static final BooleanOutputProcessorFeature ASSUME_OVERFLOW_Y =
+    new BooleanOutputProcessorFeature( "assume-overflow-y" );
+  public static final BooleanOutputProcessorFeature DIRECT_RICHTEXT_RENDERING =
+    new BooleanOutputProcessorFeature( "direct-rich-text-rendering" );
   public static final BooleanOutputProcessorFeature ALWAYS_PRINT_FIRST_LINE_OF_TEXT =
-      new BooleanOutputProcessorFeature( "always-print-first-line-of-text" );
-  public static final BooleanOutputProcessorFeature WATERMARK_PRINTED_ON_TOP = new BooleanOutputProcessorFeature(
-      "watermark-print-on-top" );
+    new BooleanOutputProcessorFeature( "always-print-first-line-of-text" );
+  public static final BooleanOutputProcessorFeature WATERMARK_PRINTED_ON_TOP =
+    new BooleanOutputProcessorFeature( "watermark-print-on-top" );
+  public static final BooleanOutputProcessorFeature FAST_EXPORT =
+    new BooleanOutputProcessorFeature( "fast-export" );
 
   private String name;
   private int hashCode;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/richtext/HtmlRichTextConverter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/richtext/HtmlRichTextConverter.java
@@ -119,7 +119,7 @@ public class HtmlRichTextConverter implements RichTextConverter {
       }
 
       final Element element = process( doc.getDefaultRootElement() );
-      return RichTextConverterUtilities.convertToBand( StyleKey.getDefinedStyleKeys(), source, element );
+      return RichTextConverterUtilities.convertToBand( StyleKey.getDefinedStyleKeysList(), source, element );
     } catch ( Exception e ) {
       return value;
     }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/richtext/RichTextConverterUtilities.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/richtext/RichTextConverterUtilities.java
@@ -17,6 +17,16 @@
 
 package org.pentaho.reporting.engine.classic.core.layout.richtext;
 
+import org.pentaho.reporting.engine.classic.core.Band;
+import org.pentaho.reporting.engine.classic.core.Element;
+import org.pentaho.reporting.engine.classic.core.ReportElement;
+import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
+import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
+import org.pentaho.reporting.engine.classic.core.style.StyleKey;
+
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.EditorKit;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,24 +35,14 @@ import java.io.StringReader;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.SQLException;
-
-import javax.swing.text.BadLocationException;
-import javax.swing.text.Document;
-import javax.swing.text.EditorKit;
-
-import org.pentaho.reporting.engine.classic.core.Band;
-import org.pentaho.reporting.engine.classic.core.Element;
-import org.pentaho.reporting.engine.classic.core.ReportElement;
-import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
+import java.util.List;
 
 public class RichTextConverterUtilities {
   private RichTextConverterUtilities() {
   }
 
-  public static Document parseDocument( final EditorKit editorKit, final Object value ) throws IOException,
-    BadLocationException {
+  public static Document parseDocument( final EditorKit editorKit, final Object value )
+    throws IOException, BadLocationException {
     if ( value instanceof Document ) {
       return (Document) value;
     }
@@ -128,24 +128,21 @@ public class RichTextConverterUtilities {
     return null;
   }
 
-  public static Band
-    convertToBand( final StyleKey[] definedStyleKeys, final ReportElement element, final Element child ) {
+  public static Band convertToBand( final List<StyleKey> definedStyleKeys,
+                                    final ReportElement element, final Element child ) {
     final Band b = new Band( element.getObjectID() );
     final ElementStyleSheet targetStyle = b.getStyle();
     final ElementStyleSheet sourceStyle = element.getStyle();
-    for ( int i = 0; i < definedStyleKeys.length; i++ ) {
-      // copy all, even the inherited styles, as we do not add the element/band to the real parent. All we do
-      // is virtual ..
-      final StyleKey key = definedStyleKeys[i];
+    for ( StyleKey key : definedStyleKeys ) {
       targetStyle.setStyleProperty( key, sourceStyle.getStyleProperty( key ) );
     }
 
     final String[] attrNs = element.getAttributeNamespaces();
     for ( int i = 0; i < attrNs.length; i++ ) {
-      final String attrNamespace = attrNs[i];
+      final String attrNamespace = attrNs[ i ];
       final String[] attrNames = element.getAttributeNames( attrNamespace );
       for ( int j = 0; j < attrNames.length; j++ ) {
-        final String attrName = attrNames[j];
+        final String attrName = attrNames[ j ];
         final Object attrValue = element.getAttribute( attrNamespace, attrName );
         b.setAttribute( attrNamespace, attrName, attrValue );
       }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/richtext/RtfRichTextConverter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/richtext/RtfRichTextConverter.java
@@ -67,7 +67,7 @@ public class RtfRichTextConverter implements RichTextConverter {
       }
 
       final Element element = process( doc.getDefaultRootElement() );
-      final Band band = RichTextConverterUtilities.convertToBand( StyleKey.getDefinedStyleKeys(), source, element );
+      final Band band = RichTextConverterUtilities.convertToBand( StyleKey.getDefinedStyleKeysList(), source, element );
       band.getStyle().setStyleProperty( BandStyleKeys.LAYOUT, "inline" );
       return band;
     } catch ( Exception e ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/DefaultStyleCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/DefaultStyleCache.java
@@ -17,6 +17,8 @@
 
 package org.pentaho.reporting.engine.classic.core.layout.style;
 
+import java.util.List;
+
 import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.InvalidReportStateException;
 import org.pentaho.reporting.engine.classic.core.style.StyleKey;
@@ -90,7 +92,10 @@ public class DefaultStyleCache implements StyleCache {
     }
 
     public String toString() {
-      return "CacheKey{" + "instanceId=" + instanceId + ", styleClass='" + styleClass + '\'' + '}';
+      return "CacheKey{" +
+        "instanceId=" + instanceId +
+        ", styleClass='" + styleClass + '\'' +
+        '}';
     }
   }
 
@@ -114,7 +119,7 @@ public class DefaultStyleCache implements StyleCache {
 
   private LFUMap<CacheKey, CacheCarrier> cache;
   private CacheKey lookupKey;
-  private StyleKey[] validateKeys;
+  private List<StyleKey> validateKeys;
   private boolean validateCache;
   private int cacheHits;
   private int cacheMiss;
@@ -167,26 +172,26 @@ public class DefaultStyleCache implements StyleCache {
     }
 
     if ( validateKeys == null ) {
-      validateKeys = StyleKey.getDefinedStyleKeys();
+      validateKeys = StyleKey.getDefinedStyleKeysList();
     }
 
-    for ( int i = 0; i < validateKeys.length; i++ ) {
-      final StyleKey validateKey = validateKeys[i];
+    for ( final StyleKey validateKey : validateKeys ) {
       final Object o1 = s1.getStyleProperty( validateKey );
       final Object o2 = s2.getStyleProperty( validateKey );
       if ( ObjectUtilities.equal( o1, o2 ) ) {
         continue;
       }
 
-      throw new InvalidReportStateException( "Cache-Failure on " + s1.getId() + " " + validateKey + " " + o1 + " vs "
-          + o2 + " [" + s1.getChangeTracker() + "; " + s2.getChangeTracker() + "]" );
+      throw new InvalidReportStateException( "Cache-Failure on " + s1.getId() + " " + validateKey + " " +
+        o1 + " vs " + o2 + " [" + s1.getChangeTracker() + "; " + s2.getChangeTracker() + "]" );
     }
   }
 
   public String printPerformanceStats() {
     final int total = cacheHits + cacheMiss;
-    return ( "StyleCache: " + name + " " + "Total=" + total + " Hits=" + cacheHits + " ("
-        + ( 100f * cacheHits / Math.max( 1, total ) ) + "%)" + " Miss=" + cacheMiss + " ("
-        + ( 100f * cacheMiss / Math.max( 1, total ) ) + "%)" );
+    return ( "StyleCache: " + name + " " +
+      "Total=" + total +
+      " Hits=" + cacheHits + " (" + ( 100f * cacheHits / Math.max( 1, total ) ) + "%)" +
+      " Miss=" + cacheMiss + " (" + ( 100f * cacheMiss / Math.max( 1, total ) ) + "%)" );
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/DefaultStyleCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/DefaultStyleCache.java
@@ -92,10 +92,10 @@ public class DefaultStyleCache implements StyleCache {
     }
 
     public String toString() {
-      return "CacheKey{" +
-        "instanceId=" + instanceId +
-        ", styleClass='" + styleClass + '\'' +
-        '}';
+      return "CacheKey{"
+        + "instanceId=" + instanceId
+        + ", styleClass='" + styleClass + '\''
+        + '}';
     }
   }
 
@@ -182,16 +182,16 @@ public class DefaultStyleCache implements StyleCache {
         continue;
       }
 
-      throw new InvalidReportStateException( "Cache-Failure on " + s1.getId() + " " + validateKey + " " +
-        o1 + " vs " + o2 + " [" + s1.getChangeTracker() + "; " + s2.getChangeTracker() + "]" );
+      throw new InvalidReportStateException( "Cache-Failure on " + s1.getId() + " " + validateKey + " "
+        + o1 + " vs " + o2 + " [" + s1.getChangeTracker() + "; " + s2.getChangeTracker() + "]" );
     }
   }
 
   public String printPerformanceStats() {
     final int total = cacheHits + cacheMiss;
-    return ( "StyleCache: " + name + " " +
-      "Total=" + total +
-      " Hits=" + cacheHits + " (" + ( 100f * cacheHits / Math.max( 1, total ) ) + "%)" +
-      " Miss=" + cacheMiss + " (" + ( 100f * cacheMiss / Math.max( 1, total ) ) + "%)" );
+    return ( "StyleCache: " + name + " "
+      + "Total=" + total
+      + " Hits=" + cacheHits + " (" + ( 100f * cacheHits / Math.max( 1, total ) ) + "%)"
+      + " Miss=" + cacheMiss + " (" + ( 100f * cacheMiss / Math.max( 1, total ) ) + "%)" );
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/ParagraphPoolboxStyleSheet.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/ParagraphPoolboxStyleSheet.java
@@ -17,6 +17,8 @@
 
 package org.pentaho.reporting.engine.classic.core.layout.style;
 
+import java.util.List;
+
 import org.pentaho.reporting.engine.classic.core.style.AbstractStyleSheet;
 import org.pentaho.reporting.engine.classic.core.style.ElementDefaultStyleSheet;
 import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
@@ -61,13 +63,13 @@ public class ParagraphPoolboxStyleSheet extends AbstractStyleSheet {
 
   public Object[] toArray() {
     final Object[] objects = defaultStyleSheet.toArray();
-    final StyleKey[] keys = StyleKey.getDefinedStyleKeys();
-    for ( int i = 0; i < keys.length; i++ ) {
-      final StyleKey key = keys[i];
+    final List<StyleKey> keys= StyleKey.getDefinedStyleKeysList();
+    for ( int i = 0; i < keys.size(); i++ ) {
+      final StyleKey key = keys.get( i );
       if ( ElementStyleKeys.AVOID_PAGEBREAK_INSIDE.equals( key ) ) {
-        objects[i] = Boolean.TRUE;
+        objects[ i ] = Boolean.TRUE;
       } else if ( key.isInheritable() ) {
-        objects[i] = parentStyleSheet.getStyleProperty( key, null );
+        objects[ i ] = parentStyleSheet.getStyleProperty( key, null );
       }
     }
     return objects;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/ParagraphPoolboxStyleSheet.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/ParagraphPoolboxStyleSheet.java
@@ -63,7 +63,7 @@ public class ParagraphPoolboxStyleSheet extends AbstractStyleSheet {
 
   public Object[] toArray() {
     final Object[] objects = defaultStyleSheet.toArray();
-    final List<StyleKey> keys= StyleKey.getDefinedStyleKeysList();
+    final List<StyleKey> keys = StyleKey.getDefinedStyleKeysList();
     for ( int i = 0, len = keys.size(); i < len; i++ ) {
       final StyleKey key = keys.get( i );
       if ( ElementStyleKeys.AVOID_PAGEBREAK_INSIDE.equals( key ) ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/ParagraphPoolboxStyleSheet.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/style/ParagraphPoolboxStyleSheet.java
@@ -64,7 +64,7 @@ public class ParagraphPoolboxStyleSheet extends AbstractStyleSheet {
   public Object[] toArray() {
     final Object[] objects = defaultStyleSheet.toArray();
     final List<StyleKey> keys= StyleKey.getDefinedStyleKeysList();
-    for ( int i = 0; i < keys.size(); i++ ) {
+    for ( int i = 0, len = keys.size(); i < len; i++ ) {
       final StyleKey key = keys.get( i );
       if ( ElementStyleKeys.AVOID_PAGEBREAK_INSIDE.equals( key ) ) {
         objects[ i ] = Boolean.TRUE;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/ResultSetTableModelFactory.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/ResultSetTableModelFactory.java
@@ -32,7 +32,6 @@ import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeCache;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributeContext;
-import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.ImmutableDataAttributes;
 import org.pentaho.reporting.libraries.base.config.Configuration;
@@ -278,12 +277,12 @@ public final class ResultSetTableModelFactory {
           }
         }
 
-        columnMeta[columnIndex] = ResultSetTableModelFactory.collectData( rsmd, columnIndex, header[columnIndex]);
+        columnMeta[ columnIndex ] = ResultSetTableModelFactory.collectData( rsmd, columnIndex, header[ columnIndex ] );
       }
 
       final Object[][] rowMap = produceData( rs, colcount );
       ImmutableTableMetaData metaData = new ImmutableTableMetaData( ImmutableDataAttributes.EMPTY,
-                                                                    map(columnMeta) );
+        map( columnMeta ) );
       return new CloseableDefaultTableModel( rowMap, header, colTypes, metaData );
     } finally {
       Statement statement = null;
@@ -310,16 +309,16 @@ public final class ResultSetTableModelFactory {
     }
   }
 
-  public static ImmutableDataAttributes[] map(AttributeMap[] data) {
+  public static ImmutableDataAttributes[] map( AttributeMap[] data ) {
     DataAttributeCache cache = ClassicEngineBoot.getInstance().getObjectFactory().get( DataAttributeCache.class );
     DataAttributeContext ctx = new DefaultDataAttributeContext();
-    ImmutableDataAttributes[] retval = new ImmutableDataAttributes[data.length];
+    ImmutableDataAttributes[] retval = new ImmutableDataAttributes[ data.length ];
     for ( int i = 0; i < data.length; i++ ) {
-      AttributeMap<Object> map = data[i];
-      if (cache != null) {
-        retval[i] = cache.normalize( new ImmutableDataAttributes( map ), ctx);
+      AttributeMap<Object> map = data[ i ];
+      if ( cache != null ) {
+        retval[ i ] = cache.normalize( new ImmutableDataAttributes( map ), ctx );
       } else {
-        retval[i] = new ImmutableDataAttributes( map );
+        retval[ i ] = new ImmutableDataAttributes( map );
       }
     }
     return retval;
@@ -347,7 +346,7 @@ public final class ResultSetTableModelFactory {
       rows.add( column );
     }
 
-    return rows.toArray(new Object[ rows.size() ][] );
+    return rows.toArray( new Object[ rows.size() ][] );
   }
 
   public static AttributeMap<Object> collectData(final ResultSetMetaData rsmd,

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/ResultSetTableModelFactory.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/ResultSetTableModelFactory.java
@@ -17,6 +17,29 @@
 
 package org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.MetaAttributeNames;
+import org.pentaho.reporting.engine.classic.core.MetaTableModel;
+import org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.DefaultTableMetaData;
+import org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.ImmutableTableMetaData;
+import org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.TableMetaData;
+import org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.TypeMapper;
+import org.pentaho.reporting.engine.classic.core.util.CloseableTableModel;
+import org.pentaho.reporting.engine.classic.core.util.IntegerCache;
+import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeCache;
+import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
+import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
+import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributeContext;
+import org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributes;
+import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
+import org.pentaho.reporting.engine.classic.core.wizard.ImmutableDataAttributes;
+import org.pentaho.reporting.libraries.base.config.Configuration;
+import org.pentaho.reporting.libraries.base.util.IOUtils;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
+
+import javax.swing.table.DefaultTableModel;
 import java.io.IOException;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -25,22 +48,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-
-import javax.swing.table.DefaultTableModel;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
-import org.pentaho.reporting.engine.classic.core.MetaAttributeNames;
-import org.pentaho.reporting.engine.classic.core.MetaTableModel;
-import org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.DefaultTableMetaData;
-import org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.TypeMapper;
-import org.pentaho.reporting.engine.classic.core.util.CloseableTableModel;
-import org.pentaho.reporting.engine.classic.core.util.IntegerCache;
-import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
-import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
-import org.pentaho.reporting.libraries.base.config.Configuration;
-import org.pentaho.reporting.libraries.base.util.IOUtils;
 
 /**
  * Creates a <code>TableModel</code> which is backed up by a <code>ResultSet</code>. If the <code>ResultSet</code> is
@@ -59,13 +66,13 @@ public final class ResultSetTableModelFactory {
    * The configuration key defining how to map column names to column indices.
    */
   public static final String COLUMN_NAME_MAPPING_KEY =
-      "org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.ColumnMappingMode"; //$NON-NLS-1$
+    "org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.ColumnMappingMode"; //$NON-NLS-1$
 
   /**
    * The 'ResultSet factory mode'.
    */
-  public static final String RESULTSET_FACTORY_MODE =
-      "org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.TableFactoryMode"; //$NON-NLS-1$
+  public static final String RESULTSET_FACTORY_MODE
+    = "org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel.TableFactoryMode"; //$NON-NLS-1$
 
   /**
    * Singleton instance of the factory.
@@ -80,27 +87,25 @@ public final class ResultSetTableModelFactory {
 
   /**
    * Creates a table model by using the given <code>ResultSet</code> as the backend. If the <code>ResultSet</code> is
-   * scrollable (the type is not <code>TYPE_FORWARD_ONLY</code>), an instance of
-   * {@link org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.ScrollableResultSetTableModel} is
-   * returned. This model uses the extended capabilities of scrollable result sets to directly read data from the
-   * database without caching or the need of copying the complete <code>ResultSet</code> into the programs memory.
+   * scrollable (the type is not <code>TYPE_FORWARD_ONLY</code>), an instance of {@link
+   * org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.ScrollableResultSetTableModel} is returned.
+   * This model uses the extended capabilities of scrollable result sets to directly read data from the database without
+   * caching or the need of copying the complete <code>ResultSet</code> into the programs memory.
    * <p/>
    * If the <code>ResultSet</code> lacks the scrollable features, the data will be copied into a
    * <code>DefaultTableModel</code> and the <code>ResultSet</code> gets closed.
    *
-   * @param rs
-   *          the result set.
-   * @param columnNameMapping
-   *          defines, whether to use column names or column labels to compute the column index. If true, then we map
-   *          the Name. If false, then we map the Label
-   * @param closeStatement
-   *          a flag indicating whether closing the resultset should also close the statement.
+   * @param rs                the result set.
+   * @param columnNameMapping defines, whether to use column names or column labels to compute the column index. If
+   *                          true, then we map the Name.  If false, then we map the Label
+   * @param closeStatement    a flag indicating whether closing the resultset should also close the statement.
    * @return a closeable table model.
-   * @throws SQLException
-   *           if there is a problem with the result set.
+   * @throws SQLException if there is a problem with the result set.
    */
-  public CloseableTableModel createTableModel( final ResultSet rs, final boolean columnNameMapping,
-      final boolean closeStatement ) throws SQLException {
+  public CloseableTableModel createTableModel( final ResultSet rs,
+                                               final boolean columnNameMapping,
+                                               final boolean closeStatement )
+    throws SQLException {
     // Allow for override, some jdbc drivers are buggy :(
     final String prop =
         ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty(
@@ -114,7 +119,8 @@ public final class ResultSetTableModelFactory {
     try {
       resultSetType = rs.getType();
     } catch ( SQLException sqle ) {
-      ResultSetTableModelFactory.logger.info( "ResultSet type could not be determined, assuming default table model." ); //$NON-NLS-1$
+      ResultSetTableModelFactory.logger.info(
+        "ResultSet type could not be determined, assuming default table model." ); //$NON-NLS-1$
     }
     if ( resultSetType == ResultSet.TYPE_FORWARD_ONLY ) {
       return generateDefaultTableModel( rs, columnNameMapping );
@@ -126,24 +132,25 @@ public final class ResultSetTableModelFactory {
   /**
    * A DefaultTableModel that implements the CloseableTableModel interface.
    */
-  private static final class CloseableDefaultTableModel extends DefaultTableModel implements CloseableTableModel,
-      MetaTableModel {
-    private DefaultTableMetaData metaData;
+  private static final class CloseableDefaultTableModel extends DefaultTableModel
+    implements CloseableTableModel, MetaTableModel {
+    private TableMetaData metaData;
     private Class[] columnTypes;
 
-    private static final Object[] EMPTY_ARRAY = new Object[0];
-    private static final Object[][] EMPTY_DATA_VECTOR = new Object[0][0];
+    private static final Object[] EMPTY_ARRAY = new Object[ 0 ];
+    private static final Object[][] EMPTY_DATA_VECTOR = new Object[ 0 ][ 0 ];
+
 
     /**
      * Creates a new closeable table model.
      *
-     * @param rowData
-     *          the table data.
-     * @param columnNames
-     *          the column names.
+     * @param rowData     the table data.
+     * @param columnNames the column names.
      */
-    private CloseableDefaultTableModel( final Object[][] rowData, final Object[] columnNames,
-        final Class[] columnTypes, final DefaultTableMetaData metaTableModel ) {
+    private CloseableDefaultTableModel( final Object[][] rowData,
+                                        final Object[] columnNames,
+                                        final Class[] columnTypes,
+                                        final TableMetaData metaTableModel ) {
       super( rowData, columnNames );
       this.columnTypes = columnTypes;
       this.metaData = metaTableModel;
@@ -152,8 +159,7 @@ public final class ResultSetTableModelFactory {
     /**
      * Returns <code>Object.class</code> regardless of <code>columnIndex</code>.
      *
-     * @param columnIndex
-     *          the column being queried
+     * @param columnIndex the column being queried
      * @return the Object.class
      */
     public Class getColumnClass( final int columnIndex ) {
@@ -163,7 +169,7 @@ public final class ResultSetTableModelFactory {
       if ( columnIndex >= columnTypes.length ) {
         return Object.class;
       }
-      return columnTypes[columnIndex];
+      return columnTypes[ columnIndex ];
     }
 
     /**
@@ -180,10 +186,8 @@ public final class ResultSetTableModelFactory {
      * <p/>
      * Meta-data models that only describe meta-data for columns can ignore the row-parameter.
      *
-     * @param row
-     *          the row of the cell for which the meta-data is queried.
-     * @param column
-     *          the index of the column for which the meta-data is queried.
+     * @param row    the row of the cell for which the meta-data is queried.
+     * @param column the index of the column for which the meta-data is queried.
      * @return the meta-data object.
      */
     public DataAttributes getCellDataAttributes( final int row, final int column ) {
@@ -225,23 +229,19 @@ public final class ResultSetTableModelFactory {
    * Hint: To customize the names of the columns, use the SQL column aliasing (done with <code>SELECT nativecolumnname
    * AS "JavaColumnName" FROM ....</code>
    *
-   * @param rs
-   *          the result set.
-   * @param columnNameMapping
-   *          defines, whether to use column names or column labels to compute the column index. If true, then we map
-   *          the Name. If false, then we map the Label
+   * @param rs                the result set.
+   * @param columnNameMapping defines, whether to use column names or column labels to compute the column index. If
+   *                          true, then we map the Name.  If false, then we map the Label
    * @return a closeable table model.
-   * @throws SQLException
-   *           if there is a problem with the result set.
+   * @throws SQLException if there is a problem with the result set.
    */
   public CloseableTableModel generateDefaultTableModel( final ResultSet rs, final boolean columnNameMapping )
     throws SQLException {
     try {
       final ResultSetMetaData rsmd = rs.getMetaData();
       final int colcount = rsmd.getColumnCount();
-      final Object[] header = new Object[colcount];
       final Class[] colTypes = TypeMapper.mapTypes( rsmd );
-      final DefaultTableMetaData metaData = new DefaultTableMetaData( colcount );
+      //final DefaultTableMetaData metaData = new DefaultTableMetaData( colcount );
 
       // In past many database drivers were returning same value for column label and column name. So it is
       // inconsistent
@@ -254,9 +254,13 @@ public final class ResultSetTableModelFactory {
       // any interpretation or interpolation.
       final Configuration globalConfig = ClassicEngineBoot.getInstance().getGlobalConfig();
       final boolean useLegacyColumnMapping =
-          "legacy".equalsIgnoreCase( // NON-NLS
-              globalConfig.getConfigProperty(
-                  "org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.ColumnMappingMode", "legacy" ) ); // NON-NLS
+        "legacy".equalsIgnoreCase(                                                                            // NON-NLS
+          globalConfig.getConfigProperty(
+            "org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql.ColumnMappingMode",
+            "legacy" ) );  // NON-NLS
+
+      final String[] header = new String[ colcount ];
+      final AttributeMap[] columnMeta = new AttributeMap[ colcount ];
 
       for ( int columnIndex = 0; columnIndex < colcount; columnIndex++ ) {
         String columnLabel = rsmd.getColumnLabel( columnIndex + 1 );
@@ -265,46 +269,21 @@ public final class ResultSetTableModelFactory {
             // We are in legacy mode and column label is either null or empty, we then use column name instead.
             columnLabel = rsmd.getColumnName( columnIndex + 1 );
           }
-
-          header[columnIndex] = columnLabel;
+          header[ columnIndex ] = columnLabel;
         } else {
           if ( columnNameMapping ) {
-            header[columnIndex] = rsmd.getColumnName( columnIndex + 1 );
+            header[ columnIndex ] = rsmd.getColumnName( columnIndex + 1 );
           } else {
-            header[columnIndex] = columnLabel;
+            header[ columnIndex ] = columnLabel;
           }
         }
 
-        ResultSetTableModelFactory.updateMetaData( rsmd, metaData, columnIndex );
-      }
-      final ArrayList rows = new ArrayList();
-      while ( rs.next() ) {
-        final Object[] column = new Object[colcount];
-        for ( int i = 0; i < colcount; i++ ) {
-          final Object val = rs.getObject( i + 1 );
-          try {
-            if ( val instanceof Blob ) {
-              column[i] = IOUtils.getInstance().readBlob( (Blob) val );
-            } else if ( val instanceof Clob ) {
-              column[i] = IOUtils.getInstance().readClob( (Clob) val );
-            } else {
-              column[i] = val;
-            }
-          } catch ( IOException ioe ) {
-            logger.error( "IO error while copying data.", ioe );
-            throw new SQLException( "IO error while copying data: " + ioe.getMessage() );
-          }
-        }
-        rows.add( column );
+        columnMeta[columnIndex] = ResultSetTableModelFactory.collectData( rsmd, columnIndex, header[columnIndex]);
       }
 
-      final Object[] tempRows = rows.toArray();
-      final int tempRowCount = tempRows.length;
-      final Object[][] rowMap = new Object[tempRowCount][];
-      for ( int i = 0; i < tempRowCount; i++ ) {
-        rowMap[i] = (Object[]) tempRows[i];
-      }
-
+      final Object[][] rowMap = produceData( rs, colcount );
+      ImmutableTableMetaData metaData = new ImmutableTableMetaData( ImmutableDataAttributes.EMPTY,
+                                                                    map(columnMeta) );
       return new CloseableDefaultTableModel( rowMap, header, colTypes, metaData );
     } finally {
       Statement statement = null;
@@ -331,8 +310,106 @@ public final class ResultSetTableModelFactory {
     }
   }
 
-  public static void
-    updateMetaData( final ResultSetMetaData rsmd, final DefaultTableMetaData metaData, final int column ) {
+  public static ImmutableDataAttributes[] map(AttributeMap[] data) {
+    DataAttributeCache cache = ClassicEngineBoot.getInstance().getObjectFactory().get( DataAttributeCache.class );
+    DataAttributeContext ctx = new DefaultDataAttributeContext();
+    ImmutableDataAttributes[] retval = new ImmutableDataAttributes[data.length];
+    for ( int i = 0; i < data.length; i++ ) {
+      AttributeMap<Object> map = data[i];
+      if (cache != null) {
+        retval[i] = cache.normalize( new ImmutableDataAttributes( map ), ctx);
+      } else {
+        retval[i] = new ImmutableDataAttributes( map );
+      }
+    }
+    return retval;
+  }
+
+  protected Object[][] produceData( final ResultSet rs, final int colcount ) throws SQLException {
+    final ArrayList<Object[]> rows = new ArrayList<Object[]>();
+    while ( rs.next() ) {
+      final Object[] column = new Object[ colcount ];
+      for ( int i = 0; i < colcount; i++ ) {
+        final Object val = rs.getObject( i + 1 );
+        try {
+          if ( val instanceof Blob ) {
+            column[ i ] = IOUtils.getInstance().readBlob( (Blob) val );
+          } else if ( val instanceof Clob ) {
+            column[ i ] = IOUtils.getInstance().readClob( (Clob) val );
+          } else {
+            column[ i ] = val;
+          }
+        } catch ( IOException ioe ) {
+          logger.error( "IO error while copying data.", ioe );
+          throw new SQLException( "IO error while copying data: " + ioe.getMessage() );
+        }
+      }
+      rows.add( column );
+    }
+
+    return rows.toArray(new Object[ rows.size() ][] );
+  }
+
+  public static AttributeMap<Object> collectData(final ResultSetMetaData rsmd,
+                                                  final int column,
+                                                  final String name)
+    throws SQLException {
+    AttributeMap<Object> metaData = new AttributeMap<Object>();
+    metaData.setAttribute( MetaAttributeNames.Core.NAMESPACE,
+                           MetaAttributeNames.Core.TYPE, TypeMapper.mapForColumn( rsmd, column ) );
+    metaData.setAttribute( MetaAttributeNames.Core.NAMESPACE,
+                           MetaAttributeNames.Core.NAME, name );
+    if ( rsmd.isCurrency( column + 1 ) ) {
+      metaData.setAttribute( MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.CURRENCY, Boolean.TRUE );
+    } else {
+      metaData.setAttribute( MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.CURRENCY, Boolean.FALSE );
+    }
+
+    if ( rsmd.isSigned( column + 1 ) ) {
+      metaData.setAttribute( MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.SIGNED, Boolean.TRUE );
+    } else {
+      metaData.setAttribute( MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.SIGNED, Boolean.FALSE );
+    }
+
+    final String tableName = rsmd.getTableName( column + 1 );
+    if ( tableName != null ) {
+      metaData.setAttribute( MetaAttributeNames.Database.NAMESPACE, MetaAttributeNames.Database.TABLE, tableName );
+    }
+    final String schemaName = rsmd.getSchemaName( column + 1 );
+    if ( schemaName != null ) {
+      metaData.setAttribute( MetaAttributeNames.Database.NAMESPACE, MetaAttributeNames.Database.SCHEMA, schemaName );
+    }
+    final String catalogName = rsmd.getCatalogName( column + 1 );
+    if ( catalogName != null ) {
+      metaData.setAttribute( MetaAttributeNames.Database.NAMESPACE, MetaAttributeNames.Database.CATALOG, catalogName );
+    }
+    final String label = rsmd.getColumnLabel( column + 1 );
+    if ( label != null ) {
+      metaData.setAttribute( MetaAttributeNames.Formatting.NAMESPACE, MetaAttributeNames.Formatting.LABEL, label );
+    }
+    final int displaySize = rsmd.getColumnDisplaySize( column + 1 );
+    metaData.setAttribute( MetaAttributeNames.Formatting.NAMESPACE, MetaAttributeNames.Formatting.DISPLAY_SIZE,
+                           IntegerCache.getInteger( displaySize ) );
+
+    final int precision = rsmd.getPrecision( column + 1 );
+    metaData.setAttribute( MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.PRECISION,
+                           IntegerCache.getInteger( precision ) );
+    final int scale = rsmd.getScale( column + 1 );
+    metaData.setAttribute( MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.SCALE,
+                           IntegerCache.getInteger( scale ) );
+    return metaData;
+  }
+
+  /**
+   * No longer used.
+   * @param rsmd
+   * @param metaData
+   * @param column
+   */
+  @Deprecated
+  public static void updateMetaData( final ResultSetMetaData rsmd,
+                                     final DefaultTableMetaData metaData,
+                                     final int column ) {
     try {
       if ( rsmd.isCurrency( column + 1 ) ) {
         metaData.setColumnAttribute( column, MetaAttributeNames.Numeric.NAMESPACE, MetaAttributeNames.Numeric.CURRENCY,

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/ScrollableResultSetTableModel.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/ScrollableResultSetTableModel.java
@@ -201,8 +201,7 @@ public class ScrollableResultSetTableModel extends AbstractTableModel
       } else {
         rowCount = 0;
       }
-    }
-    catch ( SQLException sqle ) {
+    } catch ( SQLException sqle ) {
       //Log.debug ("GetRowCount failed, returning 0 rows", sqle);
       throw new DataTableException( "Accessing the result set failed: ", sqle );
     }
@@ -224,8 +223,7 @@ public class ScrollableResultSetTableModel extends AbstractTableModel
     if ( dbmd != null ) {
       try {
         return dbmd.getColumnCount();
-      }
-      catch ( SQLException e ) {
+      } catch ( SQLException e ) {
         //Log.debug ("GetColumnCount failed", e);
         throw new DataTableException( "Accessing the result set failed: ", e );
       }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/DefaultTableMetaData.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/DefaultTableMetaData.java
@@ -24,7 +24,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
 
 import java.util.ArrayList;
 
-public class DefaultTableMetaData {
+public class DefaultTableMetaData implements TableMetaData {
   private DefaultDataAttributes tableAttributes;
   private ArrayList<DefaultDataAttributes> columnAttributes;
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/ImmutableTableMetaData.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/ImmutableTableMetaData.java
@@ -1,0 +1,56 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel;
+
+import java.io.Serializable;
+
+import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
+import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
+import org.pentaho.reporting.engine.classic.core.wizard.ImmutableDataAttributes;
+
+/**
+ * An immutable version of the table-metadata class. This class allows more efficient reuse of shared objects
+ * as all contents are guaranteed to be immutable.
+ */
+public class ImmutableTableMetaData implements TableMetaData {
+  private ImmutableDataAttributes tableAttributes;
+  private ImmutableDataAttributes[] columnAttributes;
+
+  public ImmutableTableMetaData( final ImmutableDataAttributes tableAttributes,
+                                 final ImmutableDataAttributes... columnAttributes ) {
+    this.tableAttributes = tableAttributes;
+    this.columnAttributes = columnAttributes.clone();
+  }
+
+  public DataAttributes getCellDataAttribute( final int row,
+                                              final int column ) {
+    return EmptyDataAttributes.INSTANCE;
+  }
+
+  public boolean isCellDataAttributesSupported() {
+    return false;
+  }
+
+  public DataAttributes getColumnAttribute( final int column ) {
+    return columnAttributes[column];
+  }
+
+  public DataAttributes getTableAttribute() {
+    return tableAttributes;
+  }
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/ImmutableTableMetaData.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/ImmutableTableMetaData.java
@@ -17,8 +17,6 @@
 
 package org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel;
 
-import java.io.Serializable;
-
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.EmptyDataAttributes;
 import org.pentaho.reporting.engine.classic.core.wizard.ImmutableDataAttributes;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/TableMetaData.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/TableMetaData.java
@@ -1,0 +1,34 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.misc.tablemodel;
+
+import java.io.Serializable;
+
+import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
+
+public interface TableMetaData extends Serializable {
+  public DataAttributes getCellDataAttribute( final int row,
+                                              final int column );
+
+  public boolean isCellDataAttributesSupported();
+
+  public DataAttributes getColumnAttribute( final int column );
+
+  public DataAttributes getTableAttribute();
+
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/TableMetaData.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/TableMetaData.java
@@ -22,13 +22,13 @@ import java.io.Serializable;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
 
 public interface TableMetaData extends Serializable {
-  public DataAttributes getCellDataAttribute( final int row,
-                                              final int column );
+  DataAttributes getCellDataAttribute( final int row,
+                                       final int column );
 
-  public boolean isCellDataAttributesSupported();
+  boolean isCellDataAttributesSupported();
 
-  public DataAttributes getColumnAttribute( final int column );
+  DataAttributes getColumnAttribute( final int column );
 
-  public DataAttributes getTableAttribute();
+  DataAttributes getTableAttribute();
 
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/TypeMapper.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/misc/tablemodel/TypeMapper.java
@@ -141,7 +141,7 @@ public class TypeMapper {
     return types;
   }
 
-  public static Class<?> mapForColumn(ResultSetMetaData rsmd, int i) {
+  public static Class<?> mapForColumn( ResultSetMetaData rsmd, int i ) {
     try {
       final ClassLoader cl = ObjectUtilities.getClassLoader( TypeMapper.class );
       try {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/csv/FastCsvExportProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/csv/FastCsvExportProcessor.java
@@ -25,9 +25,11 @@ import org.pentaho.reporting.engine.classic.core.layout.output.AbstractOutputPro
 import org.pentaho.reporting.engine.classic.core.layout.output.AbstractReportProcessor;
 import org.pentaho.reporting.engine.classic.core.layout.output.ContentProcessingException;
 import org.pentaho.reporting.engine.classic.core.layout.output.LogicalPageKey;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorFeature;
 import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.modules.output.fast.FastExportOutputFunction;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.csv.helper.CSVOutputProcessorMetaData;
+import org.pentaho.reporting.libraries.base.config.Configuration;
 
 import java.io.OutputStream;
 
@@ -36,7 +38,12 @@ public class FastCsvExportProcessor extends AbstractReportProcessor {
     private OutputProcessorMetaData metaData;
 
     private CSVDataOutputProcessor() {
-      metaData = new CSVOutputProcessorMetaData( CSVOutputProcessorMetaData.PAGINATION_NONE );
+      metaData = new CSVOutputProcessorMetaData( CSVOutputProcessorMetaData.PAGINATION_NONE ) {
+        public void initialize( final Configuration configuration ) {
+          super.initialize( configuration );
+          addFeature( OutputProcessorFeature.FAST_EXPORT );
+        }
+      };
     }
 
     protected void processPageContent( final LogicalPageKey logicalPageKey, final LogicalPageBox logicalPage )

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/html/FastHtmlExportProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/html/FastHtmlExportProcessor.java
@@ -25,16 +25,23 @@ import org.pentaho.reporting.engine.classic.core.layout.output.AbstractOutputPro
 import org.pentaho.reporting.engine.classic.core.layout.output.AbstractReportProcessor;
 import org.pentaho.reporting.engine.classic.core.layout.output.ContentProcessingException;
 import org.pentaho.reporting.engine.classic.core.layout.output.LogicalPageKey;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorFeature;
 import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.modules.output.fast.FastExportOutputFunction;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.html.helper.HtmlOutputProcessorMetaData;
+import org.pentaho.reporting.libraries.base.config.Configuration;
 
 public class FastHtmlExportProcessor extends AbstractReportProcessor {
   private static class HtmlDataOutputProcessor extends AbstractOutputProcessor {
     private OutputProcessorMetaData metaData;
 
     private HtmlDataOutputProcessor() {
-      metaData = new HtmlOutputProcessorMetaData( HtmlOutputProcessorMetaData.PAGINATION_NONE );
+      metaData = new HtmlOutputProcessorMetaData( HtmlOutputProcessorMetaData.PAGINATION_NONE ) {
+        public void initialize( final Configuration configuration ) {
+          super.initialize( configuration );
+          addFeature( OutputProcessorFeature.FAST_EXPORT );
+        }
+      };
     }
 
     protected void processPageContent( final LogicalPageKey logicalPageKey, final LogicalPageBox logicalPage )

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/DynamicStyleRootBandAnalyzer.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/DynamicStyleRootBandAnalyzer.java
@@ -36,13 +36,13 @@ public class DynamicStyleRootBandAnalyzer extends AbstractStructureVisitor {
   private HashNMap<String, StyleKey> styleByElementName;
 
   public DynamicStyleRootBandAnalyzer( final HashNMap<String, StyleKey> styleByElementName,
-      final HashNMap<InstanceID, StyleKey> styleById ) {
+                                       final HashNMap<InstanceID, StyleKey> styleById ) {
     this.styleByElementName = styleByElementName;
     this.dynamicTemplateInfo = new HashNMap<InstanceID, StyleKey>();
 
-    for (final InstanceID id: styleById.keySet()) {
+    for ( final InstanceID id : styleById.keySet() ) {
       Iterator<StyleKey> it = styleById.getAll( id );
-      while (it.hasNext()) {
+      while ( it.hasNext() ) {
         this.dynamicTemplateInfo.put( id, it.next() );
       }
     }
@@ -78,7 +78,7 @@ public class DynamicStyleRootBandAnalyzer extends AbstractStructureVisitor {
     String name = element.getName();
     if ( styleByElementName.containsKey( name ) ) {
       Iterator<StyleKey> it = styleByElementName.getAll( name );
-      while (it.hasNext()) {
+      while ( it.hasNext() ) {
         this.dynamicTemplateInfo.put( element.getObjectID(), it.next() );
       }
     }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/ReportDynamicStyleAnalyzerPreProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/ReportDynamicStyleAnalyzerPreProcessor.java
@@ -21,23 +21,32 @@ import org.pentaho.reporting.engine.classic.core.AbstractReportPreProcessor;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.ReportProcessingException;
 import org.pentaho.reporting.engine.classic.core.SubReport;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorFeature;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.states.datarow.DefaultFlowController;
 
 public class ReportDynamicStyleAnalyzerPreProcessor extends AbstractReportPreProcessor {
   public ReportDynamicStyleAnalyzerPreProcessor() {
   }
 
-  public MasterReport performPreProcessing( final MasterReport definition, final DefaultFlowController flowController )
+  public MasterReport performPreProcessing( final MasterReport definition,
+                                            final DefaultFlowController flowController )
     throws ReportProcessingException {
-    DynamicReportStyleAnalyzer analyzer = new DynamicReportStyleAnalyzer();
-    analyzer.compute( definition );
+    OutputProcessorMetaData meta = flowController.getReportContext().getOutputProcessorMetaData();
+    if ( meta.isFeatureSupported( OutputProcessorFeature.FAST_EXPORT )) {
+      DynamicReportStyleAnalyzer analyzer = new DynamicReportStyleAnalyzer();
+      analyzer.compute( definition );
+    }
     return definition;
   }
 
-  public SubReport performPreProcessing( final SubReport definition, final DefaultFlowController flowController )
-    throws ReportProcessingException {
-    DynamicReportStyleAnalyzer analyzer = new DynamicReportStyleAnalyzer();
-    analyzer.compute( definition );
+  public SubReport performPreProcessing( final SubReport definition,
+                                         final DefaultFlowController flowController ) throws ReportProcessingException {
+    OutputProcessorMetaData meta = flowController.getReportContext().getOutputProcessorMetaData();
+    if ( meta.isFeatureSupported( OutputProcessorFeature.FAST_EXPORT )) {
+      DynamicReportStyleAnalyzer analyzer = new DynamicReportStyleAnalyzer();
+      analyzer.compute( definition );
+    }
     return definition;
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/ReportDynamicStyleAnalyzerPreProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/validator/ReportDynamicStyleAnalyzerPreProcessor.java
@@ -33,7 +33,7 @@ public class ReportDynamicStyleAnalyzerPreProcessor extends AbstractReportPrePro
                                             final DefaultFlowController flowController )
     throws ReportProcessingException {
     OutputProcessorMetaData meta = flowController.getReportContext().getOutputProcessorMetaData();
-    if ( meta.isFeatureSupported( OutputProcessorFeature.FAST_EXPORT )) {
+    if ( meta.isFeatureSupported( OutputProcessorFeature.FAST_EXPORT ) ) {
       DynamicReportStyleAnalyzer analyzer = new DynamicReportStyleAnalyzer();
       analyzer.compute( definition );
     }
@@ -43,7 +43,7 @@ public class ReportDynamicStyleAnalyzerPreProcessor extends AbstractReportPrePro
   public SubReport performPreProcessing( final SubReport definition,
                                          final DefaultFlowController flowController ) throws ReportProcessingException {
     OutputProcessorMetaData meta = flowController.getReportContext().getOutputProcessorMetaData();
-    if ( meta.isFeatureSupported( OutputProcessorFeature.FAST_EXPORT )) {
+    if ( meta.isFeatureSupported( OutputProcessorFeature.FAST_EXPORT ) ) {
       DynamicReportStyleAnalyzer analyzer = new DynamicReportStyleAnalyzer();
       analyzer.compute( definition );
     }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/xls/FastExcelExportProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/fast/xls/FastExcelExportProcessor.java
@@ -25,9 +25,11 @@ import org.pentaho.reporting.engine.classic.core.layout.output.AbstractOutputPro
 import org.pentaho.reporting.engine.classic.core.layout.output.AbstractReportProcessor;
 import org.pentaho.reporting.engine.classic.core.layout.output.ContentProcessingException;
 import org.pentaho.reporting.engine.classic.core.layout.output.LogicalPageKey;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorFeature;
 import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.modules.output.fast.FastExportOutputFunction;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.xls.helper.ExcelOutputProcessorMetaData;
+import org.pentaho.reporting.libraries.base.config.Configuration;
 
 import java.io.OutputStream;
 
@@ -36,7 +38,12 @@ public class FastExcelExportProcessor extends AbstractReportProcessor {
     private OutputProcessorMetaData metaData;
 
     private ExcelDataOutputProcessor() {
-      metaData = new ExcelOutputProcessorMetaData( ExcelOutputProcessorMetaData.PAGINATION_NONE );
+      metaData = new ExcelOutputProcessorMetaData( ExcelOutputProcessorMetaData.PAGINATION_NONE ) {
+        public void initialize( final Configuration configuration ) {
+          super.initialize( configuration );
+          addFeature( OutputProcessorFeature.FAST_EXPORT );
+        }
+      };
     }
 
     protected void processPageContent( final LogicalPageKey logicalPageKey, final LogicalPageBox logicalPage )

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/pageable/xml/internal/XmlDocumentWriter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/pageable/xml/internal/XmlDocumentWriter.java
@@ -17,16 +17,6 @@
 
 package org.pentaho.reporting.engine.classic.core.modules.output.pageable.xml.internal;
 
-import java.awt.Color;
-import java.beans.PropertyEditor;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.util.Arrays;
-import java.util.Locale;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
@@ -75,15 +65,28 @@ import org.pentaho.reporting.libraries.fonts.encoding.EncodingRegistry;
 import org.pentaho.reporting.libraries.formatting.FastDecimalFormat;
 import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
 import org.pentaho.reporting.libraries.xmlns.common.AttributeList;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
 import org.pentaho.reporting.libraries.xmlns.writer.DefaultTagDescription;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
+
+import java.awt.*;
+import java.beans.PropertyEditor;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * @noinspection HardCodedStringLiteral
  */
 public class XmlDocumentWriter extends IterateStructuralProcessStep {
   private static final String LAYOUT_OUTPUT_NAMESPACE =
-      "http://reporting.pentaho.org/namespaces/output/layout-output/pageable/1.0";
+    "http://reporting.pentaho.org/namespaces/output/layout-output/pageable/1.0";
   private static final Log logger = LogFactory.getLog( XmlDocumentWriter.class );
 
   private OutputStream outputStream;
@@ -95,7 +98,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
   private boolean ignoreEmptyBorders = true;
   private OutputProcessorMetaData metaData;
 
-  public XmlDocumentWriter( final OutputStream outputStream, final OutputProcessorMetaData metaData ) {
+  public XmlDocumentWriter( final OutputStream outputStream,
+                            final OutputProcessorMetaData metaData ) {
     this.metaData = metaData;
     if ( outputStream == null ) {
       throw new NullPointerException();
@@ -131,8 +135,11 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     xmlWriter.close();
   }
 
-  public void processPhysicalPage( final PageGrid pageGrid, final LogicalPageBox logicalPage, final int row,
-      final int col ) throws IOException {
+  public void processPhysicalPage( final PageGrid pageGrid,
+                                   final LogicalPageBox logicalPage,
+                                   final int row,
+                                   final int col )
+    throws IOException {
     final PhysicalPageBox page = pageGrid.getPage( row, col );
     if ( page == null ) {
       return;
@@ -148,34 +155,36 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
         (float) StrictGeomUtility.toExternalValue( page.getHeight() - page.getImageableHeight() - page.getImageableY() );
 
     final AttributeList pageAttributes = new AttributeList();
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-x", pointShortConverter.format( page
-        .getGlobalX() ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-y", pointShortConverter.format( page
-        .getGlobalY() ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-width", pointShortConverter
-        .format( width ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-height", pointShortConverter
-        .format( height ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-top", pointShortConverter
-        .format( marginTop ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-left", pointShortConverter
-        .format( marginLeft ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-bottom", pointShortConverter
-        .format( marginBottom ) );
-    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-right", pointShortConverter
-        .format( marginRight ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-x",
+      pointShortConverter.format( page.getGlobalX() ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-y",
+      pointShortConverter.format( page.getGlobalY() ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-width",
+      pointShortConverter.format( width ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "page-height",
+      pointShortConverter.format( height ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-top",
+      pointShortConverter.format( marginTop ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-left",
+      pointShortConverter.format( marginLeft ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-bottom",
+      pointShortConverter.format( marginBottom ) );
+    pageAttributes.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-right",
+      pointShortConverter.format( marginRight ) );
 
     xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "physical-page", pageAttributes, XmlWriter.OPEN );
 
     // and now process the box ..
-    drawArea =
-        new StrictBounds( page.getGlobalX(), page.getGlobalY(), page.getImageableWidth(), page.getImageableHeight() );
+    drawArea = new StrictBounds( page.getGlobalX(), page.getGlobalY(),
+      page.getImageableWidth(), page.getImageableHeight() );
     processPage( logicalPage );
 
     xmlWriter.writeCloseTag();
   }
 
-  public void processLogicalPage( final LogicalPageKey key, final LogicalPageBox logicalPage ) throws IOException {
+  public void processLogicalPage( final LogicalPageKey key,
+                                  final LogicalPageBox logicalPage )
+    throws IOException {
 
     final float width = (float) StrictGeomUtility.toExternalValue( logicalPage.getPageWidth() );
     final float height = (float) StrictGeomUtility.toExternalValue( logicalPage.getPageHeight() );
@@ -203,7 +212,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     final BlockRenderBox footerArea = rootBox.getFooterArea();
     final BlockRenderBox repeatFooterArea = rootBox.getRepeatFooterArea();
     final StrictBounds headerBounds =
-        new StrictBounds( headerArea.getX(), headerArea.getY(), headerArea.getWidth(), headerArea.getHeight() );
+      new StrictBounds( headerArea.getX(), headerArea.getY(), headerArea.getWidth(), headerArea.getHeight() );
     final StrictBounds footerBounds =
         new StrictBounds( footerArea.getX(), footerArea.getY(), footerArea.getWidth(), footerArea.getHeight() );
     final StrictBounds repeatFooterBounds =
@@ -211,8 +220,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
             repeatFooterArea.getHeight() );
     final StrictBounds contentBounds =
         new StrictBounds( rootBox.getX(), headerArea.getY() + headerArea.getHeight(), rootBox.getWidth(), footerArea
-            .getY()
-            - headerArea.getHeight() );
+            .getY() - headerArea.getHeight() );
     this.drawArea = headerBounds;
     startProcessing( headerArea );
     this.drawArea = contentBounds;
@@ -227,94 +235,93 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
   private void writeElementAttributes( final RenderNode element ) throws IOException {
     final ReportAttributeMap attributes = element.getAttributes();
     final ElementType type = element.getElementType();
-    final String[] attributeNamespaces = attributes.getNameSpaces();
-    Arrays.sort( attributeNamespaces );
-    for ( int i = 0; i < attributeNamespaces.length; i++ ) {
-      final String namespace = attributeNamespaces[i];
 
+    final Set<AttributeMap.DualKey> collection = attributes.keySet();
+    final AttributeMap.DualKey[] attributeNames = collection.toArray(new AttributeMap.DualKey[collection.size()]);
+    Arrays.sort( attributeNames, new DualKeySorter() );
+
+    for ( int j = 0; j < attributeNames.length; j++ ) {
+      final String namespace = attributeNames[j].namespace;
       if ( AttributeNames.Designtime.NAMESPACE.equals( namespace ) ) {
         continue;
       }
-      final String[] attributeNames = attributes.getNames( namespace );
-      Arrays.sort( attributeNames );
-      for ( int j = 0; j < attributeNames.length; j++ ) {
-        final String name = attributeNames[j];
-        final Object value = attributes.getAttribute( namespace, name );
-        if ( value == null ) {
+      final String name = attributeNames[j].name;
+      final Object value = attributes.getAttribute( namespace, name );
+      if ( value == null ) {
+        continue;
+      }
+
+      if ( metaData.isFeatureSupported( XmlPageOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false &&
+        value instanceof ResourceKey ) {
+        continue;
+      }
+
+      final AttributeMetaData attrMeta = type.getMetaData().getAttributeDescription( namespace, name );
+      if ( attrMeta == null ) {
+        // if you want to use attributes in this output target, declare the attribute's metadata first.
+        continue;
+      }
+
+      final AttributeList attList = new AttributeList();
+      if ( value instanceof String ) {
+        final String s = (String) value;
+        if ( StringUtils.isEmpty( s ) ) {
           continue;
         }
 
-        if ( metaData.isFeatureSupported( XmlPageOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false
-            && value instanceof ResourceKey ) {
-          continue;
-        }
-
-        final AttributeMetaData attrMeta = type.getMetaData().getAttributeDescription( namespace, name );
-        if ( attrMeta == null ) {
-          // if you want to use attributes in this output target, declare the attribute's metadata first.
-          continue;
-        }
-
-        final AttributeList attList = new AttributeList();
-        if ( value instanceof String ) {
-          final String s = (String) value;
-          if ( StringUtils.isEmpty( s ) ) {
-            continue;
-          }
-
-          if ( xmlWriter.isNamespaceDefined( namespace ) == false
-              && attList.isNamespaceUriDefined( namespace ) == false ) {
-            attList.addNamespaceDeclaration( "autoGenNs", namespace );
-          }
-
-          // preserve strings, but discard anything else. Until a attribute has a definition, we cannot
-          // hope to understand the attribute's value. String-attributes can be expressed in XML easily,
-          // and string is also how all unknown attributes are stored by the parser.
-          attList.setAttribute( namespace, name, String.valueOf( value ) );
-          this.xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
-          continue;
-        }
-
-        if ( xmlWriter.isNamespaceDefined( namespace ) == false && attList.isNamespaceUriDefined( namespace ) == false ) {
+        if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
+          attList.isNamespaceUriDefined( namespace ) == false ) {
           attList.addNamespaceDeclaration( "autoGenNs", namespace );
         }
 
-        try {
-          final PropertyEditor propertyEditor = attrMeta.getEditor();
-          final String textValue;
-          if ( propertyEditor != null ) {
-            propertyEditor.setValue( value );
-            textValue = propertyEditor.getAsText();
-          } else {
-            textValue = ConverterRegistry.toAttributeValue( value );
-          }
+        // preserve strings, but discard anything else. Until a attribute has a definition, we cannot
+        // hope to understand the attribute's value. String-attributes can be expressed in XML easily,
+        // and string is also how all unknown attributes are stored by the parser.
+        attList.setAttribute( namespace, name, String.valueOf( value ) );
+        this.xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
+        continue;
+      }
 
-          if ( textValue != null ) {
-            if ( "".equals( textValue ) == false ) {
-              attList.setAttribute( namespace, name, textValue );
-              this.xmlWriter
-                  .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
-            }
-          } else {
-            if ( value instanceof ResourceKey ) {
-              final ResourceKey reskey = (ResourceKey) value;
-              final String identifierAsString = reskey.getIdentifierAsString();
-              attList.setAttribute( namespace, name, "resource-key:" + reskey.getSchema() + ":" + identifierAsString );
-              this.xmlWriter
-                  .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
-            } else {
-              XmlDocumentWriter.logger.debug( "Attribute '" + namespace + '|' + name
-                  + "' is not convertible to a text - returned null: " + value );
-            }
+      if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
+        attList.isNamespaceUriDefined( namespace ) == false ) {
+        attList.addNamespaceDeclaration( "autoGenNs", namespace );
+      }
+
+      try {
+        final PropertyEditor propertyEditor = attrMeta.getEditor();
+        final String textValue;
+        if ( propertyEditor != null ) {
+          propertyEditor.setValue( value );
+          textValue = propertyEditor.getAsText();
+        } else {
+          textValue = ConverterRegistry.toAttributeValue( value );
+        }
+
+        if ( textValue != null ) {
+          if ( "".equals( textValue ) == false ) {
+            attList.setAttribute( namespace, name, textValue );
+            this.xmlWriter
+              .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
           }
-        } catch ( BeanException e ) {
-          if ( attrMeta.isTransient() == false ) {
-            XmlDocumentWriter.logger.warn( "Attribute '" + namespace + '|' + name
-                + "' is not convertible with the bean-methods" );
+        } else {
+          if ( value instanceof ResourceKey ) {
+            final ResourceKey reskey = (ResourceKey) value;
+            final String identifierAsString = reskey.getIdentifierAsString();
+            attList.setAttribute( namespace, name, "resource-key:" + reskey.getSchema() + ":" + identifierAsString );
+            this.xmlWriter
+              .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
           } else {
-            XmlDocumentWriter.logger.debug( "Attribute '" + namespace + '|' + name
-                + "' is not convertible with the bean-methods" );
+            XmlDocumentWriter.logger.debug(
+              "Attribute '" + namespace + '|' + name + "' is not convertible to a text - returned null: " + value );
           }
+        }
+      } catch ( BeanException e ) {
+        if ( attrMeta.isTransient() == false ) {
+          XmlDocumentWriter.logger.warn(
+            "Attribute '" + namespace + '|' + name + "' is not convertible with the bean-methods" );
+        } else {
+          XmlDocumentWriter.logger.debug(
+            "Attribute '" + namespace + '|' + name + "' is not convertible with the bean-methods" );
         }
       }
     }
@@ -335,150 +342,150 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     final BorderEdge top = border.getTop();
     if ( BorderEdge.EMPTY.equals( top ) == false || ignoreEmptyBorders == false ) {
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-color",
-          convertColorToString( top ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderTop() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-style", String.valueOf( top
-          .getBorderStyle() ) );
+        convertColorToString( top ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderTop() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-style",
+        String.valueOf( top.getBorderStyle() ) );
     }
 
     final BorderEdge left = border.getLeft();
     if ( BorderEdge.EMPTY.equals( left ) == false || ignoreEmptyBorders == false ) {
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-color",
-          convertColorToString( left ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderLeft() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-style", String.valueOf( left
-          .getBorderStyle() ) );
+        convertColorToString( left ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderLeft() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-style",
+        String.valueOf( left.getBorderStyle() ) );
     }
 
     final BorderEdge bottom = border.getBottom();
     if ( BorderEdge.EMPTY.equals( bottom ) == false || ignoreEmptyBorders == false ) {
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-color",
-          convertColorToString( bottom ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderBottom() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-style", String
-          .valueOf( bottom.getBorderStyle() ) );
+        convertColorToString( bottom ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderBottom() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-style",
+        String.valueOf( bottom.getBorderStyle() ) );
     }
 
     final BorderEdge right = border.getRight();
     if ( BorderEdge.EMPTY.equals( right ) == false || ignoreEmptyBorders == false ) {
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-color",
-          convertColorToString( right ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderRight() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-style", String
-          .valueOf( right.getBorderStyle() ) );
+        convertColorToString( right ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderRight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-style",
+        String.valueOf( right.getBorderStyle() ) );
     }
 
     final BorderCorner topLeft = border.getTopLeft();
     if ( isEmptyCorner( topLeft ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topLeft.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topLeft.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topLeft.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topLeft.getHeight() ) ) );
     }
 
     final BorderCorner topRight = border.getTopRight();
     if ( isEmptyCorner( topRight ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topRight.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topRight.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topRight.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topRight.getHeight() ) ) );
     }
 
     final BorderCorner bottomLeft = border.getBottomLeft();
     if ( isEmptyCorner( bottomLeft ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomLeft.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomLeft.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomLeft.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomLeft.getHeight() ) ) );
     }
 
     final BorderCorner bottomRight = border.getBottomRight();
     if ( isEmptyCorner( bottomRight ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomRight.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomRight.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomRight.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomRight.getHeight() ) ) );
     }
 
     if ( sblp.getMarginTop() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-top", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginTop() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-top",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginTop() ) ) );
     }
     if ( sblp.getMarginLeft() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-left", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginLeft() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-left",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginLeft() ) ) );
     }
     if ( sblp.getMarginBottom() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-bottom", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginBottom() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-bottom",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginBottom() ) ) );
     }
     if ( sblp.getMarginRight() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-right", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginRight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-right",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginRight() ) ) );
     }
 
     if ( definition.getPaddingTop() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-top", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingTop() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-top",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingTop() ) ) );
     }
     if ( definition.getPaddingLeft() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-left", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingLeft() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-left",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingLeft() ) ) );
     }
     if ( definition.getPaddingBottom() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-bottom", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingBottom() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-bottom",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingBottom() ) ) );
     }
     if ( definition.getPaddingRight() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-right", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingRight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-right",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingRight() ) ) );
     }
 
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getX() ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getY() ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getWidth() ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getHeight() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getX() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getY() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getWidth() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getHeight() ) ) );
 
     final Color backgroundColor = (Color) box.getStyleSheet().getStyleProperty( ElementStyleKeys.BACKGROUND_COLOR );
     if ( backgroundColor != null ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "background-color", ColorValueConverter
-          .colorToString( backgroundColor ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "background-color",
+        ColorValueConverter.colorToString( backgroundColor ) );
     }
 
     final Color color = (Color) box.getStyleSheet().getStyleProperty( ElementStyleKeys.PAINT );
     if ( color != null ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "color", ColorValueConverter
-          .colorToString( color ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "color",
+        ColorValueConverter.colorToString( color ) );
     }
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-face", (String) box.getStyleSheet()
-        .getStyleProperty( TextStyleKeys.FONT ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-face",
+      (String) box.getStyleSheet().getStyleProperty( TextStyleKeys.FONT ) );
     final Object o = box.getStyleSheet().getStyleProperty( TextStyleKeys.FONTSIZE );
     attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-size", pointIntConverter.format( o ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-bold", String.valueOf( box
-        .getStyleSheet().getStyleProperty( TextStyleKeys.BOLD ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-italics", String.valueOf( box
-        .getStyleSheet().getStyleProperty( TextStyleKeys.ITALIC ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-underline", String.valueOf( box
-        .getStyleSheet().getStyleProperty( TextStyleKeys.UNDERLINED ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-strikethrough", String
-        .valueOf( box.getStyleSheet().getStyleProperty( TextStyleKeys.STRIKETHROUGH ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-bold",
+      String.valueOf( box.getStyleSheet().getStyleProperty( TextStyleKeys.BOLD ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-italics",
+      String.valueOf( box.getStyleSheet().getStyleProperty( TextStyleKeys.ITALIC ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-underline",
+      String.valueOf( box.getStyleSheet().getStyleProperty( TextStyleKeys.UNDERLINED ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-strikethrough",
+      String.valueOf( box.getStyleSheet().getStyleProperty( TextStyleKeys.STRIKETHROUGH ) ) );
 
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "anchor", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.ANCHOR_NAME ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.HREF_TARGET ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-window", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.HREF_WINDOW ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-title", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.HREF_TITLE ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "anchor",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.ANCHOR_NAME ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.HREF_TARGET ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-window",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.HREF_WINDOW ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-title",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.HREF_TITLE ) );
 
     return attributeList;
   }
@@ -556,14 +563,14 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       if ( nodeType == LayoutNodeTypes.TYPE_NODE_TEXT ) {
         final RenderableText text = (RenderableText) node;
         final AttributeList attributeList = new AttributeList();
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
         xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "text", attributeList, XmlWriter.OPEN );
         xmlWriter.writeTextNormalized( text.getRawText(), true );
         xmlWriter.writeCloseTag();
@@ -571,14 +578,14 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       } else if ( nodeType == LayoutNodeTypes.TYPE_NODE_COMPLEX_TEXT ) {
         final RenderableComplexText renderableComplexText = (RenderableComplexText) node;
         final AttributeList attributeList = new AttributeList();
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
 
         final String text = renderableComplexText.getRawText();
         xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "text", attributeList, XmlWriter.OPEN );
@@ -588,12 +595,12 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       } else if ( nodeType == LayoutNodeTypes.TYPE_NODE_SPACER ) {
         final SpacerRenderNode spacer = (SpacerRenderNode) node;
         final AttributeList attributeList = new AttributeList();
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "preserve", String.valueOf( spacer
-            .isDiscardable() == false ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "preserve",
+          String.valueOf( spacer.isDiscardable() == false ) );
         xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "spacer", attributeList, XmlWriter.CLOSE );
       }
     } catch ( IOException e ) {
@@ -605,33 +612,34 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     try {
       final RenderableReplacedContent prc = node.getContent();
       final AttributeList attributeList = new AttributeList();
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
       attributeList
-          .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "source", String.valueOf( prc.getSource() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( prc.getContentWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-height", pointConverter
-          .format( StrictGeomUtility.toExternalValue( prc.getContentHeight() ) ) );
+        .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "source", String.valueOf( prc.getSource() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( prc.getContentWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-height",
+        pointConverter.format( StrictGeomUtility.toExternalValue( prc.getContentHeight() ) ) );
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "requested-width",
-          convertRenderLength( prc.getRequestedWidth() ) );
+        convertRenderLength( prc.getRequestedWidth() ) );
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "requested-height",
-          convertRenderLength( prc.getRequestedHeight() ) );
+        convertRenderLength( prc.getRequestedHeight() ) );
 
       final Object o = prc.getRawObject();
       if ( o != null ) {
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "raw-object-type", o.getClass()
-            .getName() );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "raw-object-type",
+          o.getClass().getName() );
       } else {
         attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "raw-object-type", "null" );
       }
-      xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "replaced-content", attributeList, XmlWriter.OPEN );
+      xmlWriter
+        .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "replaced-content", attributeList, XmlWriter.OPEN );
       writeElementAttributes( node );
       xmlWriter.writeCloseTag();
     } catch ( IOException e ) {
@@ -678,7 +686,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       attrs.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "col-span", String.valueOf( box.getColSpan() ) );
       attrs.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "row-span", String.valueOf( box.getRowSpan() ) );
       attrs
-          .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "col-index", String.valueOf( box.getColumnIndex() ) );
+        .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "col-index", String.valueOf( box.getColumnIndex() ) );
       xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "table-cell", attrs, XmlWriter.OPEN );
       writeElementAttributes( box );
       return true;
@@ -746,12 +754,32 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
   protected boolean startBox( final RenderBox box, final String tagName ) {
     try {
-      xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, tagName, createBoxAttributeList( box ),
-          XmlWriter.OPEN );
+      xmlWriter
+        .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, tagName, createBoxAttributeList( box ), XmlWriter.OPEN );
       writeElementAttributes( box );
       return true;
     } catch ( IOException e ) {
       throw new InvalidReportStateException( e.getMessage(), e );
     }
   }
+
+  private static class DualKeySorter implements Comparator<AttributeMap.DualKey> {
+    public int compare( final AttributeMap.DualKey o1, final AttributeMap.DualKey o2 ) {
+      if (o1 == null && o2 == null) {
+        return 0;
+      }
+      if (o1 == null) {
+        return -1;
+      }
+      if (o2 == null) {
+        return 1;
+      }
+      int ns = o1.namespace.compareTo( o2.namespace );
+      if (ns != 0) {
+        return ns;
+      }
+      return o1.name.compareTo( o2.name );
+    }
+  }
+
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/pageable/xml/internal/XmlDocumentWriter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/pageable/xml/internal/XmlDocumentWriter.java
@@ -69,7 +69,7 @@ import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
 import org.pentaho.reporting.libraries.xmlns.writer.DefaultTagDescription;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
 
-import java.awt.*;
+import java.awt.Color;
 import java.beans.PropertyEditor;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -237,7 +237,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     final ElementType type = element.getElementType();
 
     final Set<AttributeMap.DualKey> collection = attributes.keySet();
-    final AttributeMap.DualKey[] attributeNames = collection.toArray(new AttributeMap.DualKey[collection.size()]);
+    final AttributeMap.DualKey[] attributeNames = collection.toArray( new AttributeMap.DualKey[ collection.size() ] );
     Arrays.sort( attributeNames, new DualKeySorter() );
 
     for ( int j = 0; j < attributeNames.length; j++ ) {
@@ -251,8 +251,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
         continue;
       }
 
-      if ( metaData.isFeatureSupported( XmlPageOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false &&
-        value instanceof ResourceKey ) {
+      if ( metaData.isFeatureSupported( XmlPageOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false
+        && value instanceof ResourceKey ) {
         continue;
       }
 
@@ -269,8 +269,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
           continue;
         }
 
-        if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
-          attList.isNamespaceUriDefined( namespace ) == false ) {
+        if ( xmlWriter.isNamespaceDefined( namespace ) == false
+          && attList.isNamespaceUriDefined( namespace ) == false ) {
           attList.addNamespaceDeclaration( "autoGenNs", namespace );
         }
 
@@ -282,8 +282,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
         continue;
       }
 
-      if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
-        attList.isNamespaceUriDefined( namespace ) == false ) {
+      if ( xmlWriter.isNamespaceDefined( namespace ) == false
+        && attList.isNamespaceUriDefined( namespace ) == false ) {
         attList.addNamespaceDeclaration( "autoGenNs", namespace );
       }
 
@@ -765,17 +765,17 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
   private static class DualKeySorter implements Comparator<AttributeMap.DualKey> {
     public int compare( final AttributeMap.DualKey o1, final AttributeMap.DualKey o2 ) {
-      if (o1 == null && o2 == null) {
+      if ( o1 == null && o2 == null ) {
         return 0;
       }
-      if (o1 == null) {
+      if ( o1 == null ) {
         return -1;
       }
-      if (o2 == null) {
+      if ( o2 == null ) {
         return 1;
       }
       int ns = o1.namespace.compareTo( o2.namespace );
-      if (ns != 0) {
+      if ( ns != 0 ) {
         return ns;
       }
       return o1.name.compareTo( o2.name );

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/base/CellBackground.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/base/CellBackground.java
@@ -23,7 +23,7 @@ import org.pentaho.reporting.engine.classic.core.layout.model.BorderEdge;
 import org.pentaho.reporting.engine.classic.core.metadata.ElementType;
 import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.ArrayList;
 
 public class CellBackground {
@@ -73,7 +73,7 @@ public class CellBackground {
       throw new NullPointerException();
     }
 
-    for (final AttributeMap.DualKey key: attrs.keySet()) {
+    for ( final AttributeMap.DualKey key : attrs.keySet() ) {
       final String namespace = key.namespace;
       final String name = key.name;
       final Object value = attrs.getAttribute( namespace, name );

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/base/CellBackground.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/base/CellBackground.java
@@ -17,13 +17,14 @@
 
 package org.pentaho.reporting.engine.classic.core.modules.output.table.base;
 
-import java.awt.Color;
-import java.util.ArrayList;
-
 import org.pentaho.reporting.engine.classic.core.ReportAttributeMap;
 import org.pentaho.reporting.engine.classic.core.layout.model.BorderCorner;
 import org.pentaho.reporting.engine.classic.core.layout.model.BorderEdge;
 import org.pentaho.reporting.engine.classic.core.metadata.ElementType;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
+
+import java.awt.*;
+import java.util.ArrayList;
 
 public class CellBackground {
   private ReportAttributeMap<Object> attributes;
@@ -43,7 +44,7 @@ public class CellBackground {
   private boolean origin;
   private ElementType elementType;
   private transient Integer hashCode;
-  private static final String[] EMPTY_ANCHORS = new String[0];
+  private static final String[] EMPTY_ANCHORS = new String[ 0 ];
 
   public CellBackground() {
     this.top = BorderEdge.EMPTY;
@@ -72,16 +73,12 @@ public class CellBackground {
       throw new NullPointerException();
     }
 
-    final String[] namespaces = attrs.getNameSpaces();
-    for ( int i = 0; i < namespaces.length; i++ ) {
-      final String namespace = namespaces[i];
-      final String[] names = attrs.getNames( namespace );
-      for ( int j = 0; j < names.length; j++ ) {
-        final String name = names[j];
-        final Object value = attrs.getAttribute( namespace, name );
-        if ( value != null ) {
-          this.attributes.setAttribute( namespace, name, value );
-        }
+    for (final AttributeMap.DualKey key: attrs.keySet()) {
+      final String namespace = key.namespace;
+      final String name = key.name;
+      final Object value = attrs.getAttribute( namespace, name );
+      if ( value != null ) {
+        this.attributes.setAttribute( namespace, name, value );
       }
     }
     this.hashCode = null;
@@ -155,10 +152,8 @@ public class CellBackground {
   /**
    * Adds two colors, the result is the mixed color of the base color and the paint color.
    *
-   * @param base
-   *          the base color
-   * @param paint
-   *          the overlay color
+   * @param base  the base color
+   * @param paint the overlay color
    * @return the merged colors.
    */
   private static Color addColor( final Color base, final Color paint ) {
@@ -291,7 +286,7 @@ public class CellBackground {
     if ( anchors == null ) {
       return EMPTY_ANCHORS;
     }
-    return anchors.toArray( new String[anchors.size()] );
+    return anchors.toArray( new String[ anchors.size() ] );
   }
 
   public void addElementType( final ElementType type ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xml/internal/XmlDocumentWriter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xml/internal/XmlDocumentWriter.java
@@ -17,16 +17,6 @@
 
 package org.pentaho.reporting.engine.classic.core.modules.output.table.xml.internal;
 
-import java.awt.Color;
-import java.beans.PropertyEditor;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.util.Arrays;
-import java.util.Locale;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
@@ -81,15 +71,29 @@ import org.pentaho.reporting.libraries.fonts.encoding.EncodingRegistry;
 import org.pentaho.reporting.libraries.formatting.FastDecimalFormat;
 import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
 import org.pentaho.reporting.libraries.xmlns.common.AttributeList;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
 import org.pentaho.reporting.libraries.xmlns.writer.DefaultTagDescription;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
+
+import java.awt.*;
+import java.beans.PropertyEditor;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * @noinspection HardCodedStringLiteral
  */
 public class XmlDocumentWriter extends IterateStructuralProcessStep {
   private static final String LAYOUT_OUTPUT_NAMESPACE =
-      "http://reporting.pentaho.org/namespaces/output/layout-output/table/1.0";
+    "http://reporting.pentaho.org/namespaces/output/layout-output/table/1.0";
   private static final Log logger = LogFactory.getLog( XmlDocumentWriter.class );
 
   private OutputStream outputStream;
@@ -103,7 +107,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
   private OutputProcessorMetaData metaData;
   private boolean tableOpen;
 
-  public XmlDocumentWriter( final OutputStream outputStream, final OutputProcessorMetaData metaData ) {
+  public XmlDocumentWriter( final OutputStream outputStream,
+                            final OutputProcessorMetaData metaData ) {
     this.metaData = metaData;
     if ( outputStream == null ) {
       throw new NullPointerException();
@@ -141,8 +146,10 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     xmlWriter.close();
   }
 
-  public void processTableContent( final LogicalPageBox logicalPageBox, final OutputProcessorMetaData metaData,
-      final TableContentProducer contentProducer, final boolean incremental ) throws IOException {
+  public void processTableContent( final LogicalPageBox logicalPageBox,
+                                   final OutputProcessorMetaData metaData,
+                                   final TableContentProducer contentProducer,
+                                   final boolean incremental ) throws IOException {
 
     // Start a new page.
     final SheetLayout sheetLayout = contentProducer.getSheetLayout();
@@ -281,151 +288,151 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
     final BorderEdge top = border.getTop();
     if ( BorderEdge.EMPTY.equals( top ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-color", ColorValueConverter
-          .colorToString( top.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderTop() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-style", String.valueOf( top
-          .getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-color",
+        ColorValueConverter.colorToString( top.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderTop() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-style",
+        String.valueOf( top.getBorderStyle() ) );
     }
 
     final BorderEdge left = border.getLeft();
     if ( BorderEdge.EMPTY.equals( left ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-color", ColorValueConverter
-          .colorToString( left.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderLeft() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-style", String.valueOf( left
-          .getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-color",
+        ColorValueConverter.colorToString( left.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderLeft() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-style",
+        String.valueOf( left.getBorderStyle() ) );
     }
 
     final BorderEdge bottom = border.getBottom();
     if ( BorderEdge.EMPTY.equals( bottom ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-color", ColorValueConverter
-          .colorToString( bottom.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderBottom() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-style", String
-          .valueOf( bottom.getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-color",
+        ColorValueConverter.colorToString( bottom.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderBottom() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-style",
+        String.valueOf( bottom.getBorderStyle() ) );
     }
 
     final BorderEdge right = border.getRight();
     if ( BorderEdge.EMPTY.equals( right ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-color", ColorValueConverter
-          .colorToString( right.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getBorderRight() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-style", String
-          .valueOf( right.getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-color",
+        ColorValueConverter.colorToString( right.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getBorderRight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-style",
+        String.valueOf( right.getBorderStyle() ) );
     }
 
     final BorderCorner topLeft = border.getTopLeft();
     if ( isEmptyCorner( topLeft ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topLeft.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topLeft.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topLeft.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topLeft.getHeight() ) ) );
     }
 
     final BorderCorner topRight = border.getTopRight();
     if ( isEmptyCorner( topRight ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topRight.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topRight.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topRight.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topRight.getHeight() ) ) );
     }
 
     final BorderCorner bottomLeft = border.getBottomLeft();
     if ( isEmptyCorner( bottomLeft ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomLeft.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomLeft.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomLeft.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomLeft.getHeight() ) ) );
     }
 
     final BorderCorner bottomRight = border.getBottomRight();
     if ( isEmptyCorner( bottomRight ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomRight.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomRight.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomRight.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomRight.getHeight() ) ) );
     }
 
     if ( sblp.getMarginTop() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-top", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginTop() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-top",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginTop() ) ) );
     }
     if ( sblp.getMarginLeft() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-left", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginLeft() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-left",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginLeft() ) ) );
     }
     if ( sblp.getMarginBottom() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-bottom", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginBottom() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-bottom",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginBottom() ) ) );
     }
     if ( sblp.getMarginRight() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-right", pointConverter
-          .format( StrictGeomUtility.toExternalValue( sblp.getMarginRight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "margin-right",
+        pointConverter.format( StrictGeomUtility.toExternalValue( sblp.getMarginRight() ) ) );
     }
 
     if ( definition.getPaddingTop() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-top", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingTop() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-top",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingTop() ) ) );
     }
     if ( definition.getPaddingLeft() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-left", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingLeft() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-left",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingLeft() ) ) );
     }
     if ( definition.getPaddingBottom() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-bottom", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingBottom() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-bottom",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingBottom() ) ) );
     }
     if ( definition.getPaddingRight() > 0 ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-right", pointConverter
-          .format( StrictGeomUtility.toExternalValue( definition.getPaddingRight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "padding-right",
+        pointConverter.format( StrictGeomUtility.toExternalValue( definition.getPaddingRight() ) ) );
     }
 
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getX() ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getY() ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getWidth() ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-        .format( StrictGeomUtility.toExternalValue( box.getHeight() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getX() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getY() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getWidth() ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+      pointConverter.format( StrictGeomUtility.toExternalValue( box.getHeight() ) ) );
 
     final Color backgroundColor = (Color) box.getStyleSheet().getStyleProperty( ElementStyleKeys.BACKGROUND_COLOR );
     if ( backgroundColor != null ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "background-color", ColorValueConverter
-          .colorToString( backgroundColor ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "background-color",
+        ColorValueConverter.colorToString( backgroundColor ) );
     }
 
     final Color color = (Color) box.getStyleSheet().getStyleProperty( ElementStyleKeys.PAINT );
     if ( color != null ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "color", ColorValueConverter
-          .colorToString( color ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "color",
+        ColorValueConverter.colorToString( color ) );
     }
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-face", (String) box.getStyleSheet()
-        .getStyleProperty( TextStyleKeys.FONT ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-face",
+      (String) box.getStyleSheet().getStyleProperty( TextStyleKeys.FONT ) );
     final Object o = box.getStyleSheet().getStyleProperty( TextStyleKeys.FONTSIZE );
     attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-size", pointIntConverter.format( o ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-bold", String.valueOf( box
-        .getStyleSheet().getStyleProperty( TextStyleKeys.BOLD ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-italics", String.valueOf( box
-        .getStyleSheet().getStyleProperty( TextStyleKeys.ITALIC ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-underline", String.valueOf( box
-        .getStyleSheet().getStyleProperty( TextStyleKeys.UNDERLINED ) ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-strikethrough", String
-        .valueOf( box.getStyleSheet().getStyleProperty( TextStyleKeys.STRIKETHROUGH ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-bold", String.valueOf(
+      box.getStyleSheet().getStyleProperty( TextStyleKeys.BOLD ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-italics", String.valueOf(
+      box.getStyleSheet().getStyleProperty( TextStyleKeys.ITALIC ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-underline", String.valueOf(
+      box.getStyleSheet().getStyleProperty( TextStyleKeys.UNDERLINED ) ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "font-style-strikethrough", String.valueOf(
+      box.getStyleSheet().getStyleProperty( TextStyleKeys.STRIKETHROUGH ) ) );
 
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "anchor", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.ANCHOR_NAME ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.HREF_TARGET ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-window", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.HREF_WINDOW ) );
-    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-title", (String) box.getStyleSheet()
-        .getStyleProperty( ElementStyleKeys.HREF_TITLE ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "anchor",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.ANCHOR_NAME ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.HREF_TARGET ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-window",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.HREF_WINDOW ) );
+    attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "href-title",
+      (String) box.getStyleSheet().getStyleProperty( ElementStyleKeys.HREF_TITLE ) );
 
     return attributeList;
   }
@@ -440,97 +447,98 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     if ( type == null ) {
       type = AutoLayoutBoxType.INSTANCE;
     }
-    final String[] attributeNamespaces = attributes.getNameSpaces();
-    Arrays.sort( attributeNamespaces );
-    for ( int i = 0; i < attributeNamespaces.length; i++ ) {
-      final String namespace = attributeNamespaces[i];
+
+    final Set<AttributeMap.DualKey> collection = attributes.keySet();
+    final AttributeMap.DualKey[] attributeNames = collection.toArray(new AttributeMap.DualKey[collection.size()]);
+    Arrays.sort( attributeNames, new DualKeySorter() );
+    for ( int j = 0; j < attributeNames.length; j++ ) {
+
+      final String namespace = attributeNames[ j ].namespace;
       if ( AttributeNames.Designtime.NAMESPACE.equals( namespace ) ) {
         continue;
       }
 
-      final String[] attributeNames = attributes.getNames( namespace );
-      Arrays.sort( attributeNames );
-      for ( int j = 0; j < attributeNames.length; j++ ) {
-        final String name = attributeNames[j];
-        final Object value = attributes.getAttribute( namespace, name );
-        if ( value == null ) {
-          continue;
-        }
-        if ( metaData.isFeatureSupported( XmlTableOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false
-            && value instanceof ResourceKey ) {
-          continue;
-        }
+      final String name = attributeNames[ j ].name;
+      final Object value = attributes.getAttribute( namespace, name );
+      if ( value == null ) {
+        continue;
+      }
 
-        final AttributeMetaData attrMeta = type.getMetaData().getAttributeDescription( namespace, name );
-        if ( attrMeta == null ) {
-          // if you want to use attributes in this output target, declare the attribute's metadata first.
-          continue;
-        }
+      if ( metaData.isFeatureSupported( XmlTableOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false &&
+        value instanceof ResourceKey ) {
+        continue;
+      }
 
-        final AttributeList attList = new AttributeList();
-        if ( value instanceof String ) {
-          final String s = (String) value;
-          if ( StringUtils.isEmpty( s ) ) {
-            continue;
-          }
 
-          if ( xmlWriter.isNamespaceDefined( namespace ) == false
-              && attList.isNamespaceUriDefined( namespace ) == false ) {
-            attList.addNamespaceDeclaration( "autoGenNs", namespace );
-          }
+      final AttributeMetaData attrMeta = type.getMetaData().getAttributeDescription( namespace, name );
+      if ( attrMeta == null ) {
+        // if you want to use attributes in this output target, declare the attribute's metadata first.
+        continue;
+      }
 
-          // preserve strings, but discard anything else. Until a attribute has a definition, we cannot
-          // hope to understand the attribute's value. String-attributes can be expressed in XML easily,
-          // and string is also how all unknown attributes are stored by the parser.
-          attList.setAttribute( namespace, name, s );
-          this.xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
+      final AttributeList attList = new AttributeList();
+      if ( value instanceof String ) {
+        final String s = (String) value;
+        if ( StringUtils.isEmpty( s ) ) {
           continue;
         }
 
-        if ( xmlWriter.isNamespaceDefined( namespace ) == false && attList.isNamespaceUriDefined( namespace ) == false ) {
+        if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
+          attList.isNamespaceUriDefined( namespace ) == false ) {
           attList.addNamespaceDeclaration( "autoGenNs", namespace );
         }
 
-        try {
-          final PropertyEditor propertyEditor = attrMeta.getEditor();
-          final String textValue;
-          if ( propertyEditor != null ) {
-            propertyEditor.setValue( value );
-            textValue = propertyEditor.getAsText();
-          } else {
-            textValue = ConverterRegistry.toAttributeValue( value );
-          }
+        // preserve strings, but discard anything else. Until a attribute has a definition, we cannot
+        // hope to understand the attribute's value. String-attributes can be expressed in XML easily,
+        // and string is also how all unknown attributes are stored by the parser.
+        attList.setAttribute( namespace, name, s );
+        this.xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
+        continue;
+      }
 
-          if ( textValue != null ) {
-            if ( "".equals( textValue ) == false ) {
-              attList.setAttribute( namespace, name, textValue );
-              this.xmlWriter
-                  .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
-            }
-          } else {
-            if ( value instanceof ResourceKey ) {
-              final ResourceKey reskey = (ResourceKey) value;
-              final String identifierAsString = reskey.getIdentifierAsString();
-              attList.setAttribute( namespace, name, "resource-key:" + reskey.getSchema() + ":" + identifierAsString );
-              this.xmlWriter
-                  .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
-            } else {
-              XmlDocumentWriter.logger.debug( "Attribute '" + namespace + '|' + name
-                  + "' is not convertible to a text - returned null: " + value );
-            }
+      if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
+        attList.isNamespaceUriDefined( namespace ) == false ) {
+        attList.addNamespaceDeclaration( "autoGenNs", namespace );
+      }
+
+      try {
+        final PropertyEditor propertyEditor = attrMeta.getEditor();
+        final String textValue;
+        if ( propertyEditor != null ) {
+          propertyEditor.setValue( value );
+          textValue = propertyEditor.getAsText();
+        } else {
+          textValue = ConverterRegistry.toAttributeValue( value );
+        }
+
+        if ( textValue != null ) {
+          if ( "".equals( textValue ) == false ) {
+            attList.setAttribute( namespace, name, textValue );
+            this.xmlWriter
+              .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
           }
-        } catch ( BeanException e ) {
-          if ( attrMeta.isTransient() == false ) {
-            XmlDocumentWriter.logger.warn( "Attribute '" + namespace + '|' + name
-                + "' is not convertible with the bean-methods" );
+        } else {
+          if ( value instanceof ResourceKey ) {
+            final ResourceKey reskey = (ResourceKey) value;
+            final String identifierAsString = reskey.getIdentifierAsString();
+            attList.setAttribute( namespace, name, "resource-key:" + reskey.getSchema() + ":" + identifierAsString );
+            this.xmlWriter
+              .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "attribute", attList, XmlWriter.CLOSE );
           } else {
-            XmlDocumentWriter.logger.debug( "Attribute '" + namespace + '|' + name
-                + "' is not convertible with the bean-methods" );
+            XmlDocumentWriter.logger.debug(
+              "Attribute '" + namespace + '|' + name + "' is not convertible to a text - returned null: " + value );
           }
+        }
+      } catch ( BeanException e ) {
+        if ( attrMeta.isTransient() == false ) {
+          XmlDocumentWriter.logger.warn(
+            "Attribute '" + namespace + '|' + name + "' is not convertible with the bean-methods" );
+        } else {
+          XmlDocumentWriter.logger.debug(
+            "Attribute '" + namespace + '|' + name + "' is not convertible with the bean-methods" );
         }
       }
     }
-
   }
 
   private boolean isEmptyCorner( final BorderCorner corner ) {
@@ -545,87 +553,87 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
     final BorderEdge top = border.getTop();
     if ( BorderEdge.EMPTY.equals( top ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-color", ColorValueConverter
-          .colorToString( top.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( top.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-style", String.valueOf( top
-          .getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-color",
+        ColorValueConverter.colorToString( top.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( top.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-style",
+        String.valueOf( top.getBorderStyle() ) );
     }
 
     final BorderEdge left = border.getLeft();
     if ( BorderEdge.EMPTY.equals( left ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-color", ColorValueConverter
-          .colorToString( left.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( left.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-style", String.valueOf( left
-          .getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-color",
+        ColorValueConverter.colorToString( left.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( left.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-left-style",
+        String.valueOf( left.getBorderStyle() ) );
     }
 
     final BorderEdge bottom = border.getBottom();
     if ( BorderEdge.EMPTY.equals( bottom ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-color", ColorValueConverter
-          .colorToString( bottom.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottom.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-style", String
-          .valueOf( bottom.getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-color",
+        ColorValueConverter.colorToString( bottom.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottom.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-style",
+        String.valueOf( bottom.getBorderStyle() ) );
     }
 
     final BorderEdge right = border.getRight();
     if ( BorderEdge.EMPTY.equals( right ) == false || ignoreEmptyBorders == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-color", ColorValueConverter
-          .colorToString( right.getColor() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( right.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-style", String
-          .valueOf( right.getBorderStyle() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-color",
+        ColorValueConverter.colorToString( right.getColor() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( right.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-right-style",
+        String.valueOf( right.getBorderStyle() ) );
     }
 
     final BorderCorner topLeft = border.getTopLeft();
     if ( isEmptyCorner( topLeft ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topLeft.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topLeft.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topLeft.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-left-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topLeft.getHeight() ) ) );
     }
 
     final BorderCorner topRight = border.getTopRight();
     if ( isEmptyCorner( topRight ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topRight.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( topRight.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topRight.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-top-right-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( topRight.getHeight() ) ) );
     }
 
     final BorderCorner bottomLeft = border.getBottomLeft();
     if ( isEmptyCorner( bottomLeft ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomLeft.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomLeft.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomLeft.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-left-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomLeft.getHeight() ) ) );
     }
 
     final BorderCorner bottomRight = border.getBottomRight();
     if ( isEmptyCorner( bottomRight ) == false ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomRight.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( bottomRight.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomRight.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "border-bottom-right-y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( bottomRight.getHeight() ) ) );
     }
 
     final Color backgroundColor = border.getBackgroundColor();
     if ( backgroundColor != null ) {
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "background-color", ColorValueConverter
-          .colorToString( backgroundColor ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "background-color",
+        ColorValueConverter.colorToString( backgroundColor ) );
     }
 
     final String[] anchors = border.getAnchors();
     if ( anchors.length > 0 ) {
       final StringBuilder anchorText = new StringBuilder( 100 );
       for ( int i = 0; i < anchors.length; i++ ) {
-        final String anchor = anchors[i];
+        final String anchor = anchors[ i ];
         if ( i == 0 ) {
           anchorText.append( ' ' );
         }
@@ -675,7 +683,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
   protected boolean startOtherBox( final RenderBox box ) {
     try {
       xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "other-box", createBoxAttributeList( box ),
-          XmlWriter.OPEN );
+        XmlWriter.OPEN );
       writeElementAttributes( box );
       return true;
     } catch ( IOException e ) {
@@ -694,7 +702,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
   private boolean startBox( final RenderBox box, final String tagName ) {
     try {
       xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, tagName, createBoxAttributeList( box ),
-          XmlWriter.OPEN );
+        XmlWriter.OPEN );
       writeElementAttributes( box );
       return true;
     } catch ( IOException e ) {
@@ -708,8 +716,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
   protected boolean startRowBox( final RenderBox box ) {
     try {
-      xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "row", createBoxAttributeList( box ),
-          XmlWriter.OPEN );
+      xmlWriter
+        .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "row", createBoxAttributeList( box ), XmlWriter.OPEN );
       writeElementAttributes( box );
       return true;
     } catch ( IOException e ) {
@@ -735,14 +743,14 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       if ( nodeType == LayoutNodeTypes.TYPE_NODE_TEXT ) {
         final RenderableText text = (RenderableText) node;
         final AttributeList attributeList = new AttributeList();
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
         xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "text", attributeList, XmlWriter.OPEN );
         xmlWriter.writeTextNormalized( text.getRawText(), true );
         xmlWriter.writeCloseTag();
@@ -750,14 +758,14 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       } else if ( nodeType == LayoutNodeTypes.TYPE_NODE_COMPLEX_TEXT ) {
         final RenderableComplexText renderableComplexText = (RenderableComplexText) node;
         final AttributeList attributeList = new AttributeList();
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
 
         final String text = renderableComplexText.getRawText();
         xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "text", attributeList, XmlWriter.OPEN );
@@ -767,12 +775,12 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       } else if ( nodeType == LayoutNodeTypes.TYPE_NODE_SPACER ) {
         final SpacerRenderNode spacer = (SpacerRenderNode) node;
         final AttributeList attributeList = new AttributeList();
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-            .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "preserve", String.valueOf( spacer
-            .isDiscardable() == false ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+          pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "preserve",
+          String.valueOf( spacer.isDiscardable() == false ) );
         xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "spacer", attributeList, XmlWriter.CLOSE );
       }
     } catch ( IOException e ) {
@@ -784,33 +792,34 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     try {
       final RenderableReplacedContent prc = node.getContent();
       final AttributeList attributeList = new AttributeList();
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height", pointConverter
-          .format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "x",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getX() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "y",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getY() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "height",
+        pointConverter.format( StrictGeomUtility.toExternalValue( node.getHeight() ) ) );
       attributeList
-          .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "source", String.valueOf( prc.getSource() ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-width", pointConverter
-          .format( StrictGeomUtility.toExternalValue( prc.getContentWidth() ) ) );
-      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-height", pointConverter
-          .format( StrictGeomUtility.toExternalValue( prc.getContentHeight() ) ) );
+        .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "source", String.valueOf( prc.getSource() ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-width",
+        pointConverter.format( StrictGeomUtility.toExternalValue( prc.getContentWidth() ) ) );
+      attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "content-height",
+        pointConverter.format( StrictGeomUtility.toExternalValue( prc.getContentHeight() ) ) );
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "requested-width",
-          convertRenderLength( prc.getRequestedWidth() ) );
+        convertRenderLength( prc.getRequestedWidth() ) );
       attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "requested-height",
-          convertRenderLength( prc.getRequestedHeight() ) );
+        convertRenderLength( prc.getRequestedHeight() ) );
 
       final Object o = prc.getRawObject();
       if ( o != null ) {
-        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "raw-object-type", o.getClass()
-            .getName() );
+        attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "raw-object-type",
+          o.getClass().getName() );
       } else {
         attributeList.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "raw-object-type", "null" );
       }
-      xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "replaced-content", attributeList, XmlWriter.OPEN );
+      xmlWriter
+        .writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "replaced-content", attributeList, XmlWriter.OPEN );
       writeElementAttributes( node );
       xmlWriter.writeCloseTag();
     } catch ( IOException e ) {
@@ -842,7 +851,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
       attrs.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "col-span", String.valueOf( box.getColSpan() ) );
       attrs.setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "row-span", String.valueOf( box.getRowSpan() ) );
       attrs
-          .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "col-index", String.valueOf( box.getColumnIndex() ) );
+        .setAttribute( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "col-index", String.valueOf( box.getColumnIndex() ) );
       xmlWriter.writeTag( XmlDocumentWriter.LAYOUT_OUTPUT_NAMESPACE, "table-cell", attrs, XmlWriter.OPEN );
       writeElementAttributes( box );
       return true;
@@ -893,6 +902,25 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
   protected void finishAutoBox( final RenderBox box ) {
     finishBox();
+  }
+
+  private static class DualKeySorter implements Comparator<AttributeMap.DualKey> {
+    public int compare( final AttributeMap.DualKey o1, final AttributeMap.DualKey o2 ) {
+      if (o1 == null && o2 == null) {
+        return 0;
+      }
+      if (o1 == null) {
+        return -1;
+      }
+      if (o2 == null) {
+        return 1;
+      }
+      int ns = o1.namespace.compareTo( o2.namespace );
+      if (ns != 0) {
+        return ns;
+      }
+      return o1.name.compareTo( o2.name );
+    }
   }
 
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xml/internal/XmlDocumentWriter.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xml/internal/XmlDocumentWriter.java
@@ -75,7 +75,7 @@ import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
 import org.pentaho.reporting.libraries.xmlns.writer.DefaultTagDescription;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
 
-import java.awt.*;
+import java.awt.Color;
 import java.beans.PropertyEditor;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -83,7 +83,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.Set;
@@ -449,7 +448,7 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
     }
 
     final Set<AttributeMap.DualKey> collection = attributes.keySet();
-    final AttributeMap.DualKey[] attributeNames = collection.toArray(new AttributeMap.DualKey[collection.size()]);
+    final AttributeMap.DualKey[] attributeNames = collection.toArray( new AttributeMap.DualKey[ collection.size() ] );
     Arrays.sort( attributeNames, new DualKeySorter() );
     for ( int j = 0; j < attributeNames.length; j++ ) {
 
@@ -464,8 +463,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
         continue;
       }
 
-      if ( metaData.isFeatureSupported( XmlTableOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false &&
-        value instanceof ResourceKey ) {
+      if ( metaData.isFeatureSupported( XmlTableOutputProcessorMetaData.WRITE_RESOURCEKEYS ) == false
+        && value instanceof ResourceKey ) {
         continue;
       }
 
@@ -483,8 +482,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
           continue;
         }
 
-        if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
-          attList.isNamespaceUriDefined( namespace ) == false ) {
+        if ( xmlWriter.isNamespaceDefined( namespace ) == false
+          && attList.isNamespaceUriDefined( namespace ) == false ) {
           attList.addNamespaceDeclaration( "autoGenNs", namespace );
         }
 
@@ -496,8 +495,8 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
         continue;
       }
 
-      if ( xmlWriter.isNamespaceDefined( namespace ) == false &&
-        attList.isNamespaceUriDefined( namespace ) == false ) {
+      if ( xmlWriter.isNamespaceDefined( namespace ) == false
+        && attList.isNamespaceUriDefined( namespace ) == false ) {
         attList.addNamespaceDeclaration( "autoGenNs", namespace );
       }
 
@@ -906,17 +905,17 @@ public class XmlDocumentWriter extends IterateStructuralProcessStep {
 
   private static class DualKeySorter implements Comparator<AttributeMap.DualKey> {
     public int compare( final AttributeMap.DualKey o1, final AttributeMap.DualKey o2 ) {
-      if (o1 == null && o2 == null) {
+      if ( o1 == null && o2 == null ) {
         return 0;
       }
-      if (o1 == null) {
+      if ( o1 == null ) {
         return -1;
       }
-      if (o2 == null) {
+      if ( o2 == null ) {
         return 1;
       }
       int ns = o1.namespace.compareTo( o2.namespace );
-      if (ns != 0) {
+      if ( ns != 0 ) {
         return ns;
       }
       return o1.name.compareTo( o2.name );

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/ReportState.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/ReportState.java
@@ -1,19 +1,19 @@
 /*
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
- * Foundation.
- *
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
- * or from the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
- */
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+*/
 
 package org.pentaho.reporting.engine.classic.core.states;
 
@@ -22,6 +22,7 @@ import org.pentaho.reporting.engine.classic.core.ReportDefinition;
 import org.pentaho.reporting.engine.classic.core.ResourceBundleFactory;
 import org.pentaho.reporting.engine.classic.core.layout.InlineSubreportMarker;
 import org.pentaho.reporting.engine.classic.core.states.datarow.DefaultFlowController;
+import org.pentaho.reporting.engine.classic.core.states.process.ReportProcessStore;
 
 /**
  * Creation-Date: 03.07.2007, 13:18:11
@@ -123,5 +124,7 @@ public interface ReportState extends Cloneable {
 
   public long getCrosstabColumnSequenceCounter( final int groupIndex );
 
-  PerformanceMonitorContext getPerformanceMonitorContext();
+  public PerformanceMonitorContext getPerformanceMonitorContext();
+
+  public ReportProcessStore getProcessStore();
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/ReportState.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/ReportState.java
@@ -33,11 +33,11 @@ public interface ReportState extends Cloneable {
   /**
    * A row number that is 'before' the first row.
    */
-  public static final int BEFORE_FIRST_ROW = -1;
+  int BEFORE_FIRST_ROW = -1;
   /**
    * A group number that is 'before' the first group.
    */
-  public static final int BEFORE_FIRST_GROUP = -1;
+  int BEFORE_FIRST_GROUP = -1;
 
   int getNumberOfRows();
 
@@ -82,49 +82,49 @@ public interface ReportState extends Cloneable {
    */
   int getEventCode();
 
-  public Object clone() throws CloneNotSupportedException;
+  Object clone() throws CloneNotSupportedException;
 
-  public DefaultFlowController getFlowController();
+  DefaultFlowController getFlowController();
 
-  public boolean isSubReportEvent();
+  boolean isSubReportEvent();
 
-  public void setErrorHandler( ReportProcessingErrorHandler errorHandler );
+  void setErrorHandler( ReportProcessingErrorHandler errorHandler );
 
-  public InlineSubreportMarker getCurrentSubReportMarker();
+  InlineSubreportMarker getCurrentSubReportMarker();
 
-  public ReportProcessingErrorHandler getErrorHandler();
+  ReportProcessingErrorHandler getErrorHandler();
 
-  public LayoutProcess getLayoutProcess();
+  LayoutProcess getLayoutProcess();
 
-  public void firePageFinishedEvent( final boolean noParentPassing );
+  void firePageFinishedEvent( final boolean noParentPassing );
 
-  public void firePageStartedEvent( final int eventCode );
+  void firePageStartedEvent( final int eventCode );
 
-  public ReportState getParentState();
+  ReportState getParentState();
 
-  public ReportState getParentSubReportState();
+  ReportState getParentSubReportState();
 
-  public ReportStateKey getProcessKey();
+  ReportStateKey getProcessKey();
 
-  public boolean isInItemGroup();
+  boolean isInItemGroup();
 
-  public boolean isInlineProcess();
+  boolean isInlineProcess();
 
-  public ResourceBundleFactory getResourceBundleFactory();
+  ResourceBundleFactory getResourceBundleFactory();
 
-  public GroupingState createGroupingState();
+  GroupingState createGroupingState();
 
-  public Integer getPredictedStateCount();
+  Integer getPredictedStateCount();
 
-  public boolean isStructuralPreprocessingNeeded();
+  boolean isStructuralPreprocessingNeeded();
 
-  public boolean isCrosstabActive();
+  boolean isCrosstabActive();
 
-  public long getGroupSequenceCounter( final int groupIndex );
+  long getGroupSequenceCounter( final int groupIndex );
 
-  public long getCrosstabColumnSequenceCounter( final int groupIndex );
+  long getCrosstabColumnSequenceCounter( final int groupIndex );
 
-  public PerformanceMonitorContext getPerformanceMonitorContext();
+  PerformanceMonitorContext getPerformanceMonitorContext();
 
-  public ReportProcessStore getProcessStore();
+  ReportProcessStore getProcessStore();
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/SubReportStorage.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/SubReportStorage.java
@@ -39,7 +39,7 @@ public class SubReportStorage implements Serializable {
     }
 
     // derive would regenerate instance-IDs, which is not advisable.
-    storage.put( key, subReport.derive(true) );
+    storage.put( key, subReport.derive( true ) );
   }
 
   public SubReport restore( final FunctionStorageKey key ) throws ReportProcessingException {
@@ -52,7 +52,7 @@ public class SubReportStorage implements Serializable {
       return null;
     }
 
-    return subReport.derive(true);
+    return subReport.derive( true );
   }
 
   public boolean contains( final FunctionStorageKey key ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/SubReportStorage.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/SubReportStorage.java
@@ -39,7 +39,7 @@ public class SubReportStorage implements Serializable {
     }
 
     // derive would regenerate instance-IDs, which is not advisable.
-    storage.put( key, subReport );
+    storage.put( key, subReport.derive(true) );
   }
 
   public SubReport restore( final FunctionStorageKey key ) throws ReportProcessingException {
@@ -52,7 +52,7 @@ public class SubReportStorage implements Serializable {
       return null;
     }
 
-    return subReport;
+    return subReport.derive(true);
   }
 
   public boolean contains( final FunctionStorageKey key ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ProcessState.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ProcessState.java
@@ -234,8 +234,8 @@ public class ProcessState implements ReportState {
         final ValidationResult validationResult =
           reportParameterValidator.validate( new ValidationResult(), parameters, parameterContext );
         if ( validationResult.isEmpty() == false ) {
-          throw new ReportParameterValidationException
-            ( "The parameters provided for this report are not valid.", validationResult );
+          throw new ReportParameterValidationException( "The parameters provided for this report are not valid.",
+            validationResult );
         }
         parameterValues = validationResult.getParameterValues();
       } finally {
@@ -250,8 +250,8 @@ public class ProcessState implements ReportState {
     this.performanceMonitorContext = new InternalPerformanceMonitorContext( rawPerformanceMonitorContext );
     final InitialLayoutProcess layoutProcess = new InitialLayoutProcess( outputFunction, performanceMonitorContext );
 
-    this.reportInstancesShareConnection = "true".equals( processingContext.getConfiguration().getConfigProperty
-      ( "org.pentaho.reporting.engine.classic.core.ReportInstancesShareConnections" ) );
+    this.reportInstancesShareConnection = "true".equals( processingContext.getConfiguration()
+      .getConfigProperty( "org.pentaho.reporting.engine.classic.core.ReportInstancesShareConnections" ) );
     this.processLevels = new HashSet<Integer>();
     this.groupStarts = new FastStack<GroupStartRecord>();
     this.errorHandler = IgnoreEverythingReportErrorHandler.INSTANCE;
@@ -263,8 +263,9 @@ public class ProcessState implements ReportState {
     this.functionStorage = new FunctionStorage();
     this.structureFunctionStorage = new FunctionStorage();
     this.sequenceCounter = 0;
-    this.processKey = new ReportStateKey
-      ( null, ReportState.BEFORE_FIRST_ROW, 0, ReportState.BEFORE_FIRST_GROUP, -1, sequenceCounter, false, false );
+    this.processKey =
+      new ReportStateKey( null, ReportState.BEFORE_FIRST_ROW, 0, ReportState.BEFORE_FIRST_GROUP, -1, sequenceCounter,
+        false, false );
     this.dataFactoryManager = new DataFactoryManager();
     this.subReportStorage = new SubReportStorage();
     this.processHandle = new InternalProcessHandle( dataFactoryManager, performanceMonitorContext );
@@ -313,8 +314,8 @@ public class ProcessState implements ReportState {
     this.queryLimit = (Integer) ConverterRegistry.convert( queryLimitRaw, Integer.class, queryLimitDefault );
     this.queryTimeout = (Integer) ConverterRegistry.convert( queryTimeoutRaw, Integer.class, queryTimeoutDefault );
 
-    DefaultFlowController postQueryFlowController = flowController.performQuery
-      ( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
+    DefaultFlowController postQueryFlowController =
+      flowController.performQuery( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
         processingContext.getResourceBundleFactory(), sortOrder );
 
     final MasterReportProcessPreprocessor postProcessor =
@@ -422,8 +423,8 @@ public class ProcessState implements ReportState {
   }
 
   private boolean isReportsShareConnections( final ReportDefinition report ) {
-    final Object attribute = report.getAttribute
-      ( AttributeNames.Internal.NAMESPACE, AttributeNames.Internal.SHARED_CONNECTIONS );
+    final Object attribute =
+      report.getAttribute( AttributeNames.Internal.NAMESPACE, AttributeNames.Internal.SHARED_CONNECTIONS );
     if ( Boolean.TRUE.equals( attribute ) ) {
       return true;
     }
@@ -470,8 +471,8 @@ public class ProcessState implements ReportState {
       parentState.isInlineProcess() || currentSubReportMarker.getProcessType() == SubReportProcessType.INLINE;
 
     final SubReport subreportFromMarker = currentSubReportMarker.getSubreport();
-    final FunctionStorageKey functionStorageKey = FunctionStorageKey.createKey
-      ( parentSubReportState.getProcessKey(), subreportFromMarker );
+    final FunctionStorageKey functionStorageKey =
+      FunctionStorageKey.createKey( parentSubReportState.getProcessKey(), subreportFromMarker );
     final boolean needPreProcessing;
     final SubReport initialSubReport;
     if ( subReportStorage.contains( functionStorageKey ) ) {
@@ -496,8 +497,8 @@ public class ProcessState implements ReportState {
         subreportFromMarker.getParentSection() );
       this.flowController = parentStateFlowController.derive();
       this.advanceHandler = EndSubReportHandler.HANDLER;
-      this.layoutProcess = new SubLayoutProcess
-        ( parentState.layoutProcess, computeStructureFunctions( initialSubReport.getStructureFunctions(),
+      this.layoutProcess = new SubLayoutProcess( parentState.layoutProcess,
+        computeStructureFunctions( initialSubReport.getStructureFunctions(),
           flowController.getReportContext().getOutputProcessorMetaData() ), this.report.getObjectID() );
     } else {
       DataFactory dataFactory =
@@ -555,8 +556,8 @@ public class ProcessState implements ReportState {
       final List<SortConstraint> sortOrder = lookupSortOrder( preDataSubReport );
 
 
-      DefaultFlowController postQueryFlowController = flowController.performSubReportQuery
-        ( query, queryLimit.intValue(), queryTimeout.intValue(), exportMappings, sortOrder );
+      DefaultFlowController postQueryFlowController = flowController
+        .performSubReportQuery( query, queryLimit.intValue(), queryTimeout.intValue(), exportMappings, sortOrder );
       final ProxyDataSchemaDefinition schemaDefinition =
         new ProxyDataSchemaDefinition( preDataSubReport.getDataSchemaDefinition(),
           postQueryFlowController.getMasterRow().getDataSchemaDefinition() );
@@ -805,19 +806,20 @@ public class ProcessState implements ReportState {
       parentStateKey = parentState.getProcessKey();
     }
 
-    final CachingDataFactory dataFactory = state.dataFactoryManager.restore
-      ( FunctionStorageKey.createKey( parentStateKey, state.getReport() ), isReportsShareConnections( report ) );
+    final CachingDataFactory dataFactory = state.dataFactoryManager
+      .restore( FunctionStorageKey.createKey( parentStateKey, state.getReport() ),
+        isReportsShareConnections( report ) );
     if ( dataFactory == null ) {
       throw new ReportProcessingException( "No data factory on restart()? Somewhere we went wrong." );
     }
 
     final DefaultFlowController fc = state.getFlowController();
     final DefaultFlowController cfc = fc.restart();
-    final DefaultFlowController qfc = cfc.performQuery
-      ( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
+    final DefaultFlowController qfc =
+      cfc.performQuery( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
         fc.getMasterRow().getResourceBundleFactory(), lookupSortOrder( state.report ) );
-    final Expression[] expressions = getFunctionStorage().restore
-      ( FunctionStorageKey.createKey( null, state.getReport() ) );
+    final Expression[] expressions =
+      getFunctionStorage().restore( FunctionStorageKey.createKey( null, state.getReport() ) );
     final DefaultFlowController efc = qfc.activateExpressions( expressions, true );
     state.setFlowController( efc );
     state.sequenceCounter += 1;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ProcessState.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ProcessState.java
@@ -1,19 +1,19 @@
 /*
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
- * Foundation.
- *
- * You should have received a copy of the GNU Lesser General Public License along with this
- * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
- * or from the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
- */
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+*/
 
 package org.pentaho.reporting.engine.classic.core.states.process;
 
@@ -120,7 +120,8 @@ public class ProcessState implements ReportState {
     private PerformanceMonitorContext monitorContext;
     private DataFactoryManager manager;
 
-    private InternalProcessHandle( final DataFactoryManager manager, final PerformanceMonitorContext monitorContext ) {
+    private InternalProcessHandle( final DataFactoryManager manager,
+                                   final PerformanceMonitorContext monitorContext ) {
       this.manager = manager;
       this.monitorContext = monitorContext;
     }
@@ -204,13 +205,16 @@ public class ProcessState implements ReportState {
   private LongSequence crosstabColumnSequenceCounter;
   private boolean designtime;
   private PerformanceMonitorContext performanceMonitorContext;
+  private ReportProcessStore processStore;
 
   public ProcessState() {
 
   }
 
-  public void initializeForMasterReport( final MasterReport report, final ProcessingContext processingContext,
-      final OutputFunction outputFunction ) throws ReportProcessingException {
+  public void initializeForMasterReport( final MasterReport report,
+                                         final ProcessingContext processingContext,
+                                         final OutputFunction outputFunction )
+    throws ReportProcessingException {
     ArgumentNullException.validate( "report", report );
     ArgumentNullException.validate( "processingContext", processingContext );
     ArgumentNullException.validate( "outputFunction", outputFunction );
@@ -222,16 +226,16 @@ public class ProcessState implements ReportState {
     initializeProcessingContext( processingContext, report );
 
     this.designtime =
-        processingContext.getOutputProcessorMetaData().isFeatureSupported( OutputProcessorFeature.DESIGNTIME );
+      processingContext.getOutputProcessorMetaData().isFeatureSupported( OutputProcessorFeature.DESIGNTIME );
     final ReportParameterValues parameterValues;
     if ( designtime == false ) {
       try {
         final ReportParameterValidator reportParameterValidator = parameters.getValidator();
         final ValidationResult validationResult =
-            reportParameterValidator.validate( new ValidationResult(), parameters, parameterContext );
+          reportParameterValidator.validate( new ValidationResult(), parameters, parameterContext );
         if ( validationResult.isEmpty() == false ) {
-          throw new ReportParameterValidationException( "The parameters provided for this report are not valid.",
-              validationResult );
+          throw new ReportParameterValidationException
+            ( "The parameters provided for this report are not valid.", validationResult );
         }
         parameterValues = validationResult.getParameterValues();
       } finally {
@@ -242,13 +246,12 @@ public class ProcessState implements ReportState {
     }
 
     final PerformanceMonitorContext rawPerformanceMonitorContext =
-        ClassicEngineBoot.getInstance().getObjectFactory().get( PerformanceMonitorContext.class );
+      ClassicEngineBoot.getInstance().getObjectFactory().get( PerformanceMonitorContext.class );
     this.performanceMonitorContext = new InternalPerformanceMonitorContext( rawPerformanceMonitorContext );
     final InitialLayoutProcess layoutProcess = new InitialLayoutProcess( outputFunction, performanceMonitorContext );
 
-    this.reportInstancesShareConnection =
-        "true".equals( processingContext.getConfiguration().getConfigProperty(
-            "org.pentaho.reporting.engine.classic.core.ReportInstancesShareConnections" ) );
+    this.reportInstancesShareConnection = "true".equals( processingContext.getConfiguration().getConfigProperty
+      ( "org.pentaho.reporting.engine.classic.core.ReportInstancesShareConnections" ) );
     this.processLevels = new HashSet<Integer>();
     this.groupStarts = new FastStack<GroupStartRecord>();
     this.errorHandler = IgnoreEverythingReportErrorHandler.INSTANCE;
@@ -256,12 +259,12 @@ public class ProcessState implements ReportState {
     this.currentSubReport = -1;
     this.currentGroupIndex = ReportState.BEFORE_FIRST_GROUP;
     this.currentPresentationGroupIndex = ReportState.BEFORE_FIRST_GROUP;
+    this.processStore = new ReportProcessStore();
     this.functionStorage = new FunctionStorage();
     this.structureFunctionStorage = new FunctionStorage();
     this.sequenceCounter = 0;
-    this.processKey =
-        new ReportStateKey( null, ReportState.BEFORE_FIRST_ROW, 0, ReportState.BEFORE_FIRST_GROUP, -1, sequenceCounter,
-            false, false );
+    this.processKey = new ReportStateKey
+      ( null, ReportState.BEFORE_FIRST_ROW, 0, ReportState.BEFORE_FIRST_GROUP, -1, sequenceCounter, false, false );
     this.dataFactoryManager = new DataFactoryManager();
     this.subReportStorage = new SubReportStorage();
     this.processHandle = new InternalProcessHandle( dataFactoryManager, performanceMonitorContext );
@@ -270,20 +273,20 @@ public class ProcessState implements ReportState {
     this.groupSequenceCounter.set( 0, -1 );
 
     final DefaultFlowController startFlowController =
-        new DefaultFlowController( processingContext, report.getDataSchemaDefinition(), StateUtilities
-            .computeParameterValueSet( report, parameterValues ), performanceMonitorContext );
+      new DefaultFlowController( processingContext, report.getDataSchemaDefinition(),
+        StateUtilities.computeParameterValueSet( report, parameterValues ), performanceMonitorContext );
 
     final MasterReportProcessPreprocessor processPreprocessor =
-        new MasterReportProcessPreprocessor( startFlowController );
+      new MasterReportProcessPreprocessor( startFlowController );
     final MasterReport processedReport = processPreprocessor.invokePreDataProcessing( report );
     final DefaultFlowController flowController = processPreprocessor.getFlowController();
 
     final Object dataCacheEnabledRaw =
-        processedReport.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.DATA_CACHE );
+      processedReport.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.DATA_CACHE );
     final boolean dataCacheEnabled = designtime == false && Boolean.FALSE.equals( dataCacheEnabledRaw ) == false;
 
     final DataFactory sortingDataFactory =
-        new SortingDataFactory( lookupDataFactory( processedReport ), performanceMonitorContext );
+      new SortingDataFactory( lookupDataFactory( processedReport ), performanceMonitorContext );
     final CachingDataFactory dataFactory = new CachingDataFactory( sortingDataFactory, dataCacheEnabled );
     dataFactory.initialize( new ProcessingDataFactoryContext( processingContext, dataFactory ) );
 
@@ -296,25 +299,26 @@ public class ProcessState implements ReportState {
 
     final String queryDefined = designtime ? "design-time-query" : processedReport.getQuery();
     final Object queryRaw =
-        evaluateExpression( processedReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
-            AttributeNames.Internal.QUERY ), queryDefined );
+      evaluateExpression( processedReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
+        AttributeNames.Internal.QUERY ), queryDefined );
     final Object queryLimitRaw =
-        evaluateExpression( processedReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
-            AttributeNames.Internal.QUERY_LIMIT ), queryLimitDefault );
+      evaluateExpression( processedReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
+        AttributeNames.Internal.QUERY_LIMIT ), queryLimitDefault );
     final Object queryTimeoutRaw =
-        evaluateExpression( processedReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
-            AttributeNames.Internal.QUERY_TIMEOUT ), queryTimeoutDefault );
+      evaluateExpression( processedReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
+        AttributeNames.Internal.QUERY_TIMEOUT ), queryTimeoutDefault );
     final List<SortConstraint> sortOrder = lookupSortOrder( processedReport );
 
     this.query = (String) ConverterRegistry.convert( queryRaw, String.class, processedReport.getQuery() );
     this.queryLimit = (Integer) ConverterRegistry.convert( queryLimitRaw, Integer.class, queryLimitDefault );
     this.queryTimeout = (Integer) ConverterRegistry.convert( queryTimeoutRaw, Integer.class, queryTimeoutDefault );
 
-    DefaultFlowController postQueryFlowController =
-        flowController.performQuery( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
-            processingContext.getResourceBundleFactory(), sortOrder );
+    DefaultFlowController postQueryFlowController = flowController.performQuery
+      ( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
+        processingContext.getResourceBundleFactory(), sortOrder );
 
-    final MasterReportProcessPreprocessor postProcessor = new MasterReportProcessPreprocessor( postQueryFlowController );
+    final MasterReportProcessPreprocessor postProcessor =
+      new MasterReportProcessPreprocessor( postQueryFlowController );
     final MasterReport fullReport = postProcessor.invokePreProcessing( processedReport );
     postQueryFlowController = postProcessor.getFlowController();
 
@@ -332,16 +336,16 @@ public class ProcessState implements ReportState {
 
     final Expression[] expressions;
     if ( designtime ) {
-      expressions = new Expression[0];
+      expressions = new Expression[ 0 ];
     } else {
       expressions = fullReport.getExpressions().getExpressions();
     }
 
     this.flowController = postQueryFlowController.activateExpressions( expressions, false );
     this.report = new ReportDefinitionImpl( fullReport, fullReport.getPageDefinition() );
-    this.layoutProcess =
-        new SubLayoutProcess( layoutProcess, computeStructureFunctions( fullReport.getStructureFunctions(),
-            getFlowController().getReportContext().getOutputProcessorMetaData() ), fullReport.getObjectID() );
+    this.layoutProcess = new SubLayoutProcess( layoutProcess,
+      computeStructureFunctions( fullReport.getStructureFunctions(),
+        getFlowController().getReportContext().getOutputProcessorMetaData() ), fullReport.getObjectID() );
 
     if ( StateUtilities.computeLevels( this.flowController, this.layoutProcess, processLevels ) ) {
       this.recorder = new DefaultGroupSizeRecorder();
@@ -352,8 +356,8 @@ public class ProcessState implements ReportState {
   }
 
   private List<SortConstraint> lookupSortOrder( final ReportDefinition report ) {
-    Object attribute =
-        report.getAttribute( AttributeNames.Internal.NAMESPACE, AttributeNames.Internal.COMPUTED_SORT_CONSTRAINTS );
+    Object attribute = report.getAttribute
+      ( AttributeNames.Internal.NAMESPACE, AttributeNames.Internal.COMPUTED_SORT_CONSTRAINTS );
     if ( attribute instanceof List<?> ) {
       return (List<SortConstraint>) attribute;
     }
@@ -368,16 +372,19 @@ public class ProcessState implements ReportState {
   private Configuration mapStaticMetaData( final Configuration configuration, final MasterReport report ) {
     HierarchicalConfiguration hc = new HierarchicalConfiguration( configuration );
 
-    setConfigurationIfDefined( hc, "org.pentaho.reporting.engine.classic.core.layout.fontrenderer.ComplexTextLayout",
-        report.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.COMPLEX_TEXT ) );
-    setConfigurationIfDefined( hc, "org.pentaho.reporting.engine.classic.core.WatermarkPrintedOnTopOfContent", report
-        .getWatermark().getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.WATERMARK_PRINTED_ON_TOP ) );
+    setConfigurationIfDefined( hc,
+      "org.pentaho.reporting.engine.classic.core.layout.fontrenderer.ComplexTextLayout",
+      report.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.COMPLEX_TEXT ) );
+    setConfigurationIfDefined( hc,
+      "org.pentaho.reporting.engine.classic.core.WatermarkPrintedOnTopOfContent",
+      report.getWatermark()
+        .getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.WATERMARK_PRINTED_ON_TOP ) );
 
     return hc;
   }
 
   private void setConfigurationIfDefined( final ModifiableConfiguration config, final String configKey,
-      final Object value ) {
+                                          final Object value ) {
     if ( value == null ) {
       return;
     }
@@ -385,8 +392,9 @@ public class ProcessState implements ReportState {
       String valueText = ConverterRegistry.toAttributeValue( value );
       config.setConfigProperty( configKey, valueText );
     } catch ( final BeanException e ) {
-      logger.info( String.format( "Ignoring invalid attribute-value override for configuration '%s' with value '%s'",
-          configKey, value ) );
+      logger.info( String
+        .format( "Ignoring invalid attribute-value override for configuration '%s' with value '%s'", configKey,
+          value ) );
     }
   }
 
@@ -399,7 +407,8 @@ public class ProcessState implements ReportState {
     if ( compatibilityLevel < ClassicEngineBoot.computeVersionId( 3, 999, 999 ) ) {
       // enable strict compatibility mode for reports older than 4.0.
       final HierarchicalConfiguration config = new HierarchicalConfiguration( processingContext.getConfiguration() );
-      config.setConfigProperty( "org.pentaho.reporting.engine.classic.core.legacy.WrapProgressMarkerInSection", "true" );
+      config
+        .setConfigProperty( "org.pentaho.reporting.engine.classic.core.legacy.WrapProgressMarkerInSection", "true" );
       config.setConfigProperty( "org.pentaho.reporting.engine.classic.core.legacy.StrictCompatibility", "true" );
       return config;
     }
@@ -413,8 +422,8 @@ public class ProcessState implements ReportState {
   }
 
   private boolean isReportsShareConnections( final ReportDefinition report ) {
-    final Object attribute =
-        report.getAttribute( AttributeNames.Internal.NAMESPACE, AttributeNames.Internal.SHARED_CONNECTIONS );
+    final Object attribute = report.getAttribute
+      ( AttributeNames.Internal.NAMESPACE, AttributeNames.Internal.SHARED_CONNECTIONS );
     if ( Boolean.TRUE.equals( attribute ) ) {
       return true;
     }
@@ -424,8 +433,9 @@ public class ProcessState implements ReportState {
     return reportInstancesShareConnection;
   }
 
-  public void initializeForSubreport( final InlineSubreportMarker[] subReports, final int subReportIndex,
-      final ProcessState parentState ) throws ReportProcessingException {
+  public void initializeForSubreport( final InlineSubreportMarker[] subReports,
+                                      final int subReportIndex,
+                                      final ProcessState parentState ) throws ReportProcessingException {
     if ( parentState == null ) {
       throw new NullPointerException();
     }
@@ -444,6 +454,7 @@ public class ProcessState implements ReportState {
     this.errorHandler = parentState.errorHandler;
     this.functionStorage = parentState.functionStorage;
     this.structureFunctionStorage = parentState.structureFunctionStorage;
+    this.processStore = parentState.processStore;
     this.currentGroupIndex = ReportState.BEFORE_FIRST_GROUP;
     this.currentPresentationGroupIndex = ReportState.BEFORE_FIRST_GROUP;
     this.currentSubReport = subReportIndex;
@@ -454,13 +465,13 @@ public class ProcessState implements ReportState {
     this.processLevels = parentState.processLevels;
     this.sequenceCounter = parentState.getSequenceCounter() + 1;
 
-    this.currentSubReportMarker = subReports[subReportIndex];
+    this.currentSubReportMarker = subReports[ subReportIndex ];
     this.inlineProcess =
-        parentState.isInlineProcess() || currentSubReportMarker.getProcessType() == SubReportProcessType.INLINE;
+      parentState.isInlineProcess() || currentSubReportMarker.getProcessType() == SubReportProcessType.INLINE;
 
     final SubReport subreportFromMarker = currentSubReportMarker.getSubreport();
-    final FunctionStorageKey functionStorageKey =
-        FunctionStorageKey.createKey( parentSubReportState.getProcessKey(), subreportFromMarker );
+    final FunctionStorageKey functionStorageKey = FunctionStorageKey.createKey
+      ( parentSubReportState.getProcessKey(), subreportFromMarker );
     final boolean needPreProcessing;
     final SubReport initialSubReport;
     if ( subReportStorage.contains( functionStorageKey ) ) {
@@ -481,18 +492,16 @@ public class ProcessState implements ReportState {
       // make it a minimum effort report, but still enter the loop.
       final ReportDefinition parentReport = parentState.getReport();
       final SubReport dummyReport = new SubReport( functionStorageKey.getReportId() );
-      this.report =
-          new ReportDefinitionImpl( dummyReport, parentReport.getPageDefinition(), subreportFromMarker
-              .getParentSection() );
+      this.report = new ReportDefinitionImpl( dummyReport, parentReport.getPageDefinition(),
+        subreportFromMarker.getParentSection() );
       this.flowController = parentStateFlowController.derive();
       this.advanceHandler = EndSubReportHandler.HANDLER;
-      this.layoutProcess =
-          new SubLayoutProcess( parentState.layoutProcess, computeStructureFunctions( initialSubReport
-              .getStructureFunctions(), flowController.getReportContext().getOutputProcessorMetaData() ), this.report
-              .getObjectID() );
+      this.layoutProcess = new SubLayoutProcess
+        ( parentState.layoutProcess, computeStructureFunctions( initialSubReport.getStructureFunctions(),
+          flowController.getReportContext().getOutputProcessorMetaData() ), this.report.getObjectID() );
     } else {
       DataFactory dataFactory =
-          dataFactoryManager.restore( functionStorageKey, isReportsShareConnections( initialSubReport ) );
+        dataFactoryManager.restore( functionStorageKey, isReportsShareConnections( initialSubReport ) );
 
       final DefaultFlowController postPreProcessingFlowController;
       final SubReport preDataSubReport;
@@ -525,32 +534,32 @@ public class ProcessState implements ReportState {
       final ParameterMapping[] exportMappings = preDataSubReport.getExportMappings();
 
       // eval query, query-limit and query-timeout
-      this.flowController =
-          postPreProcessingFlowController.performInitSubreport( dataFactory, inputMappings, resourceBundleFactory );
+      this.flowController = postPreProcessingFlowController.performInitSubreport
+        ( dataFactory, inputMappings, resourceBundleFactory );
       final Integer queryLimitDefault = IntegerCache.getInteger( preDataSubReport.getQueryLimit() );
       final Integer queryTimeoutDefault = IntegerCache.getInteger( preDataSubReport.getQueryTimeout() );
 
       final Object queryRaw =
-          evaluateExpression( preDataSubReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
-              AttributeNames.Internal.QUERY ), preDataSubReport.getQuery() );
+        evaluateExpression( preDataSubReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
+          AttributeNames.Internal.QUERY ), preDataSubReport.getQuery() );
       final Object queryLimitRaw =
-          evaluateExpression( preDataSubReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
-              AttributeNames.Internal.QUERY_LIMIT ), queryLimitDefault );
+        evaluateExpression( preDataSubReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
+          AttributeNames.Internal.QUERY_LIMIT ), queryLimitDefault );
       final Object queryTimeoutRaw =
-          evaluateExpression( preDataSubReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
-              AttributeNames.Internal.QUERY_TIMEOUT ), queryTimeoutDefault );
+        evaluateExpression( preDataSubReport.getAttributeExpression( AttributeNames.Internal.NAMESPACE,
+          AttributeNames.Internal.QUERY_TIMEOUT ), queryTimeoutDefault );
       final String queryDefined = designtime ? "design-time-query" : preDataSubReport.getQuery();
       this.query = (String) ConverterRegistry.convert( queryRaw, String.class, queryDefined );
       this.queryLimit = (Integer) ConverterRegistry.convert( queryLimitRaw, Integer.class, queryLimitDefault );
       this.queryTimeout = (Integer) ConverterRegistry.convert( queryTimeoutRaw, Integer.class, queryTimeoutDefault );
       final List<SortConstraint> sortOrder = lookupSortOrder( preDataSubReport );
 
-      DefaultFlowController postQueryFlowController =
-          flowController.performSubReportQuery( query, queryLimit.intValue(), queryTimeout.intValue(), exportMappings,
-              sortOrder );
+
+      DefaultFlowController postQueryFlowController = flowController.performSubReportQuery
+        ( query, queryLimit.intValue(), queryTimeout.intValue(), exportMappings, sortOrder );
       final ProxyDataSchemaDefinition schemaDefinition =
-          new ProxyDataSchemaDefinition( preDataSubReport.getDataSchemaDefinition(), postQueryFlowController
-              .getMasterRow().getDataSchemaDefinition() );
+        new ProxyDataSchemaDefinition( preDataSubReport.getDataSchemaDefinition(),
+          postQueryFlowController.getMasterRow().getDataSchemaDefinition() );
       postQueryFlowController = postQueryFlowController.updateDataSchema( schemaDefinition );
 
       SubReport fullReport = preDataSubReport;
@@ -563,18 +572,18 @@ public class ProcessState implements ReportState {
       }
 
       this.report =
-          new ReportDefinitionImpl( fullReport, fullReport.getPageDefinition(), subreportFromMarker.getParentSection() );
+        new ReportDefinitionImpl( fullReport, fullReport.getPageDefinition(), subreportFromMarker.getParentSection() );
+
 
       final Expression[] structureFunctions = getStructureFunctionStorage().restore( functionStorageKey );
       if ( structureFunctions != null ) {
-        final StructureFunction[] functions = new StructureFunction[structureFunctions.length];
-        // noinspection SuspiciousSystemArraycopy
+        final StructureFunction[] functions = new StructureFunction[ structureFunctions.length ];
+        //noinspection SuspiciousSystemArraycopy
         System.arraycopy( structureFunctions, 0, functions, 0, structureFunctions.length );
         this.layoutProcess = new SubLayoutProcess( parentState.layoutProcess, functions, this.report.getObjectID() );
       } else {
-        final StructureFunction[] functions =
-            computeStructureFunctions( fullReport.getStructureFunctions(), fullFlowController.getReportContext()
-                .getOutputProcessorMetaData() );
+        final StructureFunction[] functions = computeStructureFunctions( fullReport.getStructureFunctions(),
+          fullFlowController.getReportContext().getOutputProcessorMetaData() );
         this.layoutProcess = new SubLayoutProcess( parentState.layoutProcess, functions, this.report.getObjectID() );
       }
 
@@ -584,7 +593,7 @@ public class ProcessState implements ReportState {
         // ok, it seems we have entered a new subreport ..
         // we use the expressions from the report itself ..
         if ( designtime ) {
-          expressions = new Expression[0];
+          expressions = new Expression[ 0 ];
         } else {
           expressions = fullReport.getExpressions().getExpressions();
         }
@@ -615,6 +624,10 @@ public class ProcessState implements ReportState {
     this.processKey = createKey();
   }
 
+  public ReportProcessStore getProcessStore() {
+    return processStore;
+  }
+
   private DataFactory lookupDataFactory( final AbstractReportDefinition report ) {
     if ( designtime ) {
       return new DesignTimeDataFactory();
@@ -628,7 +641,8 @@ public class ProcessState implements ReportState {
     report.copyAttributes( subreportFromMarker.getAttributes() );
   }
 
-  private boolean isSubReportInvisible( final SubReport report, final DefaultFlowController flowController ) {
+  private boolean isSubReportInvisible( final SubReport report,
+                                        final DefaultFlowController flowController ) {
     final int processingLevel = flowController.getReportContext().getProcessingLevel();
     if ( processingLevel != LayoutProcess.LEVEL_PAGINATE ) {
       // outside
@@ -639,11 +653,10 @@ public class ProcessState implements ReportState {
       return false;
     }
 
-    if ( flowController.getReportContext().getOutputProcessorMetaData().isFeatureSupported(
-        OutputProcessorFeature.DESIGNTIME ) ) {
-      final Object attribute =
-          report.getAttribute( AttributeNames.Designtime.NAMESPACE,
-              AttributeNames.Designtime.HIDE_IN_LAYOUT_GUI_ATTRIBUTE );
+    OutputProcessorMetaData metaData = flowController.getReportContext().getOutputProcessorMetaData();
+    if ( metaData.isFeatureSupported( OutputProcessorFeature.DESIGNTIME ) ) {
+      final Object attribute = report.getAttribute( AttributeNames.Designtime.NAMESPACE,
+        AttributeNames.Designtime.HIDE_IN_LAYOUT_GUI_ATTRIBUTE );
       if ( Boolean.TRUE.equals( attribute ) ) {
         return true;
       }
@@ -660,7 +673,7 @@ public class ProcessState implements ReportState {
   private static boolean isCacheEnabled( ReportDefinition reportDefinition ) {
     while ( reportDefinition != null ) {
       final Object dataCacheEnabledRaw =
-          reportDefinition.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.DATA_CACHE );
+        reportDefinition.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.DATA_CACHE );
       if ( Boolean.FALSE.equals( dataCacheEnabledRaw ) ) {
         return false;
       }
@@ -672,6 +685,7 @@ public class ProcessState implements ReportState {
     }
     return true;
   }
+
 
   private Object evaluateExpression( final Expression expression, final Object defaultValue ) {
     if ( expression == null ) {
@@ -700,19 +714,19 @@ public class ProcessState implements ReportState {
   public int[] getRequiredRuntimeLevels() {
     processLevels.add( IntegerCache.getInteger( LayoutProcess.LEVEL_PAGINATE ) );
 
-    final int[] retval = new int[processLevels.size()];
-    final Integer[] levels = processLevels.toArray( new Integer[processLevels.size()] );
+    final int[] retval = new int[ processLevels.size() ];
+    final Integer[] levels = processLevels.toArray( new Integer[ processLevels.size() ] );
     Arrays.sort( levels, new StateUtilities.DescendingComparator<Integer>() );
     for ( int i = 0; i < levels.length; i++ ) {
-      final Integer level = levels[i];
-      retval[i] = level.intValue();
+      final Integer level = levels[ i ];
+      retval[ i ] = level.intValue();
     }
 
     return retval;
   }
 
   private StructureFunction[] computeStructureFunctions( final StructureFunction[] fromReport,
-      final OutputProcessorMetaData metaData ) {
+                                                         final OutputProcessorMetaData metaData ) {
     final ArrayList<StructureFunction> e = new ArrayList<StructureFunction>( Arrays.asList( fromReport ) );
     if ( structuralPreprocessingNeeded ) {
       e.add( new CrosstabProcessorFunction() );
@@ -729,12 +743,12 @@ public class ProcessState implements ReportState {
     e.add( new StyleResolvingEvaluator() );
 
     Collections.sort( e, new StructureFunctionComparator() );
-    return e.toArray( new StructureFunction[e.size()] );
+    return e.toArray( new StructureFunction[ e.size() ] );
   }
 
   public boolean isSubReportExecutable() {
     final Expression expression =
-        getReport().getAttributeExpression( AttributeNames.Core.NAMESPACE, AttributeNames.Core.SUBREPORT_ACTIVE );
+      getReport().getAttributeExpression( AttributeNames.Core.NAMESPACE, AttributeNames.Core.SUBREPORT_ACTIVE );
     if ( expression != null ) {
       // the master-report state will only be non-null for subreports.
       final InlineDataRowRuntime dataRowRuntime = new InlineDataRowRuntime();
@@ -791,20 +805,19 @@ public class ProcessState implements ReportState {
       parentStateKey = parentState.getProcessKey();
     }
 
-    final CachingDataFactory dataFactory =
-        state.dataFactoryManager.restore( FunctionStorageKey.createKey( parentStateKey, state.getReport() ),
-            isReportsShareConnections( report ) );
+    final CachingDataFactory dataFactory = state.dataFactoryManager.restore
+      ( FunctionStorageKey.createKey( parentStateKey, state.getReport() ), isReportsShareConnections( report ) );
     if ( dataFactory == null ) {
       throw new ReportProcessingException( "No data factory on restart()? Somewhere we went wrong." );
     }
 
     final DefaultFlowController fc = state.getFlowController();
     final DefaultFlowController cfc = fc.restart();
-    final DefaultFlowController qfc =
-        cfc.performQuery( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(), fc.getMasterRow()
-            .getResourceBundleFactory(), lookupSortOrder( state.report ) );
-    final Expression[] expressions =
-        getFunctionStorage().restore( FunctionStorageKey.createKey( null, state.getReport() ) );
+    final DefaultFlowController qfc = cfc.performQuery
+      ( dataFactory, query, queryLimit.intValue(), queryTimeout.intValue(),
+        fc.getMasterRow().getResourceBundleFactory(), lookupSortOrder( state.report ) );
+    final Expression[] expressions = getFunctionStorage().restore
+      ( FunctionStorageKey.createKey( null, state.getReport() ) );
     final DefaultFlowController efc = qfc.activateExpressions( expressions, true );
     state.setFlowController( efc );
     state.sequenceCounter += 1;
@@ -903,12 +916,16 @@ public class ProcessState implements ReportState {
   private ReportStateKey createKey() {
     final ProcessState parent = (ProcessState) getParentState();
     if ( parent != null ) {
-      return new ReportStateKey( parent.createKey(), getCurrentRow(), getEventCode(), getCurrentGroupIndex(),
-          getCurrentSubReport(), sequenceCounter, advanceHandler.isRestoreHandler(), isInlineProcess() );
+      return new ReportStateKey( parent.createKey(),
+        getCurrentRow(), getEventCode(),
+        getCurrentGroupIndex(), getCurrentSubReport(),
+        sequenceCounter, advanceHandler.isRestoreHandler(),
+        isInlineProcess() );
     }
 
-    return new ReportStateKey( null, getCurrentRow(), getEventCode(), getCurrentGroupIndex(), getCurrentSubReport(),
-        sequenceCounter, advanceHandler.isRestoreHandler(), false );
+    return new ReportStateKey( null, getCurrentRow(),
+      getEventCode(), getCurrentGroupIndex(), getCurrentSubReport(),
+      sequenceCounter, advanceHandler.isRestoreHandler(), false );
   }
 
   public void setAdvanceHandler( final AdvanceHandler advanceHandler ) {
@@ -1065,8 +1082,7 @@ public class ProcessState implements ReportState {
   /**
    * Fires a 'page-started' event.
    *
-   * @param baseEvent
-   *          the type of the base event which caused the page start to be triggered.
+   * @param baseEvent the type of the base event which caused the page start to be triggered.
    */
   public void firePageStartedEvent( final int baseEvent ) {
     final ReportEvent event = new ReportEvent( this, ReportEvent.PAGE_STARTED | baseEvent );
@@ -1075,7 +1091,7 @@ public class ProcessState implements ReportState {
   }
 
   /**
-   * Fires a '<code>page-finished</code>' event. The <code>pageFinished(...)</code> method is called for every report
+   * Fires a '<code>page-finished</code>' event.  The <code>pageFinished(...)</code> method is called for every report
    * function.
    */
   public void firePageFinishedEvent( final boolean noParentPassing ) {
@@ -1100,16 +1116,14 @@ public class ProcessState implements ReportState {
    * Returns true if this is the last item in the group, and false otherwise. This checks the group condition and all
    * conditions of all subgroups.
    *
-   * @param rootGroup
-   *          the root group that should be checked.
-   * @param currentDataRow
-   *          the current data row.
-   * @param nextDataRow
-   *          the next data row, or null, if this is the last datarow.
+   * @param rootGroup      the root group that should be checked.
+   * @param currentDataRow the current data row.
+   * @param nextDataRow    the next data row, or null, if this is the last datarow.
    * @return A flag indicating whether or not the current item is the last in its group.
    */
-  public static boolean isLastItemInGroup( final Group rootGroup, final MasterDataRow currentDataRow,
-      final MasterDataRow nextDataRow ) {
+  public static boolean isLastItemInGroup( final Group rootGroup,
+                                           final MasterDataRow currentDataRow,
+                                           final MasterDataRow nextDataRow ) {
     // return true if this is the last row in the model.
     if ( currentDataRow.isAdvanceable() == false || nextDataRow == null ) {
       return true;
@@ -1250,7 +1264,7 @@ public class ProcessState implements ReportState {
     next.suspendedState = this;
     next.flowController = flowController.replayStoredCrosstabRowState();
     next.processKey = next.createKey();
-    // DebugLog.log("ProcessState:replay " + processKey);
+    //    DebugLog.log("ProcessState:replay " + processKey);
     return next;
   }
 
@@ -1272,7 +1286,7 @@ public class ProcessState implements ReportState {
     next.flowController = flowController.derive();
     next.advanceHandler = this.advanceHandler;
     next.flowController.getMasterRow().validateReplayFinished();
-    // DebugLog.log("ProcessState:finish-replay " + processKey);
+    //    DebugLog.log("ProcessState:finish-replay " + processKey);
     return next;
   }
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ReportProcessStore.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ReportProcessStore.java
@@ -1,0 +1,44 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.states.process;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A simple central storage for all sort of caching needs. On use, use your caller's class-name as key to
+ * avoid conflicts with other users. This cache is instantiated per report-run and does not need synchronisation.
+ */
+public class ReportProcessStore implements Serializable {
+  private HashMap<String, HashMap<?, ?>> storage;
+
+  public ReportProcessStore() {
+    storage = new HashMap<String, HashMap<?, ?>>(  );
+  }
+
+  public <K,V> Map<K,V> get( String id ) {
+    HashMap<?, ?> cache = storage.get( id );
+    if (cache != null) {
+      return (Map<K, V>) cache;
+    }
+    HashMap<K,V> m = new HashMap<K, V>();
+    storage.put(id, m);
+    return m;
+  }
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ReportProcessStore.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/states/process/ReportProcessStore.java
@@ -22,23 +22,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A simple central storage for all sort of caching needs. On use, use your caller's class-name as key to
- * avoid conflicts with other users. This cache is instantiated per report-run and does not need synchronisation.
+ * A simple central storage for all sort of caching needs. On use, use your caller's class-name as key to avoid
+ * conflicts with other users. This cache is instantiated per report-run and does not need synchronisation.
  */
 public class ReportProcessStore implements Serializable {
   private HashMap<String, HashMap<?, ?>> storage;
 
   public ReportProcessStore() {
-    storage = new HashMap<String, HashMap<?, ?>>(  );
+    storage = new HashMap<String, HashMap<?, ?>>();
   }
 
-  public <K,V> Map<K,V> get( String id ) {
+  public <K, V> Map<K, V> get( String id ) {
     HashMap<?, ?> cache = storage.get( id );
-    if (cache != null) {
+    if ( cache != null ) {
       return (Map<K, V>) cache;
     }
-    HashMap<K,V> m = new HashMap<K, V>();
-    storage.put(id, m);
+    HashMap<K, V> m = new HashMap<K, V>();
+    storage.put( id, m );
     return m;
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/style/ElementStyleSheet.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/style/ElementStyleSheet.java
@@ -26,14 +26,15 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 
 /**
- * An element style-sheet contains zero, one or many attributes that affect the appearance of report elements. For each
+ * An element style-sheet contains zero, one or many attributes that affect the appearance of report elements.  For each
  * attribute, there is a predefined key that can be used to access that attribute in the style sheet.
  * <p/>
  * Every report element has an associated style-sheet.
  * <p/>
- * A style-sheet maintains a list of parent style-sheets. If an attribute is not defined in a style-sheet, the code
+ * A style-sheet maintains a list of parent style-sheets.  If an attribute is not defined in a style-sheet, the code
  * refers to the parent style-sheets to see if the attribute is defined there.
  * <p/>
  * All StyleSheet entries are checked against the StyleKeyDefinition for validity.
@@ -47,7 +48,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * The keys for the properties that have been explicitly set on the element.
    */
-  private StyleKey[] propertyKeys;
+  private List<StyleKey> propertyKeys;
 
   /**
    * The properties that have been explicitly set on the element.
@@ -66,7 +67,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
 
   private long modificationCount;
   private long changeTrackerHash;
-  private static final StyleKey[] EMPTY_KEYS = new StyleKey[0];
+  private static final StyleKey[] EMPTY_KEYS = new StyleKey[ 0 ];
 
   /**
    * Creates a new element style-sheet. The style-sheet initially contains no attributes, and has no parent
@@ -74,9 +75,9 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
    */
   public ElementStyleSheet() {
     this.styleChangeSupport = new StyleChangeSupport( this );
-    this.propertyKeys = StyleKey.getDefinedStyleKeys();
-    if ( propertyKeys[0] == null ) {
-      throw new IllegalStateException();
+    this.propertyKeys = StyleKey.getDefinedStyleKeysList();
+    if ( propertyKeys.isEmpty() || propertyKeys.get( 0 ) == null ) {
+      throw new IllegalStateException("ReportingEngine has not been initialized properly.");
     }
   }
 
@@ -87,8 +88,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Returns true, if the given key is locally defined, false otherwise.
    *
-   * @param key
-   *          the key to test
+   * @param key the key to test
    * @return true, if the key is local, false otherwise.
    */
   public boolean isLocalKey( final StyleKey key ) {
@@ -99,53 +99,52 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     if ( source.length <= identifier ) {
       return false;
     }
-    return source[identifier] == SOURCE_DIRECT;
+    return source[ identifier ] == SOURCE_DIRECT;
   }
 
   private void pruneCachedEntries() {
     if ( source != null && properties != null ) {
       for ( int i = 0; i < source.length; i++ ) {
-        if ( source[i] == SOURCE_FROM_PARENT ) {
-          source[i] = SOURCE_UNDEFINED;
-          properties[i] = null;
+        if ( source[ i ] == SOURCE_FROM_PARENT ) {
+          source[ i ] = SOURCE_UNDEFINED;
+          properties[ i ] = null;
         }
       }
     }
   }
 
   public final Object[] toArray() {
-    final StyleKey[] keys = propertyKeys;
-    final Object[] data = new Object[keys.length];
+    final List<StyleKey> keys = propertyKeys;
+    final int size = keys.size();
+    final Object[] data = new Object[ size ];
     if ( source == null ) {
-      source = new byte[keys.length];
-      properties = new Object[keys.length];
+      source = new byte[ size ];
+      properties = new Object[ size ];
     }
 
-    for ( int i = 0; i < keys.length; i++ ) {
-      final StyleKey key = keys[i];
+    for ( int i = 0; i < size; i++ ) {
+      final StyleKey key = keys.get(i);
       if ( key == null ) {
         throw new NullPointerException();
       }
       final int identifier = key.identifier;
-      final byte sourceHint = source[identifier];
+      final byte sourceHint = source[ identifier ];
       if ( sourceHint == SOURCE_UNDEFINED ) {
-        data[identifier] = getStyleProperty( key );
+        data[ identifier ] = getStyleProperty( key );
       } else {
-        data[identifier] = properties[identifier];
+        data[ identifier ] = properties[ identifier ];
       }
     }
     return data;
   }
 
   /**
-   * Returns the value of a style. If the style is not found in this style-sheet, the code looks in the parent
-   * style-sheets. If the style is not found in any of the parent style-sheets, then the default value (possibly
+   * Returns the value of a style.  If the style is not found in this style-sheet, the code looks in the parent
+   * style-sheets.  If the style is not found in any of the parent style-sheets, then the default value (possibly
    * <code>null</code>) is returned.
    *
-   * @param key
-   *          the style key.
-   * @param defaultValue
-   *          the default value (<code>null</code> permitted).
+   * @param key          the style key.
+   * @param defaultValue the default value (<code>null</code> permitted).
    * @return the value.
    */
   public Object getStyleProperty( final StyleKey key, final Object defaultValue ) {
@@ -155,9 +154,9 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
         throw new IllegalStateException();
       }
 
-      final byte source = this.source[identifier];
+      final byte source = this.source[ identifier ];
       if ( source != SOURCE_UNDEFINED ) {
-        final Object value = properties[identifier];
+        final Object value = properties[ identifier ];
         if ( value == null ) {
           return defaultValue;
         }
@@ -172,30 +171,24 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Puts an object into the cache (if caching is enabled).
    *
-   * @param key
-   *          the stylekey for that object
-   * @param value
-   *          the object.
+   * @param key   the stylekey for that object
+   * @param value the object.
    */
   private void putInCache( final StyleKey key, final Object value, final byte sourceHint ) {
     ensurePropertiesReady();
 
     final int identifier = key.identifier;
-    properties[identifier] = value;
-    source[identifier] = sourceHint;
+    properties[ identifier ] = value;
+    source[ identifier ] = sourceHint;
   }
 
   /**
    * Sets a boolean style property.
    *
-   * @param key
-   *          the style key (<code>null</code> not permitted).
-   * @param value
-   *          the value.
-   * @throws NullPointerException
-   *           if the given key is null.
-   * @throws ClassCastException
-   *           if the value cannot be assigned with the given key.
+   * @param key   the style key (<code>null</code> not permitted).
+   * @param value the value.
+   * @throws NullPointerException if the given key is null.
+   * @throws ClassCastException   if the value cannot be assigned with the given key.
    */
   public void setBooleanStyleProperty( final StyleKey key, final boolean value ) {
     if ( value ) {
@@ -208,14 +201,10 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Sets a style property (or removes the style if the value is <code>null</code>).
    *
-   * @param key
-   *          the style key (<code>null</code> not permitted).
-   * @param value
-   *          the value.
-   * @throws NullPointerException
-   *           if the given key is null.
-   * @throws ClassCastException
-   *           if the value cannot be assigned with the given key.
+   * @param key   the style key (<code>null</code> not permitted).
+   * @param value the value.
+   * @throws NullPointerException if the given key is null.
+   * @throws ClassCastException   if the value cannot be assigned with the given key.
    */
   public void setStyleProperty( final StyleKey key, final Object value ) {
     if ( key == null ) {
@@ -225,26 +214,27 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     final int identifier = key.identifier;
     if ( value == null ) {
       if ( properties != null ) {
-        if ( properties[identifier] == null ) {
+        if ( properties[ identifier ] == null ) {
           return;
         }
 
         // invalidate the cache ..
         putInCache( key, null, SOURCE_UNDEFINED );
         updateChangeTracker( key, null );
-        properties[identifier] = null;
+        properties[ identifier ] = null;
         styleChangeSupport.fireStyleRemoved( key );
       }
       return;
     }
 
     if ( key.getValueType().isAssignableFrom( value.getClass() ) == false ) {
-      throw new ClassCastException( "Value for key " + key.getName() + " is not assignable: " + value.getClass()
-          + " is not assignable from " + key.getValueType() );
+      throw new ClassCastException( "Value for key " + key.getName()
+        + " is not assignable: " + value.getClass()
+        + " is not assignable from " + key.getValueType() );
     }
     ensurePropertiesReady();
 
-    if ( ObjectUtilities.equal( properties[identifier], value ) ) {
+    if ( ObjectUtilities.equal( properties[ identifier ], value ) ) {
       // no need to change anything ..
       return;
     }
@@ -258,9 +248,9 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
 
   private void ensurePropertiesReady() {
     if ( properties == null ) {
-      final int definedStyleKeyCount = propertyKeys.length;
-      properties = new Object[definedStyleKeyCount];
-      source = new byte[definedStyleKeyCount];
+      final int definedStyleKeyCount = propertyKeys.size();
+      properties = new Object[ definedStyleKeyCount ];
+      source = new byte[ definedStyleKeyCount ];
     }
   }
 
@@ -304,10 +294,10 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
       return ElementStyleSheet.EMPTY_KEYS;
     }
 
-    final StyleKey[] retval = propertyKeys.clone();
+    final StyleKey[] retval = propertyKeys.toArray( new StyleKey[ propertyKeys.size() ] );
     for ( int i = 0; i < source.length; i++ ) {
-      if ( source[i] != SOURCE_DIRECT ) {
-        retval[i] = null;
+      if ( source[ i ] != SOURCE_DIRECT ) {
+        retval[ i ] = null;
       }
     }
     return retval;
@@ -316,8 +306,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Adds a {@link StyleChangeListener}.
    *
-   * @param l
-   *          the listener.
+   * @param l the listener.
    */
   public void addListener( final StyleChangeListener l ) {
     styleChangeSupport.addListener( l );
@@ -326,8 +315,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Removes a {@link StyleChangeListener}.
    *
-   * @param l
-   *          the listener.
+   * @param l the listener.
    */
   public void removeListener( final StyleChangeListener l ) {
     styleChangeSupport.removeListener( l );
@@ -346,10 +334,8 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Helper method for serialization.
    *
-   * @param out
-   *          the output stream where to write the object.
-   * @throws IOException
-   *           if errors occur while writing the stream.
+   * @param out the output stream where to write the object.
+   * @throws IOException if errors occur while writing the stream.
    */
   private void writeObject( final ObjectOutputStream out ) throws IOException {
     out.defaultWriteObject();
@@ -359,7 +345,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
       final int size = properties.length;
       out.writeInt( size );
       for ( int i = 0; i < size; i++ ) {
-        final Object value = properties[i];
+        final Object value = properties[ i ];
         SerializerHelper.getInstance().writeObject( value, out );
       }
     }
@@ -368,18 +354,15 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   /**
    * Helper method for serialization.
    *
-   * @param in
-   *          the input stream from where to read the serialized object.
-   * @throws IOException
-   *           when reading the stream fails.
-   * @throws ClassNotFoundException
-   *           if a class definition for a serialized object could not be found.
+   * @param in the input stream from where to read the serialized object.
+   * @throws IOException            when reading the stream fails.
+   * @throws ClassNotFoundException if a class definition for a serialized object could not be found.
    */
   private void readObject( final ObjectInputStream in ) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
     final int size = in.readInt();
 
-    propertyKeys = StyleKey.getDefinedStyleKeys();
+    propertyKeys = StyleKey.getDefinedStyleKeysList();
     styleChangeSupport = new StyleChangeSupport( this );
 
     if ( size == 0 ) {
@@ -387,25 +370,26 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
       return;
     }
 
-    if ( size != propertyKeys.length ) {
-      throw new IOException( "Encountered a different style-system configuration. This report cannot be deserialized." );
+    if ( size != propertyKeys.size() ) {
+      throw new IOException(
+        "Encountered a different style-system configuration. This report cannot be deserialized." );
     }
-    if ( propertyKeys[0] == null ) {
+    if ( propertyKeys.get(0) == null ) {
       throw new IllegalStateException();
     }
-    properties = new Object[size];
+    properties = new Object[ size ];
 
-    final Object[] values = new Object[size];
+    final Object[] values = new Object[ size ];
     final SerializerHelper serHelper = SerializerHelper.getInstance();
     for ( int i = 0; i < size; i++ ) {
-      values[i] = serHelper.readObject( in );
+      values[ i ] = serHelper.readObject( in );
     }
 
     for ( int i = 0; i < size; i++ ) {
-      final StyleKey key = propertyKeys[i];
+      final StyleKey key = propertyKeys.get( i );
       if ( key != null ) {
         final int identifier = key.identifier;
-        properties[identifier] = values[i];
+        properties[ identifier ] = values[ i ];
       }
     }
   }
@@ -417,7 +401,11 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
    * @return the local copy of the style keys.
    */
   public StyleKey[] getPropertyKeys() {
-    return propertyKeys.clone();
+    return propertyKeys.toArray( new StyleKey[propertyKeys.size()] );
+  }
+
+  public List<StyleKey> getPropertyKeyList() {
+    return propertyKeys;
   }
 
   public void addAll( final ElementStyleSheet sourceStyleSheet ) {
@@ -428,10 +416,10 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     ensurePropertiesReady();
 
     for ( int i = 0; i < sourceStyleSheet.source.length; i++ ) {
-      final byte sourceFlag = sourceStyleSheet.source[i];
+      final byte sourceFlag = sourceStyleSheet.source[ i ];
       if ( sourceFlag == SOURCE_DIRECT ) {
-        properties[i] = sourceStyleSheet.properties[i];
-        source[i] = sourceFlag;
+        properties[ i ] = sourceStyleSheet.properties[ i ];
+        source[ i ] = sourceFlag;
       }
     }
   }
@@ -443,13 +431,13 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     ensurePropertiesReady();
 
     for ( int i = 0; i < source.length; i++ ) {
-      if ( propertyKeys[i].isInheritable() == false ) {
+      if ( propertyKeys.get(i).isInheritable() == false ) {
         continue;
       }
-      final byte sourceFlag = sourceStyleSheet.source[i];
+      final byte sourceFlag = sourceStyleSheet.source[ i ];
       if ( sourceFlag == SOURCE_DIRECT ) {
-        properties[i] = sourceStyleSheet.properties[i];
-        source[i] = SOURCE_FROM_PARENT;
+        properties[ i ] = sourceStyleSheet.properties[ i ];
+        source[ i ] = SOURCE_FROM_PARENT;
       }
     }
   }
@@ -458,12 +446,13 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     ensurePropertiesReady();
 
     for ( int i = 0; i < source.length; i++ ) {
-      if ( propertyKeys[i].isInheritable() == false ) {
+      StyleKey styleKey = propertyKeys.get( i );
+      if ( styleKey.isInheritable() == false ) {
         continue;
       }
 
-      properties[i] = sourceStyleSheet.getStyleProperty( propertyKeys[i], null );
-      source[i] = SOURCE_FROM_PARENT;
+      properties[ i ] = sourceStyleSheet.getStyleProperty( styleKey, null );
+      source[ i ] = SOURCE_FROM_PARENT;
     }
   }
 
@@ -474,10 +463,10 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     ensurePropertiesReady();
 
     for ( int i = 0; i < source.length; i++ ) {
-      final byte sourceFlag = sourceStyleSheet.source[i];
-      if ( sourceFlag == SOURCE_DIRECT && source[i] == SOURCE_UNDEFINED ) {
-        properties[i] = sourceStyleSheet.properties[i];
-        source[i] = sourceFlag;
+      final byte sourceFlag = sourceStyleSheet.source[ i ];
+      if ( sourceFlag == SOURCE_DIRECT && source[ i ] == SOURCE_UNDEFINED ) {
+        properties[ i ] = sourceStyleSheet.properties[ i ];
+        source[ i ] = sourceFlag;
       }
     }
   }
@@ -513,7 +502,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
   public void copyFrom( final ElementStyleSheet style ) {
     this.changeTrackerHash = style.changeTrackerHash;
     this.modificationCount = style.modificationCount;
-    this.propertyKeys = style.propertyKeys.clone();
+    this.propertyKeys = style.propertyKeys;
     if ( style.source != null ) {
       this.source = style.source.clone();
     } else if ( this.source != null ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/style/ElementStyleSheet.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/style/ElementStyleSheet.java
@@ -77,7 +77,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     this.styleChangeSupport = new StyleChangeSupport( this );
     this.propertyKeys = StyleKey.getDefinedStyleKeysList();
     if ( propertyKeys.isEmpty() || propertyKeys.get( 0 ) == null ) {
-      throw new IllegalStateException("ReportingEngine has not been initialized properly.");
+      throw new IllegalStateException( "ReportingEngine has not been initialized properly." );
     }
   }
 
@@ -123,7 +123,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     }
 
     for ( int i = 0; i < size; i++ ) {
-      final StyleKey key = keys.get(i);
+      final StyleKey key = keys.get( i );
       if ( key == null ) {
         throw new NullPointerException();
       }
@@ -374,7 +374,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
       throw new IOException(
         "Encountered a different style-system configuration. This report cannot be deserialized." );
     }
-    if ( propertyKeys.get(0) == null ) {
+    if ( propertyKeys.get( 0 ) == null ) {
       throw new IllegalStateException();
     }
     properties = new Object[ size ];
@@ -401,7 +401,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
    * @return the local copy of the style keys.
    */
   public StyleKey[] getPropertyKeys() {
-    return propertyKeys.toArray( new StyleKey[propertyKeys.size()] );
+    return propertyKeys.toArray( new StyleKey[ propertyKeys.size() ] );
   }
 
   public List<StyleKey> getPropertyKeyList() {
@@ -431,7 +431,7 @@ public class ElementStyleSheet extends AbstractStyleSheet implements Serializabl
     ensurePropertiesReady();
 
     for ( int i = 0; i < source.length; i++ ) {
-      if ( propertyKeys.get(i).isInheritable() == false ) {
+      if ( propertyKeys.get( i ).isInheritable() == false ) {
         continue;
       }
       final byte sourceFlag = sourceStyleSheet.source[ i ];

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/style/StyleKey.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/style/StyleKey.java
@@ -27,8 +27,11 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A style key represents a (key, class) pair. Style keys are used to access style attributes defined in a
@@ -49,6 +52,7 @@ public final class StyleKey implements Serializable, Cloneable {
   private static HashMap definedKeys;
   private static int definedKeySize;
   private static StyleKey[] definedKeysArray;
+  private static List<StyleKey> definedKeysList;
   private static boolean locked;
 
   /**
@@ -117,7 +121,7 @@ public final class StyleKey implements Serializable, Cloneable {
    *
    * @return the class.
    */
-  public Class getValueType() {
+  public Class<?> getValueType() {
     return valueType;
   }
 
@@ -165,6 +169,7 @@ public final class StyleKey implements Serializable, Cloneable {
       definedKeys.put( name, key );
       definedKeySize = definedKeys.size();
       definedKeysArray = null;
+      definedKeysList = null;
     }
     return key;
   }
@@ -276,6 +281,14 @@ public final class StyleKey implements Serializable, Cloneable {
 
   public static int getDefinedStyleKeyCount() {
     return definedKeySize;
+  }
+
+  public static synchronized List<StyleKey> getDefinedStyleKeysList() {
+    if (definedKeysList != null) {
+      return definedKeysList;
+    }
+    definedKeysList = Collections.unmodifiableList( Arrays.asList( getDefinedStyleKeys() ) );
+    return definedKeysList;
   }
 
   public static synchronized StyleKey[] getDefinedStyleKeys() {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/style/StyleKey.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/style/StyleKey.java
@@ -284,7 +284,7 @@ public final class StyleKey implements Serializable, Cloneable {
   }
 
   public static synchronized List<StyleKey> getDefinedStyleKeysList() {
-    if (definedKeysList != null) {
+    if ( definedKeysList != null ) {
       return definedKeysList;
     }
     definedKeysList = Collections.unmodifiableList( Arrays.asList( getDefinedStyleKeys() ) );

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DataAttributeCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DataAttributeCache.java
@@ -1,0 +1,22 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.wizard;
+
+public interface DataAttributeCache {
+  public ImmutableDataAttributes normalize( DataAttributes attrs, DataAttributeContext context  );
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DataAttributeCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DataAttributeCache.java
@@ -18,5 +18,5 @@
 package org.pentaho.reporting.engine.classic.core.wizard;
 
 public interface DataAttributeCache {
-  public ImmutableDataAttributes normalize( DataAttributes attrs, DataAttributeContext context  );
+  ImmutableDataAttributes normalize( DataAttributes attrs, DataAttributeContext context  );
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributeCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributeCache.java
@@ -66,11 +66,10 @@ public class DefaultDataAttributeCache implements DataAttributeCache {
     }
 
     public String toString() {
-      return "CacheKey{" +
-               "locale='" + locale + '\'' +
-               ", outputType='" + outputType + '\'' +
-               ", attrs=" + attrs +
-               '}';
+      return "CacheKey{"
+        + "locale='" + locale + '\''
+        + ", outputType='" + outputType + '\''
+        + ", attrs=" + attrs + '}';
     }
   }
 

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributeCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributeCache.java
@@ -1,0 +1,97 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.wizard;
+
+import org.pentaho.reporting.libraries.base.boot.SingletonHint;
+import org.pentaho.reporting.libraries.base.util.DebugLog;
+import org.pentaho.reporting.libraries.base.util.LFUMap;
+
+@SingletonHint
+public class DefaultDataAttributeCache implements DataAttributeCache {
+  private static class CacheKey {
+    private String locale;
+    private String outputType;
+    private ImmutableDataAttributes attrs;
+
+    private CacheKey( final DataAttributeContext context,
+                      final ImmutableDataAttributes attrs ) {
+      this.locale = context.getLocale().toLanguageTag();
+      this.outputType = context.getOutputProcessorMetaData().getExportDescriptor();
+      this.attrs = attrs;
+    }
+
+    public boolean equals( final Object o ) {
+      if ( this == o ) {
+        return true;
+      }
+      if ( o == null || getClass() != o.getClass() ) {
+        return false;
+      }
+
+      final CacheKey cacheKey = (CacheKey) o;
+
+      if ( locale != null ? !locale.equals( cacheKey.locale ) : cacheKey.locale != null ) {
+        return false;
+      }
+      if ( outputType != null ? !outputType.equals( cacheKey.outputType ) : cacheKey.outputType != null ) {
+        return false;
+      }
+      if ( attrs != null ? !attrs.equals( cacheKey.attrs ) : cacheKey.attrs != null ) {
+        return false;
+      }
+
+      return true;
+    }
+
+    public int hashCode() {
+      int result = locale != null ? locale.hashCode() : 0;
+      result = 31 * result + ( outputType != null ? outputType.hashCode() : 0 );
+      result = 31 * result + ( attrs != null ? attrs.hashCode() : 0 );
+      return result;
+    }
+
+    public String toString() {
+      return "CacheKey{" +
+               "locale='" + locale + '\'' +
+               ", outputType='" + outputType + '\'' +
+               ", attrs=" + attrs +
+               '}';
+    }
+  }
+
+  private LFUMap<CacheKey, ImmutableDataAttributes> backend;
+
+  public DefaultDataAttributeCache() {
+    DebugLog.log( this.toString() );
+    this.backend = new LFUMap<CacheKey, ImmutableDataAttributes>( 5000 );
+  }
+
+  public ImmutableDataAttributes normalize( final DataAttributes attrs,
+                                                         final DataAttributeContext context ) {
+    ImmutableDataAttributes key = ImmutableDataAttributes.create( attrs, context );
+    CacheKey cacheKey = new CacheKey( context, key );
+    synchronized ( this ) {
+      ImmutableDataAttributes fromCache = backend.get( cacheKey );
+      if ( fromCache == null ) {
+        backend.put( cacheKey, key );
+        return key;
+      }
+      return fromCache;
+    }
+  }
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributeCache.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributeCache.java
@@ -24,9 +24,9 @@ import org.pentaho.reporting.libraries.base.util.LFUMap;
 @SingletonHint
 public class DefaultDataAttributeCache implements DataAttributeCache {
   private static class CacheKey {
-    private String locale;
-    private String outputType;
-    private ImmutableDataAttributes attrs;
+    private final String locale;
+    private final String outputType;
+    private final ImmutableDataAttributes attrs;
 
     private CacheKey( final DataAttributeContext context,
                       final ImmutableDataAttributes attrs ) {

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributes.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/DefaultDataAttributes.java
@@ -48,7 +48,7 @@ public class DefaultDataAttributes implements DataAttributes {
     if ( domain == null ) {
       throw new NullPointerException();
     }
-    backend.setAttribute( domain, name, new Entry(conceptMapper, value));
+    backend.setAttribute( domain, name, new Entry( conceptMapper, value ) );
   }
 
   public String[] getMetaAttributeDomains() {
@@ -138,7 +138,7 @@ public class DefaultDataAttributes implements DataAttributes {
         final Object value = attributes.getMetaAttribute( domain, name, null, context );
         if ( value != null ) {
           ConceptQueryMapper mapper = attributes.getMetaAttributeMapper( domain, name );
-          backend.setAttribute( domain, name, new Entry(mapper, value) );
+          backend.setAttribute( domain, name, new Entry( mapper, value ) );
         }
       }
     }
@@ -162,7 +162,7 @@ public class DefaultDataAttributes implements DataAttributes {
         final Object value = ref.resolve( this, context );
         if ( value != null ) {
           ConceptQueryMapper conceptQueryMapper = ref.resolveMapper( this );
-          backend.setAttribute( domain, name, new Entry(conceptQueryMapper, value ));
+          backend.setAttribute( domain, name, new Entry( conceptQueryMapper, value ) );
         }
       }
     }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/ImmutableDataAttributes.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/wizard/ImmutableDataAttributes.java
@@ -66,24 +66,23 @@ public final class ImmutableDataAttributes implements DataAttributes {
     this.backend = new AttributeMap<Entry>();
   }
 
-  private ImmutableDataAttributes(DataAttributes source, DataAttributeContext context) {
+  private ImmutableDataAttributes( DataAttributes source, DataAttributeContext context ) {
     this.backend = new AttributeMap<Entry>();
     merge( source, context );
   }
 
-  public ImmutableDataAttributes(AttributeMap<Object> data) {
+  public ImmutableDataAttributes( AttributeMap<Object> data ) {
     this.backend = new AttributeMap<Entry>();
-    for (AttributeMap.DualKey k: data.keySet()) {
+    for ( AttributeMap.DualKey k : data.keySet() ) {
       final Object value = data.getAttribute( k.namespace, k.name );
       this.backend.setAttribute( k.namespace, k.name, new Entry( DefaultConceptQueryMapper.INSTANCE, value ) );
     }
   }
 
-  public static ImmutableDataAttributes create(DataAttributes source, DataAttributeContext context) {
-    if (source instanceof ImmutableDataAttributes) {
+  public static ImmutableDataAttributes create( DataAttributes source, DataAttributeContext context ) {
+    if ( source instanceof ImmutableDataAttributes ) {
       return (ImmutableDataAttributes) source;
-    }
-    else {
+    } else {
       return new ImmutableDataAttributes( source, context );
     }
   }
@@ -135,7 +134,7 @@ public final class ImmutableDataAttributes implements DataAttributes {
     if ( attribute == null ) {
       return defaultValue;
     }
-    if (attribute.value == null) {
+    if ( attribute.value == null ) {
       return defaultValue;
     }
     final ConceptQueryMapper mapper = attribute.mapper;
@@ -158,7 +157,7 @@ public final class ImmutableDataAttributes implements DataAttributes {
   }
 
   private void merge( final DataAttributes attributes,
-                     final DataAttributeContext context ) {
+                      final DataAttributeContext context ) {
     if ( attributes == null ) {
       throw new NullPointerException();
     }
@@ -175,7 +174,7 @@ public final class ImmutableDataAttributes implements DataAttributes {
         final Object value = attributes.getMetaAttribute( domain, name, null, context );
         if ( value != null ) {
           ConceptQueryMapper mapper = attributes.getMetaAttributeMapper( domain, name );
-          backend.setAttribute( domain, name, new Entry(mapper, value) );
+          backend.setAttribute( domain, name, new Entry( mapper, value ) );
         }
       }
     }
@@ -212,4 +211,3 @@ public final class ImmutableDataAttributes implements DataAttributes {
     return backend.hashCode();
   }
 }
-

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/ReportAttributeMapTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/ReportAttributeMapTest.java
@@ -17,7 +17,10 @@
 
 package org.pentaho.reporting.engine.classic.core;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/ReportAttributeMapTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/ReportAttributeMapTest.java
@@ -1,0 +1,103 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.reporting.libraries.xmlns.common.AttributeMap;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ReportAttributeMapTest {
+
+  private ReportAttributeMap<String> map;
+
+  @Before
+  public void setUp() {
+    map = new ReportAttributeMap<String>();
+  }
+
+  @After
+  public void tearDown() {
+    map = null;
+  }
+
+
+  @Test( expected = UnsupportedOperationException.class )
+  public void unmodifiable_setAttribute() {
+    map.createUnmodifiableMap().setAttribute( "namespace", "attribute", "value" );
+  }
+
+  @Test( expected = UnsupportedOperationException.class )
+  public void unmodifiable_putAll() {
+    map.createUnmodifiableMap().putAll( new AttributeMap<String>() );
+  }
+
+  @Test
+  public void unmodifiable_isReadOnly() {
+    assertTrue( map.createUnmodifiableMap().isReadOnly() );
+  }
+
+
+  @Test
+  public void ordinal_isNotReadOnly() {
+    assertFalse( map.isReadOnly() );
+  }
+
+  @Test
+  public void ordinal_setAttribute() {
+    assertNull( map.setAttribute( "namespace", "attribute", "value" ) );
+    assertEquals( 1, map.getChangeTracker() );
+  }
+
+  @Test
+  public void ordinal_setAttribute_DoesNotIncrementCounterForSameValues() {
+    assertNull( map.setAttribute( "namespace", "attribute", "value" ) );
+    assertEquals( "value", map.setAttribute( "namespace", "attribute", "value" ) );
+    assertEquals( 1, map.getChangeTracker() );
+  }
+
+  @Test
+  public void ordinal_putAll() {
+    ReportAttributeMap<String> another = new ReportAttributeMap<>();
+    another.setAttribute( "namespace1", "attribute1", "value1" );
+    another.setAttribute( "namespace1", "attribute2", "value2" );
+    another.setAttribute( "namespace2", "attribute1", "value1" );
+    another.setAttribute( "namespace2", "attribute2", "value2" );
+    map.putAll( another );
+
+    assertEquals( 1, map.getChangeTracker() );
+    assertEquals( 4, map.keySet().size() );
+  }
+
+  @Test
+  public void ordinal_putAll_AlwaysIncrementsCounter() {
+    ReportAttributeMap<String> another = new ReportAttributeMap<>();
+    another.setAttribute( "namespace", "attribute", "value" );
+    map.putAll( another );
+    map.putAll( another );
+
+    assertEquals( 2, map.getChangeTracker() );
+    assertEquals( 1, map.keySet().size() );
+  }
+
+}

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/bugs/Prd4071IT.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/bugs/Prd4071IT.java
@@ -67,7 +67,7 @@ public class Prd4071IT extends TestCase {
     assertEquals( 71700000, logicalPageBox.getPageEnd() );
     final RenderNode[] elementsByElementType =
         MatchFactory.findElementsByElementType( logicalPageBox, ItemBandType.INSTANCE );
-    assertEquals( 23, elementsByElementType.length );
+    assertEquals( 22, elementsByElementType.length );
     // The second page is not empty even though a break-marker box exists at the beginning.
     // This break-marker is ignored as its validity range is wrong for the page it is on.
     // If it were NOT ingnored, there would be no itembands on that page.
@@ -90,7 +90,7 @@ public class Prd4071IT extends TestCase {
     assertEquals( 21, elementsByElementType.length ); // 21
     final RenderNode lastChild = elementsByElementType[20];
     // important part is that the y2 is less than the page-end
-    assertEquals( 68447100, lastChild.getY() + lastChild.getHeight() );
+    assertEquals( 69420900, lastChild.getY() + lastChild.getHeight() );
 
   }
 
@@ -107,10 +107,10 @@ public class Prd4071IT extends TestCase {
     assertEquals( 71700000, logicalPageBox.getPageEnd() );
     final RenderNode[] elementsByElementType =
         MatchFactory.findElementsByElementType( logicalPageBox, ItemBandType.INSTANCE );
-    assertEquals( 22, elementsByElementType.length ); // 22
-    final RenderNode lastChild = elementsByElementType[21];
+    assertEquals( 9, elementsByElementType.length ); // 22
+    final RenderNode lastChild = elementsByElementType[elementsByElementType.length - 1];
     // important part is that the y2 is less than the page-end
-    assertEquals( 68097100, lastChild.getY() + lastChild.getHeight() );
+    assertTrue( lastChild.getY() + lastChild.getHeight() < logicalPageBox.getPageEnd() );
   }
 
 }

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/query-1.txt
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/query-1.txt
@@ -1599,6 +1599,8 @@ ValueAt (121, 9) is in a typed column and is of type class java.lang.String
 ValueAt (121, 10) is in a typed column and is of type class java.lang.String
 ValueAt (121, 11) is in a typed column and is of type class java.lang.Integer
 ValueAt (121, 12) is in a typed column and is of type class java.math.BigDecimal
+ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=CUSTOMERNUMBER
+ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.Integer
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1608,6 +1610,8 @@ ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=32
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=true
+ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=CUSTOMERNAME
+ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1617,6 +1621,8 @@ ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=CONTACTLASTNAME
+ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1626,6 +1632,8 @@ ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=CONTACTFIRSTNAME
+ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1635,6 +1643,8 @@ ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=PHONE
+ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1644,6 +1654,8 @@ ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(4) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=ADDRESSLINE1
+ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1653,6 +1665,8 @@ ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(5) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=ADDRESSLINE2
+ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1662,6 +1676,8 @@ ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(6) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=CITY
+ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1671,6 +1687,8 @@ ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(7) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=STATE
+ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1680,6 +1698,8 @@ ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(8) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=POSTALCODE
+ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1689,6 +1709,8 @@ ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=15
 ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(9) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=COUNTRY
+ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1698,6 +1720,8 @@ ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attribu
 ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=50
 ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(10) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=false
+ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=SALESREPEMPLOYEENUMBER
+ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.Integer
 ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS
@@ -1707,6 +1731,8 @@ ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attribu
 ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:precision]=32
 ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:scale]=0
 ColumnAttribute(11) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/numeric:signed]=true
+ColumnAttribute(12) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=CREDITLIMIT
+ColumnAttribute(12) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.math.BigDecimal
 ColumnAttribute(12) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(12) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(12) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMERS

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PentahoMetaDataAttributes.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PentahoMetaDataAttributes.java
@@ -18,6 +18,7 @@
 package org.pentaho.reporting.engine.classic.extensions.datasources.pmd;
 
 import org.pentaho.metadata.model.concept.IConcept;
+import org.pentaho.reporting.engine.classic.core.MetaAttributeNames;
 import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributes;
@@ -50,15 +51,24 @@ public class PentahoMetaDataAttributes implements DataAttributes {
   private IConcept concept;
   private ArrayList<ConceptQueryMapper> conceptMappers;
   private LinkedHashMap<String, Object> properties;
+  private String columnName;
 
+  @Deprecated
   public PentahoMetaDataAttributes( final DataAttributes backend,
                                     final IConcept concept ) {
+    this(backend, concept, null);
+  }
+
+  public PentahoMetaDataAttributes( final DataAttributes backend,
+                                    final IConcept concept,
+                                    final String columnName ) {
     if ( concept == null ) {
       throw new NullPointerException();
     }
     if ( backend == null ) {
       throw new NullPointerException();
     }
+    this.columnName = columnName;
     this.concept = concept;
     this.properties = new LinkedHashMap<String, Object>( concept.getProperties() );
 
@@ -123,7 +133,13 @@ public class PentahoMetaDataAttributes implements DataAttributes {
       // We cant solve the problem here, so all we can do is hope and pray.
       return convertFromPmd( value, type, defaultValue, context );
     }
-
+    if ( MetaAttributeNames.Core.NAMESPACE.equals( domain ) &&
+         MetaAttributeNames.Core.NAME.equals( name )) {
+      ConceptQueryMapper metaAttributeMapper = backend.getMetaAttributeMapper( domain, name );
+      if ( metaAttributeMapper != null ) {
+        return metaAttributeMapper.getValue( columnName, type, context );
+      }
+    }
     return backend.getMetaAttribute( domain, name, type, context, defaultValue );
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PentahoMetaDataAttributes.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PentahoMetaDataAttributes.java
@@ -44,8 +44,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 public class PentahoMetaDataAttributes implements DataAttributes {
-  private static final String[] NAMESPACES = new String[]
-    { PmdDataFactoryModule.META_DOMAIN };
+  private static final String[] NAMESPACES = new String[] { PmdDataFactoryModule.META_DOMAIN };
 
   private DataAttributes backend;
   private IConcept concept;
@@ -65,21 +64,21 @@ public class PentahoMetaDataAttributes implements DataAttributes {
 
     this.backend = backend;
     this.conceptMappers = new ArrayList<ConceptQueryMapper>();
-    this.conceptMappers.add( new AggregationConceptMapper() );
-    this.conceptMappers.add( new AlignmentConceptMapper() );
-    this.conceptMappers.add( new BooleanConceptMapper() );
-    this.conceptMappers.add( new ColorConceptMapper() );
-    this.conceptMappers.add( new ColumnWidthConceptMapper() );
-    this.conceptMappers.add( new DataTypeConceptMapper() );
-    this.conceptMappers.add( new DateConceptMapper() );
-    this.conceptMappers.add( new FieldTypeConceptMapper() );
-    this.conceptMappers.add( new FontSettingsConceptMapper() );
-    this.conceptMappers.add( new NumberConceptMapper() );
-    this.conceptMappers.add( new LocalizedStringConceptMapper() );
-    this.conceptMappers.add( new TableTypeConceptMapper() );
-    this.conceptMappers.add( new URLConceptMapper() );
-    this.conceptMappers.add( new StringConceptMapper() );
-    this.conceptMappers.add( new SecurityConceptMapper() );
+    this.conceptMappers.add( AggregationConceptMapper.INSTANCE );
+    this.conceptMappers.add( AlignmentConceptMapper.INSTANCE );
+    this.conceptMappers.add( BooleanConceptMapper.INSTANCE );
+    this.conceptMappers.add( ColorConceptMapper.INSTANCE );
+    this.conceptMappers.add( ColumnWidthConceptMapper.INSTANCE );
+    this.conceptMappers.add( DataTypeConceptMapper.INSTANCE );
+    this.conceptMappers.add( DateConceptMapper.INSTANCE );
+    this.conceptMappers.add( FieldTypeConceptMapper.INSTANCE );
+    this.conceptMappers.add( FontSettingsConceptMapper.INSTANCE );
+    this.conceptMappers.add( NumberConceptMapper.INSTANCE );
+    this.conceptMappers.add( LocalizedStringConceptMapper.INSTANCE );
+    this.conceptMappers.add( TableTypeConceptMapper.INSTANCE );
+    this.conceptMappers.add( URLConceptMapper.INSTANCE );
+    this.conceptMappers.add( StringConceptMapper.INSTANCE );
+    this.conceptMappers.add( SecurityConceptMapper.INSTANCE );
   }
 
   public String[] getMetaAttributeDomains() {

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PmdMetaTableModel.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PmdMetaTableModel.java
@@ -59,7 +59,7 @@ public class PmdMetaTableModel implements MetaTableModel, CloseableTableModel {
 
   public DataAttributes getCellDataAttributes( final int row, final int column ) {
     return new PentahoMetaDataAttributes( parentTableModel.getCellDataAttributes( row, column ),
-      selections[ column ].getLogicalColumn() );
+      selections[ column ].getLogicalColumn(), getColumnName( column ) );
   }
 
   public boolean isCellDataAttributesSupported() {
@@ -68,7 +68,7 @@ public class PmdMetaTableModel implements MetaTableModel, CloseableTableModel {
 
   public DataAttributes getColumnAttributes( final int column ) {
     return new PentahoMetaDataAttributes( parentTableModel.getColumnAttributes( column ),
-      selections[ column ].getLogicalColumn() );
+      selections[ column ].getLogicalColumn(), getColumnName( column )  );
   }
 
   public DataAttributes getTableAttributes() {

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/AggregationConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/AggregationConceptMapper.java
@@ -22,6 +22,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class AggregationConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new AggregationConceptMapper();
+
   public AggregationConceptMapper() {
   }
 
@@ -43,7 +45,7 @@ public class AggregationConceptMapper implements ConceptQueryMapper {
       return value;
     }
 
-    if ( type == null || Object.class.equals( type ) || AggregationType.class.equals( type ) ) {
+    if ( type == null || Object.class.equals( type ) ) {
       return value;
     }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/AlignmentConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/AlignmentConceptMapper.java
@@ -24,6 +24,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class AlignmentConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new AlignmentConceptMapper();
+
   private ElementAlignmentValueConverter alignmentValueConverter;
 
   public AlignmentConceptMapper() {
@@ -48,7 +50,7 @@ public class AlignmentConceptMapper implements ConceptQueryMapper {
       return value;
     }
 
-    if ( type == null || Object.class.equals( type ) || Alignment.class.equals( type ) ) {
+    if ( type == null || Object.class.equals( type ) ) {
       return value;
     }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/BooleanConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/BooleanConceptMapper.java
@@ -21,6 +21,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class BooleanConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new BooleanConceptMapper();
+
   public BooleanConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/ColorConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/ColorConceptMapper.java
@@ -24,6 +24,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class ColorConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new ColorConceptMapper();
+
   private ColorValueConverter colorValueConverter;
 
   public ColorConceptMapper() {

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/ColumnWidthConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/ColumnWidthConceptMapper.java
@@ -69,8 +69,7 @@ public class ColumnWidthConceptMapper implements ConceptQueryMapper {
       final double resolution = data.getNumericFeatureValue( OutputProcessorFeature.DEVICE_RESOLUTION );
       final double deviceScaleFactor = ( 72.0 / resolution );
       rawWidth = (float) ( widthValue * deviceScaleFactor );
-    } else // if (widthType == ColumnWidth.POINTS
-    {
+    } else {// if (widthType == ColumnWidth.POINTS
       rawWidth = Math.max( 0, widthValue );
     }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/ColumnWidthConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/ColumnWidthConceptMapper.java
@@ -27,6 +27,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class ColumnWidthConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new ColumnWidthConceptMapper();
+
   public ColumnWidthConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/DataTypeConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/DataTypeConceptMapper.java
@@ -24,6 +24,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 import java.util.Date;
 
 public class DataTypeConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new DataTypeConceptMapper();
+
   public DataTypeConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/DateConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/DateConceptMapper.java
@@ -25,6 +25,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 import java.util.Date;
 
 public class DateConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new DateConceptMapper();
+
   public DateConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FieldTypeConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FieldTypeConceptMapper.java
@@ -22,6 +22,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class FieldTypeConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new FieldTypeConceptMapper();
+
   public FieldTypeConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontBoldConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontBoldConceptMapper.java
@@ -22,6 +22,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class FontBoldConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new FontBoldConceptMapper();
+
   public FontBoldConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontItalicConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontItalicConceptMapper.java
@@ -22,6 +22,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class FontItalicConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new FontItalicConceptMapper();
   public FontItalicConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontNameConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontNameConceptMapper.java
@@ -22,6 +22,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class FontNameConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new FontNameConceptMapper();
   public FontNameConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontSettingsConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontSettingsConceptMapper.java
@@ -22,6 +22,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class FontSettingsConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new FontSettingsConceptMapper();
   public FontSettingsConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontSizeConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/FontSizeConceptMapper.java
@@ -24,6 +24,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class FontSizeConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new FontSizeConceptMapper();
   public FontSizeConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/LocalizedStringConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/LocalizedStringConceptMapper.java
@@ -26,6 +26,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 import java.util.Locale;
 
 public class LocalizedStringConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new LocalizedStringConceptMapper();
   private static final Log logger = LogFactory.getLog( LocalizedStringConceptMapper.class );
 
   public LocalizedStringConceptMapper() {

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/LocalizedStringConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/LocalizedStringConceptMapper.java
@@ -62,8 +62,8 @@ public class LocalizedStringConceptMapper implements ConceptQueryMapper {
     final String localeAsText = locale.toString();
     final Object o = settings.getLocalizedString( localeAsText );
     if ( o == null ) {
-      logger.warn( "Unable to translate localized-string property for locale [" + locale + "]. " +
-        "The localization does not contain a translation for this locale and does not provide a fallback." );
+      logger.warn( "Unable to translate localized-string property for locale [" + locale + "]. "
+        + "The localization does not contain a translation for this locale and does not provide a fallback." );
     }
     return o;
   }

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/NumberConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/NumberConceptMapper.java
@@ -23,6 +23,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class NumberConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new NumberConceptMapper();
   public NumberConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/SecurityConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/SecurityConceptMapper.java
@@ -23,6 +23,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class SecurityConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new SecurityConceptMapper();
   public SecurityConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/StringConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/StringConceptMapper.java
@@ -21,6 +21,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class StringConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new StringConceptMapper();
   public StringConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/TableTypeConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/TableTypeConceptMapper.java
@@ -22,6 +22,7 @@ import org.pentaho.reporting.engine.classic.core.wizard.ConceptQueryMapper;
 import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 
 public class TableTypeConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new TableTypeConceptMapper();
   public TableTypeConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/URLConceptMapper.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/types/URLConceptMapper.java
@@ -23,6 +23,8 @@ import org.pentaho.reporting.engine.classic.core.wizard.DataAttributeContext;
 import java.net.URL;
 
 public class URLConceptMapper implements ConceptQueryMapper {
+  public static final ConceptQueryMapper INSTANCE = new URLConceptMapper();
+
   public URLConceptMapper() {
   }
 

--- a/engine/extensions-pentaho-metadata/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/agg-query-results.txt
+++ b/engine/extensions-pentaho-metadata/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/agg-query-results.txt
@@ -15,6 +15,8 @@ ValueAt (2, 2) is not assignable from class java.lang.Integer
 ValueAt (3, 0) is in a typed column and is of type class java.lang.String
 ValueAt (3, 1) is in a typed column and is of type class java.lang.Long
 ValueAt (3, 2) is not assignable from class java.lang.Integer
+ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_CUSTOMER_W_TER_TERRITORY
+ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=CUSTOMER_W_TER
@@ -36,6 +38,8 @@ ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:security]=SecurityWrapper{ownerAclMap={{class=SecurityOwner, ownerType=ROLE, ownerName=Admin}=31, {class=SecurityOwner, ownerType=USER, ownerName=suzy}=31}}
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column]=TERRITORY
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column_type]=COLUMN_NAME
+ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_ORDERDETAILS_QUANTITYORDERED
+ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.Long
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=
@@ -57,6 +61,8 @@ ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:security]=SecurityWrapper{ownerAclMap={{class=SecurityOwner, ownerType=ROLE, ownerName=Admin}=31, {class=SecurityOwner, ownerType=USER, ownerName=suzy}=31}}
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column]=QUANTITYORDERED
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column_type]=COLUMN_NAME
+ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_ORDERDETAILS_QUANTITYORDERED:AVERAGE
+ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.Integer
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=

--- a/engine/extensions-pentaho-metadata/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/query-results.txt
+++ b/engine/extensions-pentaho-metadata/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/query-results.txt
@@ -96,6 +96,8 @@ ValueAt (22, 0) is in a typed column and is of type class java.lang.String
 ValueAt (22, 1) is in a typed column and is of type class java.lang.String
 ValueAt (22, 2) is in a typed column and is of type class java.lang.Integer
 ValueAt (22, 3) is in a typed column and is of type class java.lang.String
+ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_EMPLOYEES_FIRSTNAME
+ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=EMPLOYEES
@@ -116,6 +118,8 @@ ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:security]=SecurityWrapper{ownerAclMap={{class=SecurityOwner, ownerType=ROLE, ownerName=Admin}=31}}
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column]=FIRSTNAME
 ColumnAttribute(0) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column_type]=COLUMN_NAME
+ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_EMPLOYEES_LASTNAME
+ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=EMPLOYEES
@@ -136,6 +140,8 @@ ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:security]=SecurityWrapper{ownerAclMap={{class=SecurityOwner, ownerType=ROLE, ownerName=Admin}=31}}
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column]=LASTNAME
 ColumnAttribute(1) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column_type]=COLUMN_NAME
+ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_EMPLOYEES_EMPLOYEENUMBER
+ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.Integer
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=EMPLOYEES
@@ -156,6 +162,8 @@ ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attribut
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:security]=SecurityWrapper{ownerAclMap={{class=SecurityOwner, ownerType=ROLE, ownerName=Admin}=31}}
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column]=EMPLOYEENUMBER
 ColumnAttribute(2) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/pentaho-meta-data:target_column_type]=COLUMN_NAME
+ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:name]=BC_EMPLOYEES_EMAIL
+ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/core:value-type]=class java.lang.String
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:catalog]=PUBLIC
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:schema]=PUBLIC
 ColumnAttribute(3) [http://reporting.pentaho.org/namespaces/engine/meta-attributes/database:table]=EMPLOYEES

--- a/engine/samples/build.xml
+++ b/engine/samples/build.xml
@@ -95,4 +95,6 @@
   		<fileset dir="${basedir}/WebContent"/>
   	</war>
   </target>
+
+  <target name="integration-test"/>
 </project>

--- a/engine/sdk/build.xml
+++ b/engine/sdk/build.xml
@@ -260,5 +260,6 @@
 
 	</target>
 
+  <target name="integration-test"/>
 
 </project>

--- a/libraries/libpensol/libpensol.iml
+++ b/libraries/libpensol/libpensol.iml
@@ -39,6 +39,19 @@
         <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" type="SOURCES" />
       </library>
     </orderEntry>
+    <orderEntry type="module-library" exported="" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/test-lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="file://$MODULE_DIR$/test-lib" />
+        </SOURCES>
+        <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" />
+        <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" type="SOURCES" />
+      </library>
+    </orderEntry>
   </component>
 </module>
 

--- a/libraries/libxml/source/org/pentaho/reporting/libraries/xmlns/common/AttributeMap.java
+++ b/libraries/libxml/source/org/pentaho/reporting/libraries/xmlns/common/AttributeMap.java
@@ -112,8 +112,7 @@ public class AttributeMap<T> implements Serializable, Cloneable {
         map.content = (LinkedHashMap<DualKey, T>) content.clone();
       }
       return map;
-    }
-    catch ( final CloneNotSupportedException cne ) {
+    } catch ( final CloneNotSupportedException cne ) {
       // ignored
       throw new IllegalStateException( "Cannot happen: Clone not supported exception" );
     }
@@ -244,7 +243,7 @@ public class AttributeMap<T> implements Serializable, Cloneable {
   }
 
   public Set<DualKey> keySet() {
-    if (content == null) {
+    if ( content == null ) {
       return Collections.emptySet();
     }
     return content.keySet();

--- a/libraries/libxml/source/org/pentaho/reporting/libraries/xmlns/common/AttributeMap.java
+++ b/libraries/libxml/source/org/pentaho/reporting/libraries/xmlns/common/AttributeMap.java
@@ -18,15 +18,16 @@
 package org.pentaho.reporting.libraries.xmlns.common;
 
 import java.io.Serializable;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * A attribute map holding &lt;namspace;name&gt;-value pairs.
+ * A attribute map holding &lt;namespace;name&gt;-value pairs.
  *
  * @author Thomas Morgner
  */
@@ -83,7 +84,7 @@ public class AttributeMap<T> implements Serializable, Cloneable {
   }
 
   /**
-   * Creates a new attibute map using the given parameter as source for the initial values.
+   * Creates a new attribute map using the given parameter as source for the initial values.
    *
    * @param copy the attribute map that should be copied.
    * @noinspection unchecked
@@ -193,7 +194,7 @@ public class AttributeMap<T> implements Serializable, Cloneable {
   }
 
   /**
-   * Returns all attributes of the given namespace as unmodifable map.
+   * Returns all attributes of the given namespace as unmodifiable map.
    *
    * @param namespace the namespace for which the attributes should be returned.
    * @return the map, never null.
@@ -204,12 +205,13 @@ public class AttributeMap<T> implements Serializable, Cloneable {
     }
 
     if ( content == null ) {
-      return null;
+      return Collections.emptyMap();
     }
     LinkedHashMap<String, T> entries = new LinkedHashMap<String, T>();
     for ( final Map.Entry<DualKey, T> entry : content.entrySet() ) {
-      if ( namespace.equals( entry.getKey().namespace ) ) {
-        entries.put( entry.getKey().name, entry.getValue() );
+      DualKey key = entry.getKey();
+      if ( namespace.equals( key.namespace ) ) {
+        entries.put( key.name, entry.getValue() );
       }
     }
     return Collections.unmodifiableMap( entries );
@@ -230,14 +232,15 @@ public class AttributeMap<T> implements Serializable, Cloneable {
       return AttributeMap.EMPTY_NAMESPACES;
     }
 
-    LinkedHashSet<String> entries = new LinkedHashSet<String>();
+    List<String> entries = new ArrayList<String>();
     for ( final Map.Entry<DualKey, T> entry : content.entrySet() ) {
-      if ( namespace.equals( entry.getKey().namespace ) ) {
-        entries.add( entry.getKey().name );
+      DualKey key = entry.getKey();
+      if ( namespace.equals( key.namespace ) ) {
+        entries.add( key.name );
       }
     }
 
-    return entries.toArray( new String[entries.size()] );
+    return entries.toArray( new String[ entries.size() ] );
   }
 
   public Set<DualKey> keySet() {


### PR DESCRIPTION
@tmorgner, review it please. Here are commits' messages:
 
[CLEANUP] - Add test-lib to LibPensol as Mockito is needed here. Update IntelliJ Code-Style rules to match Pentaho code style.
(cherry picked from commit 7e49ac8)

[PRD-5556] - Running PRPT in the background increases memory usage
- store derived instances; this severs the link to the master-report and marginally reduces retained heap size (cherry picked from commit c5d6d2f)
- introduced general process-level data store; this allows us to easily share instances across functions and helps to reduce heap usage (adopted from commit fdca215)
- optimize style resolver (adopted from commit a921b54)
  - by sharing more caches and instances, we can greatly reduce the retained heap here;
  - each instance used to use 4KB of heap, now with sharing we are down to roughly 250 bytes
- tone down the logging a bit (cherry picked from commit 74fdc0b)
- if a map is empty, use global shared empty instance (cherry picked from commit 0e80511)
  - potential bug: do not mix attributes and parameter!
- reorganize internal data for attribute-map (adopted from commit fbfc238)
  - using a single map saves quite some memory without too much negative impact
  - having a single key-set allows for some faster iteration.
- stateless classes can safely be singletons to reduce memory pressures (adopted from commit 54d83e4)
- normalize all data-attributes (adopted from commit af77380)
  - this way, if we see the same data over and over again, we can consolidate them into single instances
  - everyone else will not be worse off
- activate the fast-export scan only when we are actually in fast export mode (adopted from commit d4fd0c5)
  - every bit of data not stored on elements will reduce size manyfold as elements get cloned a lot
- wrapping style-keys into a read-only list allows safe sharing without creating copies all the time (adopted from commit d2ae4ca)
  - the key-list is only used in non-performance critical code, so it is relatively safe to do this

[PRD-5556] - Running PRPT in the background increases memory usage
- add several more improvements
  - in DataCacheKey, handle singletonMap case
  - in ParagraphPoolboxStyleSheet, optimise for-loop
  - in DefaultDataAttributeCache, make cache key's fields final
  - in ReportAttributeMap
    - remove the flag
    - introduce a separate immutable subclass
    - add tests
  - in AttributeMap
    - fix some typos
    - replace LinkedHashSet with ArrayList in getNames()
    - in getAttributes(), return empty map instead of null as the javadoc claims

[CLEANUP] - Apply Pentaho formatting
- apply proper formatting for all classes affected within [PRD-5556]