### PR TITLE
[SP-2821] - Backport of PPP-3536 - Use of vulnerable component  org.c…

### DIFF
--- a/engine/core/ivy.xml
+++ b/engine/core/ivy.xml
@@ -56,7 +56,7 @@
 
       <dependency org="bsf" name="bsf" rev="2.4.0" transitive="false" conf="default_external->default"/>
       <dependency org="org.beanshell" name="bsh" rev="1.3.0" conf="default_external->default"/>
-      <dependency org="org.codehaus.groovy" name="groovy" rev="1.8.0" conf="default_external->default" transitive="false"/>
+      <dependency org="org.codehaus.groovy" name="groovy-all" rev="2.4.7" conf="default_external->default" transitive="false"/>
       <dependency org="antlr" name="antlr" rev="2.7.7" conf="default_external->default" transitive="true"/>
       <dependency org="asm" name="asm" rev="3.2" conf="default_external->default" transitive="true"/>
       


### PR DESCRIPTION
…odehaus.groovy v.1.8.0 CVE-2015-3253 (6.1 Suite)

@pamval, @mchen-len-son, here is the backport of https://github.com/pentaho/pentaho-reporting/pull/798/files to 6.1. Thanks.