### PR TITLE
[BACKLOG-6988] - log if debug only if interrupted exception thrown.

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/output/AbstractReportProcessor.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/layout/output/AbstractReportProcessor.java
@@ -1444,6 +1444,13 @@ public abstract class AbstractReportProcessor implements ReportProcessor {
         }
       } catch ( EmptyReportException re ) {
         throw re;
+      } catch( ReportInterruptedException interrupt ) {
+        // log interruption stacktrace in case of debug level only
+        // since interruption is ok.
+        if ( AbstractReportProcessor.logger.isDebugEnabled() ) {
+          AbstractReportProcessor.logger.debug( "Report processing interrupted: " + this.getClass().getName(), interrupt );
+        }
+        throw interrupt;
       } catch ( ReportProcessingException re ) {
         AbstractReportProcessor.logger.error( System.identityHashCode( Thread.currentThread() )
             + ": Report processing failed.", re );


### PR DESCRIPTION
Separately catch and re-throw ReportInterruptedException. Log stacktrace for debug level only. Interruption is not a error drama.

see https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/245 