### PR TITLE
[BACKLOG-8389] - Upgrade antlr to version 3.4 across Pentaho product suite - changes for pentaho reporting repository

### DIFF
--- a/engine/core/ivy.xml
+++ b/engine/core/ivy.xml
@@ -57,7 +57,7 @@
       <dependency org="bsf" name="bsf" rev="2.4.0" transitive="false" conf="default_external->default"/>
       <dependency org="org.beanshell" name="bsh" rev="1.3.0" conf="default_external->default"/>
       <dependency org="org.codehaus.groovy" name="groovy" rev="1.8.0" conf="default_external->default" transitive="false"/>
-      <dependency org="antlr" name="antlr" rev="2.7.7" conf="default_external->default" transitive="true"/>
+      <dependency org="org.antlr" name="antlr" rev="3.4-complete" conf="default_external->default" transitive="false"/>
       <dependency org="asm" name="asm" rev="3.2" conf="default_external->default" transitive="true"/>
       
 


### PR DESCRIPTION
Replace antrl-2.7.7 with antlr-3.4-complete which contains antlr-2.7.7