### PR TITLE
[BACKLOG-8389] - Upgrade antlr to version 3.5.2 across Pentaho product suite - changes for pentaho reporting repository

### DIFF
--- a/engine/core/ivy.xml
+++ b/engine/core/ivy.xml
@@ -57,7 +57,7 @@
       <dependency org="bsf" name="bsf" rev="2.4.0" transitive="false" conf="default_external->default"/>
       <dependency org="org.beanshell" name="bsh" rev="1.3.0" conf="default_external->default"/>
       <dependency org="org.codehaus.groovy" name="groovy" rev="1.8.0" conf="default_external->default" transitive="false"/>
-      <dependency org="org.antlr" name="antlr" rev="3.4-complete" conf="default_external->default" transitive="false"/>
+      <dependency org="org.antlr" name="antlr-complete" rev="3.5.2" conf="default_external->default" transitive="false"/>
       <dependency org="asm" name="asm" rev="3.2" conf="default_external->default" transitive="true"/>
       
 


### PR DESCRIPTION
Replace antrl-3.4-complete with antlr-complete-3.5.2 which contains antlr-2.7.7