### PR TITLE
PRD-5511 - PRD: Not saved parameter mapping when it uses formulas

### DIFF
--- a/engine/extensions-kettle/source/org/pentaho/reporting/engine/classic/extensions/datasources/kettle/FormulaParameter.java
+++ b/engine/extensions-kettle/source/org/pentaho/reporting/engine/classic/extensions/datasources/kettle/FormulaParameter.java
@@ -59,9 +59,10 @@ public class FormulaParameter implements Serializable {
       FormulaParameter arg = args[ i ];
       try {
         String[] references = FormulaUtil.getReferences( arg.getFormula() );
-        if ( references.length > 0 ) {
-          textList.add( new ParameterMapping( references[ 0 ], arg.getName() ) );
-        }
+        // some functions can have no references at all like '=FALSE()'
+        // but it still be correct function.
+        textList.add( new ParameterMapping( references.length > 0 ? references[ 0 ] : "",
+                                            arg.getName() ) );
       } catch ( ParseException e ) {
         //
       }

--- a/engine/extensions-kettle/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/kettle/FormulaParameterTest.java
+++ b/engine/extensions-kettle/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/kettle/FormulaParameterTest.java
@@ -18,6 +18,7 @@ package org.pentaho.reporting.engine.classic.extensions.datasources.kettle;
 
 import static org.junit.Assert.*;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.ParameterMapping;
 
@@ -36,6 +37,65 @@ public class FormulaParameterTest {
     assertEquals( 1, actualResult.length );
     assertEquals( "TEST_TRANS_PARAM_NAME", actualResult[0].getAlias() );
     assertEquals( "TEST_REPORT_FIELD_NAME", actualResult[0].getName() );
+  }
+
+  @Test
+  public void convert_formula_parameter_to_parameter_mapping_1() {
+    FormulaParameter formulaParameter = new FormulaParameter( "TEST_TRANS_PARAM_NAME", "=FALSE()" );
+    ParameterMapping[] actualResult = FormulaParameter.convert( new FormulaParameter[] { formulaParameter } );
+    assertEquals( 1, actualResult.length );
+    assertEquals( "TEST_TRANS_PARAM_NAME", actualResult[0].getAlias() );
+    assertEquals( "there is no name since =FLASE() function have no parameters", "", actualResult[0].getName() );
+  }
+
+  /**
+   * Should be able to parse complex functions
+   * see PRD-5511
+   */
+  @Test
+  public void convert_formula_parameter_to_parameter_mapping_2() {
+    FormulaParameter fp = new FormulaParameter( "TEST_TRANS_PARAM_NAME",
+                                                "=CSVTEXT([TEST_REPORT_FIELD_NAME];FALSE();\",\";\"'\")" );
+    ParameterMapping[] actualResult = FormulaParameter.convert( new FormulaParameter[] { fp } );
+    assertEquals( 1, actualResult.length );
+    assertEquals( "TEST_TRANS_PARAM_NAME", actualResult[0].getAlias() );
+    assertEquals( "TEST_REPORT_FIELD_NAME", actualResult[0].getName() );
+  }
+
+  /**
+   * Simulates many parameters passed.
+   */
+  @Test
+  public void convert_formula_parameter_to_parameter_mapping_3() {
+    FormulaParameter fp = new FormulaParameter( "par1",
+                                                "=CSVTEXT([TEST_REPORT_FIELD_NAME_1];FALSE();\",\";\"'\")" );
+    FormulaParameter fp2 = new FormulaParameter( "par2",
+                                                 "=ABS([TEST_REPORT_FIELD_NAME_2])" );
+    FormulaParameter fp3 = new FormulaParameter( "par3", "=ABS(13)" );
+    ParameterMapping[] actualResult = FormulaParameter.convert( new FormulaParameter[] { fp, fp2, fp3} );
+    assertEquals( 3, actualResult.length );
+
+    assertEquals( "par1", actualResult[0].getAlias() );
+    assertEquals( "TEST_REPORT_FIELD_NAME_1", actualResult[0].getName() );
+
+    assertEquals( "par2", actualResult[1].getAlias() );
+    assertEquals( "TEST_REPORT_FIELD_NAME_2", actualResult[1].getName() );
+
+    assertEquals( "par3", actualResult[2].getAlias() );
+    assertEquals( "13 for formula =ABS(13) is a static value, not a parameter", "", actualResult[2].getName() );
+  }
+
+  /**
+   * Formula with 1+ parameters and string value.
+   * Currently returns only one result, if formula contains multiple parameter
+   * references seems we only have one in return...
+   */
+  @Test
+  @Ignore
+  public void convert_formula_parameter_to_parameter_mapping_4() {
+    FormulaParameter fp1 = new FormulaParameter( "par1",
+                                                  "=CONCATENATE([GUID]; \"Hello world!\"; [GUIH])" );
+    ParameterMapping[] actualResult = FormulaParameter.convert( new FormulaParameter[] { fp1} );
   }
 
   @Test

--- a/libraries/libformula/source/org/pentaho/reporting/libraries/formula/util/FormulaUtil.java
+++ b/libraries/libformula/source/org/pentaho/reporting/libraries/formula/util/FormulaUtil.java
@@ -23,6 +23,7 @@ import org.pentaho.reporting.libraries.formula.DefaultFormulaContext;
 import org.pentaho.reporting.libraries.formula.Formula;
 import org.pentaho.reporting.libraries.formula.FormulaContext;
 import org.pentaho.reporting.libraries.formula.lvalues.ContextLookup;
+import org.pentaho.reporting.libraries.formula.lvalues.FormulaFunction;
 import org.pentaho.reporting.libraries.formula.lvalues.LValue;
 import org.pentaho.reporting.libraries.formula.lvalues.StaticValue;
 import org.pentaho.reporting.libraries.formula.lvalues.Term;
@@ -115,6 +116,12 @@ public class FormulaUtil {
     } else if ( lval instanceof ContextLookup ) {
       final ContextLookup cl = (ContextLookup) lval;
       map.put( cl.getName(), Boolean.TRUE );
+    } else if ( lval instanceof FormulaFunction ){
+      FormulaFunction ff = FormulaFunction.class.cast(lval);
+      LValue[] lvals = ff.getChildValues();
+      for (int i = 0; i < lvals.length; i++) {
+        collectReferences( lvals[i], map );
+      }
     }
   }
 

