### PR TITLE
PRD-5567 Tab of report displays not correctly information about stateof report.

### DIFF
--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/actions/global/OpenReportAction.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/actions/global/OpenReportAction.java
@@ -199,10 +199,10 @@ public final class OpenReportAction extends AbstractDesignerContextAction {
     final MasterReport reportDefinition = loadReport( selectedFile, resourceManager );
     try {
       reportDefinition.setAttribute
-        ( ReportDesignerBoot.DESIGNER_NAMESPACE, "report-save-path", selectedFile.getCanonicalPath() ); // NON-NLS
+        ( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME, selectedFile.getCanonicalPath() ); // NON-NLS
     } catch ( IOException ioe ) {
       reportDefinition.setAttribute
-        ( ReportDesignerBoot.DESIGNER_NAMESPACE, "report-save-path", selectedFile.getAbsolutePath() ); // NON-NLS
+        ( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME, selectedFile.getAbsolutePath() ); // NON-NLS
     }
 
     return reportDefinition;

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/actions/report/AbstractSaveReportAction.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/actions/report/AbstractSaveReportAction.java
@@ -69,18 +69,21 @@ public abstract class AbstractSaveReportAction extends AbstractReportContextActi
     }
 
     // if no name has been set for the report, default to the name of the file
+    String attPath;
     try {
-      report.setAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, "report-save-path",
-        target.getCanonicalPath() ); // NON-NLS
+      attPath = target.getCanonicalPath();
     } catch ( IOException ioe ) {
       // then let's not set the save path attribute to the *canonical path*
-      report
-        .setAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, "report-save-path", target.getAbsolutePath() ); // NON-NLS
+      attPath = target.getAbsolutePath();
     }
 
     // Write the report to the filename
     if ( SaveReportUtilities.saveReport( context, activeContext, target ) ) {
       try {
+        // change report save path only in case save success. see PRD-5567
+        report
+          .setAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME, attPath );
+
         // Update the definition source to be the location from which the file is saved
         final ResourceManager resourceManager = report.getResourceManager();
         final Resource bundleResource = resourceManager.createDirectly( target, DocumentBundle.class );

--- a/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/ReportRenderContext.java
+++ b/designer/report-designer/src/org/pentaho/reporting/designer/core/editor/ReportRenderContext.java
@@ -102,7 +102,7 @@ public class ReportRenderContext implements ReportDocumentContext {
       }
 
       final String theSavePath =
-        (String) report.getAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, "report-save-path" );// NON-NLS
+        (String) report.getAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME );// NON-NLS
       if ( !StringUtils.isEmpty( theSavePath ) ) {
         final String fileName = IOUtils.getInstance().getFileName( theSavePath );
         return IOUtils.getInstance().stripFileExtension( fileName );
@@ -425,7 +425,7 @@ public class ReportRenderContext implements ReportDocumentContext {
   }
 
   public String getDocumentFile() {
-    return (String) masterReportElement.getAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, "report-save-path" );
+    return (String) masterReportElement.getAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME );
   }
 
   public void removePropertyChangeListener( final String propertyName, final PropertyChangeListener listener ) {


### PR DESCRIPTION
Avoid to change last file name for report in case report attempted to be save with incorrect path.
We can't determine using file.getCanonicalPath() is path is correct since file can be saved in filesystem as far as in any independent destination and only call to SaveReportUtilities.saveReport(...) will give the real picture can't this file for any reason or been saved successful.
Refactoring to use 'ReportDesignerBoot.LAST_FILENAME' in all places where 'report-save-path' string was directly hard-coded.