### PR TITLE
[CLEANUP] - Fix invalid tests. 

### DIFF
--- a/designer/report-designer-extension-pentaho/test-src/org/pentaho/reporting/designer/extensions/pentaho/repository/util/PublishSettingsTest.java
+++ b/designer/report-designer-extension-pentaho/test-src/org/pentaho/reporting/designer/extensions/pentaho/repository/util/PublishSettingsTest.java
@@ -20,8 +20,10 @@ package org.pentaho.reporting.designer.extensions.pentaho.repository.util;
 import static org.junit.Assert.*;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("We cannot test PublishSettns as it is using the preferences-API and thus is not independent.")
 public class PublishSettingsTest {
 
   @Before

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabHeaderTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabHeaderTest.java
@@ -27,10 +27,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.CrosstabHeaderType;
-import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class CrosstabHeaderTest {
 
@@ -38,9 +34,7 @@ public class CrosstabHeaderTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabOtherGroupBodyTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabOtherGroupBodyTest.java
@@ -29,14 +29,12 @@ import static org.mockito.Mockito.mock;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.CrosstabOtherGroupBodyType;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 
 public class CrosstabOtherGroupBodyTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabOtherGroupTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabOtherGroupTest.java
@@ -33,14 +33,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.CrosstabOtherGroupType;
 import org.pentaho.reporting.engine.classic.core.sorting.SortConstraint;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 
 public class CrosstabOtherGroupTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabSummaryHeaderTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabSummaryHeaderTest.java
@@ -27,17 +27,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.CrosstabSummaryHeaderType;
 import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class CrosstabSummaryHeaderTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test
@@ -61,7 +56,7 @@ public class CrosstabSummaryHeaderTest {
   @Test
   public void testGetSubReports() {
     CrosstabSummaryHeader header = new CrosstabSummaryHeader();
-    assertThat( header.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( header.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabTitleHeaderTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/CrosstabTitleHeaderTest.java
@@ -27,10 +27,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.CrosstabTitleHeaderType;
-import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class CrosstabTitleHeaderTest {
 
@@ -38,9 +34,7 @@ public class CrosstabTitleHeaderTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before
@@ -65,7 +59,7 @@ public class CrosstabTitleHeaderTest {
 
   @Test
   public void testGetSubReports() {
-    assertThat( header.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( header.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/DetailsFooterTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/DetailsFooterTest.java
@@ -28,16 +28,12 @@ import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.DetailsFooterType;
 import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
 import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class DetailsFooterTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test
@@ -93,7 +89,7 @@ public class DetailsFooterTest {
   @Test
   public void testGetSubReports() {
     DetailsFooter footer = new DetailsFooter();
-    assertThat( footer.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( footer.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/DetailsHeaderTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/DetailsHeaderTest.java
@@ -28,16 +28,12 @@ import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.DetailsHeaderType;
 import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
 import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class DetailsHeaderTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test
@@ -93,7 +89,7 @@ public class DetailsHeaderTest {
   @Test
   public void testGetSubReports() {
     DetailsHeader header = new DetailsHeader();
-    assertThat( header.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( header.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/GroupDataBodyTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/GroupDataBodyTest.java
@@ -30,10 +30,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.GroupDataBodyType;
-import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class GroupDataBodyTest {
 
@@ -41,9 +37,7 @@ public class GroupDataBodyTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/PageFooterTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/PageFooterTest.java
@@ -27,17 +27,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.PageFooterType;
 import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class PageFooterTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test
@@ -80,7 +75,7 @@ public class PageFooterTest {
   @Test
   public void testGetSubReports() {
     PageFooter footer = new PageFooter();
-    assertThat( footer.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( footer.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/PageHeaderTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/PageHeaderTest.java
@@ -27,13 +27,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.PageHeaderType;
 import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 
 public class PageHeaderTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( BandStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test
@@ -76,7 +75,7 @@ public class PageHeaderTest {
   @Test
   public void testGetSubReports() {
     PageHeader header = new PageHeader();
-    assertThat( header.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( header.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/RelationalGroupTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/RelationalGroupTest.java
@@ -35,8 +35,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.RelationalGroupType;
 import org.pentaho.reporting.engine.classic.core.sorting.SortConstraint;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 
 public class RelationalGroupTest {
 
@@ -44,7 +42,7 @@ public class RelationalGroupTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before
@@ -115,7 +113,7 @@ public class RelationalGroupTest {
     group.setFields( fields );
     group.clearFields();
     assertThat( (String[]) group.getAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.GROUP_FIELDS ),
-        is( equalTo( new String[] {} ) ) );
+        is( equalTo( new String[] { } ) ) );
   }
 
   @Test
@@ -178,11 +176,11 @@ public class RelationalGroupTest {
     group.setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.GROUP_FIELDS, "str" );
     assertThat( group.isGroupChange( dataRow ), is( equalTo( false ) ) );
 
-    group.setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.GROUP_FIELDS, new String[] {} );
+    group.setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.GROUP_FIELDS, new String[] { } );
     assertThat( group.isGroupChange( dataRow ), is( equalTo( false ) ) );
 
     group.setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.GROUP_FIELDS, new String[] { "field_0",
-      null, "field_1" } );
+        null, "field_1" } );
     doReturn( false ).when( dataRow ).isChanged( "field_0" );
     doReturn( true ).when( dataRow ).isChanged( "field_1" );
     assertThat( group.isGroupChange( dataRow ), is( equalTo( true ) ) );

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/StaticDataRowTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/StaticDataRowTest.java
@@ -29,14 +29,12 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 
 public class StaticDataRowTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    StyleKey.registerClass( BandStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test( expected = NullPointerException.class )
@@ -58,55 +56,55 @@ public class StaticDataRowTest {
 
   @Test( expected = NullPointerException.class )
   public void testCreationWithoutValues() {
-    new StaticDataRow( new String[] {}, null );
+    new StaticDataRow( new String[]{ }, null );
   }
 
   @Test
   public void testCreation() {
     StaticDataRow dataRow = new StaticDataRow();
-    assertThat( dataRow.getColumnNames(), is( equalTo( new String[] {} ) ) );
+    assertThat( dataRow.getColumnNames(), is( equalTo( new String[]{ } ) ) );
 
     StaticDataRow staticDataRowParam = mock( StaticDataRow.class );
     dataRow = new StaticDataRow( staticDataRowParam );
-    assertThat( dataRow.getColumnNames(), is( equalTo( new String[] {} ) ) );
+    assertThat( dataRow.getColumnNames(), is( equalTo( new String[]{ } ) ) );
 
     DataRow dataRowParam = mock( DataRow.class );
-    doReturn( new String[] { "test_name" } ).when( dataRowParam ).getColumnNames();
+    doReturn( new String[]{ "test_name" } ).when( dataRowParam ).getColumnNames();
     doReturn( "test_val" ).when( dataRowParam ).get( "test_name" );
     dataRow = new StaticDataRow( dataRowParam );
-    assertThat( dataRow.getColumnNames(), is( equalTo( new String[] { "test_name" } ) ) );
+    assertThat( dataRow.getColumnNames(), is( equalTo( new String[]{ "test_name" } ) ) );
     assertThat( (String) dataRow.get( "test_name" ), is( equalTo( "test_val" ) ) );
 
-    String[] names = new String[] { "name_0", "name_1" };
-    Object[] values = new Object[] { "value_0" };
+    String[] names = new String[]{ "name_0", "name_1" };
+    Object[] values = new Object[]{ "value_0" };
     dataRow = new StaticDataRow( names, values );
-    assertThat( dataRow.getColumnNames(), is( equalTo( new String[] { "name_0" } ) ) );
+    assertThat( dataRow.getColumnNames(), is( equalTo( new String[]{ "name_0" } ) ) );
     assertThat( (String) dataRow.get( "name_0" ), is( equalTo( "value_0" ) ) );
 
     Map<String, Object> parameterValues = new HashMap<String, Object>();
     parameterValues.put( "name_0", "value_0" );
     dataRow = new StaticDataRow( parameterValues );
-    assertThat( dataRow.getColumnNames(), is( equalTo( new String[] { "name_0" } ) ) );
+    assertThat( dataRow.getColumnNames(), is( equalTo( new String[]{ "name_0" } ) ) );
     assertThat( (String) dataRow.get( "name_0" ), is( equalTo( "value_0" ) ) );
   }
 
   @Test
   public void testUpdateData() {
-    String[] names = new String[] { "name_0" };
-    Object[] values = new Object[] { "value_0" };
+    String[] names = new String[]{ "name_0" };
+    Object[] values = new Object[]{ "value_0" };
     StaticDataRow dataRow = new StaticDataRow( names, values );
-    Object[] newValues = new Object[] { "new_value_0" };
+    Object[] newValues = new Object[]{ "new_value_0" };
     dataRow.updateData( newValues );
-    assertThat( dataRow.getColumnNames(), is( equalTo( new String[] { "name_0" } ) ) );
+    assertThat( dataRow.getColumnNames(), is( equalTo( new String[]{ "name_0" } ) ) );
     assertThat( (String) dataRow.get( "name_0" ), is( equalTo( "new_value_0" ) ) );
   }
 
   @Test( expected = IllegalArgumentException.class )
   public void testUpdateDataException() {
-    String[] names = new String[] { "name_0" };
-    Object[] values = new Object[] { "value_0" };
+    String[] names = new String[]{ "name_0" };
+    Object[] values = new Object[]{ "value_0" };
     StaticDataRow dataRow = new StaticDataRow( names, values );
-    Object[] newValues = new Object[] { "new_value_0", "new_value_1" };
+    Object[] newValues = new Object[]{ "new_value_0", "new_value_1" };
     dataRow.updateData( newValues );
   }
 
@@ -122,12 +120,12 @@ public class StaticDataRowTest {
     assertThat( dataRow.equals( dataRow ), is( equalTo( true ) ) );
     assertThat( dataRow.equals( "incorrect" ), is( equalTo( false ) ) );
 
-    String[] names = new String[] { "name_0" };
-    Object[] values = new Object[] { "value_0" };
+    String[] names = new String[]{ "name_0" };
+    Object[] values = new Object[]{ "value_0" };
     StaticDataRow newDataRow = new StaticDataRow( names, values );
     assertThat( dataRow.equals( newDataRow ), is( equalTo( false ) ) );
 
-    dataRow.setData( names, new Object[] { "test_val" } );
+    dataRow.setData( names, new Object[]{ "test_val" } );
     assertThat( dataRow.equals( newDataRow ), is( equalTo( false ) ) );
 
     dataRow.setData( names, values );

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/WatermarkTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/WatermarkTest.java
@@ -27,17 +27,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.filter.types.bands.WatermarkType;
 import org.pentaho.reporting.engine.classic.core.style.BandStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
-import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
 
 public class WatermarkTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
-    StyleKey.registerClass( BandStyleKeys.class );
-    StyleKey.registerClass( TextStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Test
@@ -84,7 +79,7 @@ public class WatermarkTest {
   @Test
   public void testGetSubReports() {
     Watermark watermark = new Watermark();
-    assertThat( watermark.getSubReports(), is( equalTo( new SubReport[] {} ) ) );
+    assertThat( watermark.getSubReports(), is( equalTo( new SubReport[]{ } ) ) );
   }
 
   @Test

--- a/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sbarcodes/elementfactory/BarcodeElementFactoryTest.java
+++ b/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sbarcodes/elementfactory/BarcodeElementFactoryTest.java
@@ -35,9 +35,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.Element;
 import org.pentaho.reporting.engine.classic.core.function.FormulaExpression;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
 import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
 import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
@@ -50,7 +50,7 @@ public class BarcodeElementFactoryTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before

--- a/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/elementfactory/BarSparklineElementFactoryTest.java
+++ b/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/elementfactory/BarSparklineElementFactoryTest.java
@@ -37,9 +37,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.Element;
 import org.pentaho.reporting.engine.classic.core.function.FormulaExpression;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
 import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
 import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.BarSparklineType;
@@ -52,7 +52,7 @@ public class BarSparklineElementFactoryTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before

--- a/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/elementfactory/LineSparklineElementFactoryTest.java
+++ b/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/elementfactory/LineSparklineElementFactoryTest.java
@@ -30,10 +30,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.Element;
 import org.pentaho.reporting.engine.classic.core.function.FormulaExpression;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
-import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.LineSparklineType;
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.SparklineAttributeNames;
 
@@ -43,7 +42,7 @@ public class LineSparklineElementFactoryTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before

--- a/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/elementfactory/PieSparklineElementFactoryTest.java
+++ b/engine/extensions/test-src/org/pentaho/reporting/engine/classic/extensions/modules/sparklines/elementfactory/PieSparklineElementFactoryTest.java
@@ -37,9 +37,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.AttributeNames;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.Element;
 import org.pentaho.reporting.engine.classic.core.function.FormulaExpression;
-import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
 import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
 import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 import org.pentaho.reporting.engine.classic.extensions.modules.sparklines.PieSparklineType;
@@ -52,7 +52,7 @@ public class PieSparklineElementFactoryTest {
 
   @BeforeClass
   public static void init() {
-    StyleKey.registerClass( ElementStyleKeys.class );
+    ClassicEngineBoot.getInstance().start();
   }
 
   @Before


### PR DESCRIPTION
We cannot assume the system is stable until the reporting engine has been properly initialized. Manually registering parts of the system will not yield correct results, it needs a full boot. PublishSettingsTest cannot work as it uses the system-state dependent preferences API.