--- a/libraries/libformula/test-src/org/pentaho/reporting/libraries/formula/util/FormulaUtilTest.java
+++ b/libraries/libformula/test-src/org/pentaho/reporting/libraries/formula/util/FormulaUtilTest.java
@@ -18,7 +18,10 @@
 package org.pentaho.reporting.libraries.formula.util;
 
 import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
+import org.pentaho.reporting.libraries.formula.parser.ParseException;
 
 public class FormulaUtilTest {
   @Test
@@ -38,10 +41,21 @@ public class FormulaUtilTest {
       if ( strings[ 0 ] == null ) {
         Assert.assertFalse( "Failure in " + v, (Boolean) objects[ 1 ] );
       } else {
-        Assert.assertTrue( "Failure in " + v, (Boolean) objects[ 1 ] );
-        Assert.assertEquals( "Failure in " + v, strings[ 0 ], objects[ 2 ] );
-        Assert.assertEquals( "Failure in " + v, strings[ 1 ], objects[ 3 ] );
+        assertTrue( "Failure in " + v, (Boolean) objects[ 1 ] );
+        assertEquals( "Failure in " + v, strings[ 0 ], objects[ 2 ] );
+        assertEquals( "Failure in " + v, strings[ 1 ], objects[ 3 ] );
       }
     }
+  }
+
+  /**
+   * See PRD-5511 for details.
+   * @throws ParseException
+   */
+  @Test
+  public void getReferencesTest() throws ParseException {
+    String[] references = FormulaUtil.getReferences( "=CSVTEXT([parmTerritory];FALSE();\",\";\"'\")" );
+    assertTrue("References list is not empty", references.length > 0);
+    assertEquals("Fromula has one reference to paramTerritory", "parmTerritory", references[0]);
   }
 }


### PR DESCRIPTION
The root cause of formulas not being saved is incorrect conversion of formulas parameters. Formulas since that never have been saved to report correctly. This issue being hided by arguments - so when arguments is existed for kettle query even formulas was not recognized - report been saved
correctly. If there was no arguments - formulas for kettle query were existed only in master report and never being saved to xml/zip file.

To fix that libformula/FormulaUtil.collectReferences(...) should start recognize LValue as FormulaFunction. So that we can be able to extract parameter references from formula, then - since we recognize references we will be able to create FormulaParameter in FormulaParameter.convert(
ParameterMapping[] ...) and since formulas being converted they will be processed in

FileTransformationProducerWriteHandler (line 61)

where statement definedArgumentNames.length == 0 && parameterMappings.length == 0
will not be true since parameterMappings.length will be > 0 and formulas will be saved to zip report file.