### PR TITLE
PRD-5021 - As an end user when viewing a paginated html output, I don't want the report viewer to re-query the database when I select particular page to see (PRD-5618 - Create a new report-level attribute named 'content-cache-key', marked as transient, type string)

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/AttributeNames.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/AttributeNames.java
@@ -275,5 +275,6 @@ public class AttributeNames {
     public static final String VISIBLE = "visible";
     public static final String STAGING_MODE = "staging-mode";
     public static final String REPORT_CACHE = "report-cache";
+    public static final String CONTENT_CACHE_KEY = "content-cache-key";
   }
 }

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/MasterReport.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/MasterReport.java
@@ -610,6 +610,14 @@ public class MasterReport extends AbstractReportDefinition {
     setAttribute( AttributeNames.Core.NAMESPACE, AttributeNames.Core.STYLE_SHEET_REFERENCE, styleSheetReference );
   }
 
+  public String getContentCacheKey() {
+    return (String) getAttribute( AttributeNames.Pentaho.NAMESPACE, AttributeNames.Pentaho.CONTENT_CACHE_KEY );
+  }
+
+  public void setContentCacheKey( final String contentCacheKey ) {
+    setAttribute( AttributeNames.Pentaho.NAMESPACE, AttributeNames.Pentaho.CONTENT_CACHE_KEY, contentCacheKey );
+  }
+
   public boolean isStrictLegacyMode() {
     return "true".equals( getReportConfiguration().getConfigProperty(
         "org.pentaho.reporting.engine.classic.core.legacy.StrictCompatibility" ) );

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/messages.properties
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/messages.properties
@@ -1315,6 +1315,13 @@ element.master-report.attribute.pentaho.report-cache.ordinal=30
 element.master-report.attribute.pentaho.report-cache.description=Defines whether server-side report-caching is enabled for this report.
 element.master-report.attribute.pentaho.report-cache.deprecated=
 
+element.master-report.attribute.pentaho.content-cache-key.display-name=content-cache-key
+element.master-report.attribute.pentaho.content-cache-key.grouping=pentaho
+element.master-report.attribute.pentaho.content-cache-key.grouping.ordinal=10000
+element.master-report.attribute.pentaho.content-cache-key.ordinal=50
+element.master-report.attribute.pentaho.content-cache-key.description=Defines content cache key for this report.
+element.master-report.attribute.pentaho.content-cache-key.deprecated=
+
 attribute.report-designer.hideInLayoutGUI.display-name=hide-on-canvas
 attribute.report-designer.hideInLayoutGUI.grouping=common
 attribute.report-designer.hideInLayoutGUI.grouping.ordinal=200

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/meta-elements.xml
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/metadata/meta-elements.xml
@@ -274,6 +274,17 @@
                value-type="java.lang.Boolean"
                value-role="Value"/>
 
+    <attribute namespace="http://reporting.pentaho.org/namespaces/engine/attributes/pentaho"
+               name="content-cache-key"
+               mandatory="false"
+               expert="true"
+               hidden="true"
+               design-time-value="false"
+               computed="true"
+               transient="true"
+               value-type="java.lang.String"
+               value-role="Value"/>
+
     <attribute namespace="http://reporting.pentaho.org/namespaces/engine/attributes/core"
                name="data-cache"
                mandatory="false"


### PR DESCRIPTION
@tmorgner 
Please review.