### PR TITLE
[BACKLOG-8503]-It's impossible to create interactive report based on hive datasource in PUC due to :ERROR [org.pentaho.reporting.engine.classic.core.layout.output.AbstractReportProcessor]

### DIFF
--- a/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/SimplePmdDataFactory.java
+++ b/engine/extensions-pentaho-metadata/source/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/SimplePmdDataFactory.java
@@ -522,7 +522,7 @@ public class SimplePmdDataFactory extends AbstractDataFactory {
     try {
 
       // if the connection type is not of the current dialect, regenerate the query
-      final DatabaseInterface di = getDatabaseInterface( connection );
+      final DatabaseInterface di = getDatabaseInterface( connection, databaseMeta );
 
       if ( ( di != null ) && !databaseMeta.getPluginId().equals( di.getPluginId() ) ) {
         // we need to reinitialize our mqlQuery object and reset the query.
@@ -579,10 +579,10 @@ public class SimplePmdDataFactory extends AbstractDataFactory {
     return password;
   }
 
-  private DatabaseInterface getDatabaseInterface( final Connection conn ) {
+  private DatabaseInterface getDatabaseInterface( final Connection conn, final DatabaseMeta databaseMeta ) {
     try {
       final String prod = conn.getMetaData().getDatabaseProductName();
-      final DatabaseInterface di = DatabaseMetaUtil.getDatabaseInterface( prod );
+      final DatabaseInterface di = DatabaseMetaUtil.getDatabaseInterface( prod, databaseMeta );
       if ( prod != null && di == null ) {
         logger.warn( "dialect not detected" ); //$NON-NLS-1$
       }


### PR DESCRIPTION
* Switch to use overloaded method which has some workaround logic.
* There is no unit as mostly required big-data database interfaces static load