### PR TITLE
[PRD-4160] Xul based DrillDown dialogs in Report Designer cannot be internationalized

### DIFF
--- a/designer/report-designer-extension-pentaho/source/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
+++ b/designer/report-designer-extension-pentaho/source/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
@@ -17,6 +17,7 @@
 
 package org.pentaho.reporting.designer.extensions.pentaho.drilldown.swing;
 
+import org.apache.commons.lang.ObjectUtils;
 import org.pentaho.reporting.designer.core.ReportDesignerContext;
 import org.pentaho.reporting.designer.core.auth.AuthenticationData;
 import org.pentaho.reporting.designer.core.auth.AuthenticationStore;
@@ -336,14 +337,18 @@ public class SwingRemoteDrillDownController {
     public void propertyChange( PropertyChangeEvent evt ) {
       AuthenticationData loginData = pentahoPathWrapper.getLoginData();
       String serverUrl = loginData == null ? "" : loginData.getUrl();
-      drillDownUi.<JTextField>getComponent(
-              SwingRemoteDrillDownUi.ComponentLookup.SERVER_URL_FIELD
-      ).setText( serverUrl == null ? "" : serverUrl );
+      JTextField serverUrlField = drillDownUi.<JTextField>getComponent(
+          SwingRemoteDrillDownUi.ComponentLookup.SERVER_URL_FIELD );
+      if ( !ObjectUtils.equals( serverUrlField.getText(), serverUrl ) ) {
+        serverUrlField.setText( serverUrl );
+      }
 
       String path = pentahoPathWrapper.getLocalPath();
-      drillDownUi.<JTextField>getComponent(
-              SwingRemoteDrillDownUi.ComponentLookup.PATH_FIELD
-      ).setText( path == null ? "" : path );
+      JTextField pathField = drillDownUi.<JTextField>getComponent(
+          SwingRemoteDrillDownUi.ComponentLookup.PATH_FIELD );
+      if ( !ObjectUtils.equals( pathField.getText(), path ) ) {
+        pathField.setText( path );
+      }
     }
   }
 


### PR DESCRIPTION
- Fix for the bug with pentaho-sugar-drilldown dialog that appeared in the latest QAT build.