### PR TITLE
[BACKLOG-10064] - improve html rotated text output

### DIFF
--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelCellStyleBuilder.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelCellStyleBuilder.java
@@ -1,0 +1,152 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.output.table.xls.helper;
+
+import org.apache.poi.hssf.usermodel.HSSFCellStyle;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.extensions.XSSFCellBorder;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.base.CellBackground;
+import org.pentaho.reporting.engine.classic.core.style.BorderStyle;
+import org.pentaho.reporting.engine.classic.core.style.StyleSheet;
+import org.pentaho.reporting.engine.classic.core.style.TextRotation;
+
+import java.awt.Color;
+
+
+/**
+ * Created by dima.prokopenko@gmail.com on 9/13/2016.
+ */
+public class ExcelCellStyleBuilder {
+
+  private final Workbook workbook;
+  private final CellStyle hssfCellStyle;
+
+  private boolean isXLSX = false;
+
+  public ExcelCellStyleBuilder( Workbook workbook ) {
+    this.workbook = workbook;
+    this.hssfCellStyle = workbook.createCellStyle();
+    this.isXLSX = hssfCellStyle instanceof XSSFCellStyle;
+  }
+
+  public void withRotation( final TextRotation rotation ) {
+    if ( rotation == null ) {
+      return;
+    }
+
+    if ( isXLSX ) {
+      //xlsx has different rotation degree boundaries
+      final short numericValue = rotation.getNumericValue();
+      hssfCellStyle.setRotation( numericValue < 0 ? (short) ( 90 - numericValue ) : numericValue );
+    } else {
+      hssfCellStyle.setRotation( rotation.getNumericValue() );
+    }
+  }
+
+  public void withElementStyle( final StyleSheet elementStyleSheet, final HSSFCellStyleProducer.HSSFCellStyleKey styleKey ) {
+    if ( elementStyleSheet == null ) {
+      return;
+    }
+
+    hssfCellStyle.setAlignment( styleKey.getHorizontalAlignment() );
+    hssfCellStyle.setVerticalAlignment( styleKey.getVerticalAlignment() );
+    hssfCellStyle.setFont( workbook.getFontAt( styleKey.getFont() ) );
+    hssfCellStyle.setWrapText( styleKey.isWrapText() );
+    hssfCellStyle.setIndention( styleKey.getIndention() );
+    if ( styleKey.getDataStyle() >= 0 ) {
+      hssfCellStyle.setDataFormat( styleKey.getDataStyle() );
+    }
+  }
+
+  public void withBackgroundStyle( final CellBackground bg, final HSSFCellStyleProducer.HSSFCellStyleKey styleKey ) {
+    if ( bg == null ) {
+      return;
+    }
+    if ( isXLSX ) {
+      xlsx_backgroundStyle( bg, styleKey );
+    } else {
+      xls_BackgroundStyle( bg, styleKey );
+    }
+  }
+
+  // default visibility for testing purposes
+  void xls_BackgroundStyle( final CellBackground bg, final HSSFCellStyleProducer.HSSFCellStyleKey styleKey ) {
+    if ( BorderStyle.NONE.equals( bg.getBottom().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderBottom( styleKey.getBorderStrokeBottom() );
+      hssfCellStyle.setBottomBorderColor( styleKey.getColorBottom() );
+    }
+    if ( BorderStyle.NONE.equals( bg.getTop().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderTop( styleKey.getBorderStrokeTop() );
+      hssfCellStyle.setTopBorderColor( styleKey.getColorTop() );
+    }
+    if ( BorderStyle.NONE.equals( bg.getLeft().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderLeft( styleKey.getBorderStrokeLeft() );
+      hssfCellStyle.setLeftBorderColor( styleKey.getColorLeft() );
+    }
+    if ( BorderStyle.NONE.equals( bg.getRight().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderRight( styleKey.getBorderStrokeRight() );
+      hssfCellStyle.setRightBorderColor( styleKey.getColorRight() );
+    }
+    if ( bg.getBackgroundColor() != null ) {
+      hssfCellStyle.setFillForegroundColor( styleKey.getColor() );
+      hssfCellStyle.setFillPattern( HSSFCellStyle.SOLID_FOREGROUND );
+    }
+  }
+
+  // default visibility for testing purposes
+  void xlsx_backgroundStyle( final CellBackground bg, final HSSFCellStyleProducer.HSSFCellStyleKey styleKey ) {
+    final XSSFCellStyle xssfCellStyle = (XSSFCellStyle) hssfCellStyle;
+    if ( BorderStyle.NONE.equals( bg.getBottom().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderBottom( styleKey.getBorderStrokeBottom() );
+      xssfCellStyle.setBorderColor( XSSFCellBorder.BorderSide.BOTTOM, createXSSFColor( styleKey
+        .getExtendedColorBottom() ) );
+    }
+    if ( BorderStyle.NONE.equals( bg.getTop().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderTop( styleKey.getBorderStrokeTop() );
+      xssfCellStyle
+        .setBorderColor( XSSFCellBorder.BorderSide.TOP, createXSSFColor( styleKey.getExtendedColorTop() ) );
+    }
+    if ( BorderStyle.NONE.equals( bg.getLeft().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderLeft( styleKey.getBorderStrokeLeft() );
+      xssfCellStyle.setBorderColor( XSSFCellBorder.BorderSide.LEFT, createXSSFColor( styleKey
+        .getExtendedColorLeft() ) );
+    }
+    if ( BorderStyle.NONE.equals( bg.getRight().getBorderStyle() ) == false ) {
+      hssfCellStyle.setBorderRight( styleKey.getBorderStrokeRight() );
+      xssfCellStyle.setBorderColor( XSSFCellBorder.BorderSide.RIGHT, createXSSFColor( styleKey
+        .getExtendedColorRight() ) );
+    }
+    if ( bg.getBackgroundColor() != null ) {
+      xssfCellStyle.setFillForegroundColor( createXSSFColor( styleKey.getExtendedColor() ) );
+      hssfCellStyle.setFillPattern( HSSFCellStyle.SOLID_FOREGROUND );
+    }
+  }
+
+  public CellStyle build() {
+    return this.hssfCellStyle;
+  }
+
+  // default visibility for testing purposes
+  XSSFColor createXSSFColor( final Color clr ) {
+    byte[] rgb = { (byte) 255, (byte) clr.getRed(), (byte) clr.getGreen(), (byte) clr.getBlue() };
+    return new XSSFColor( rgb );
+  }
+}

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/HSSFCellStyleProducer.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/HSSFCellStyleProducer.java
@@ -53,7 +53,7 @@ import java.util.HashMap;
 public class HSSFCellStyleProducer implements CellStyleProducer {
   private static final Log logger = LogFactory.getLog( HSSFCellStyleProducer.class );
 
-  private static class HSSFCellStyleKey {
+  static class HSSFCellStyleKey {
     /**
      * The cell background color.
      */
@@ -590,9 +590,28 @@ public class HSSFCellStyleProducer implements CellStyleProducer {
       }
     }
 
-    final CellStyle hssfCellStyle = workbook.createCellStyle();
-    TextRotation rotation = null;
-    if ( element != null ) {
+    ExcelCellStyleBuilder builder = new ExcelCellStyleBuilder( this.workbook );
+
+    builder.withRotation( (TextRotation) element.getStyleProperty( TextStyleKeys.TEXT_ROTATION, null ) );
+    builder.withElementStyle( element, styleKey );
+    builder.withBackgroundStyle( bg, styleKey );
+
+    final CellStyle hssfCellStyle = builder.build();
+
+    /*final CellStyle hssfCellStyle = workbook.createCellStyle();
+    final boolean isXlsx = hssfCellStyle instanceof XSSFCellStyle;
+
+    TextRotation rotation = (TextRotation) element.getStyleProperty( TextStyleKeys.TEXT_ROTATION, null );
+    if ( rotation != null ) {
+      if ( isXlsx ) {
+        hssfCellStyle.setRotation( rotation.getNumericValue() );
+      } else {
+        final short numericValue = rotation.getNumericValue();
+        hssfCellStyle.setRotation( numericValue < 0 ? (short) ( 90 - numericValue ) : numericValue );
+      }
+    }*/
+
+    /*if ( element != null ) {
       hssfCellStyle.setAlignment( styleKey.getHorizontalAlignment() );
       hssfCellStyle.setVerticalAlignment( styleKey.getVerticalAlignment() );
       hssfCellStyle.setFont( workbook.getFontAt( styleKey.getFont() ) );
@@ -601,10 +620,10 @@ public class HSSFCellStyleProducer implements CellStyleProducer {
       if ( styleKey.getDataStyle() >= 0 ) {
         hssfCellStyle.setDataFormat( styleKey.getDataStyle() );
       }
-      rotation = (TextRotation) element.getStyleProperty( TextStyleKeys.TEXT_ROTATION, null );
-    }
-    if ( bg != null ) {
-      if ( hssfCellStyle instanceof XSSFCellStyle ) {
+    }*/
+
+    /*if ( bg != null ) {
+      if ( isXlsx ) {
         final XSSFCellStyle xssfCellStyle = (XSSFCellStyle) hssfCellStyle;
         if ( BorderStyle.NONE.equals( bg.getBottom().getBorderStyle() ) == false ) {
           hssfCellStyle.setBorderBottom( styleKey.getBorderStrokeBottom() );
@@ -630,11 +649,6 @@ public class HSSFCellStyleProducer implements CellStyleProducer {
           xssfCellStyle.setFillForegroundColor( createXSSFColor( styleKey.getExtendedColor() ) );
           hssfCellStyle.setFillPattern( HSSFCellStyle.SOLID_FOREGROUND );
         }
-        if ( rotation != null ) {
-          //xlsx has different rotation degree boundaries
-          final short numericValue = rotation.getNumericValue();
-          hssfCellStyle.setRotation( numericValue < 0 ? (short) ( 90 - numericValue ) : numericValue );
-        }
       } else {
         if ( BorderStyle.NONE.equals( bg.getBottom().getBorderStyle() ) == false ) {
           hssfCellStyle.setBorderBottom( styleKey.getBorderStrokeBottom() );
@@ -656,11 +670,8 @@ public class HSSFCellStyleProducer implements CellStyleProducer {
           hssfCellStyle.setFillForegroundColor( styleKey.getColor() );
           hssfCellStyle.setFillPattern( HSSFCellStyle.SOLID_FOREGROUND );
         }
-        if ( rotation != null ) {
-          hssfCellStyle.setRotation( rotation.getNumericValue() );
-        }
       }
-    }
+    }*/
 
     styleCache.put( styleKey, hssfCellStyle );
     return hssfCellStyle;

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/style/TextRotation.java
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/style/TextRotation.java
@@ -18,7 +18,9 @@
 package org.pentaho.reporting.engine.classic.core.style;
 
 import org.pentaho.reporting.engine.classic.core.util.ObjectStreamResolveException;
+import org.pentaho.reporting.engine.classic.core.util.RotatedTextDrawable;
 
+import java.awt.Dimension;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.text.MessageFormat;
@@ -27,7 +29,8 @@ public class TextRotation implements Serializable {
   public static final TextRotation D_90 = new TextRotation( "90" );
   public static final TextRotation D_270 = new TextRotation( "-90" );
   private static final String CSS =
-    "transform: rotate({0}deg); -ms-transform: rotate({0}deg); -webkit-transform: rotate({0}deg);";
+    "transform: rotate({0}deg); -ms-transform: rotate({0}deg); -webkit-transform: rotate({0}deg); {1}";
+  private static final String CSS_POS = "white-space: nowrap;";
   private String type;
 
   private TextRotation( final String type ) {
@@ -81,7 +84,7 @@ public class TextRotation implements Serializable {
   }
 
   public String getCss() {
-    return MessageFormat.format( CSS, String.valueOf( -this.getNumericValue() ) );
+    return MessageFormat.format( CSS, -this.getNumericValue(), CSS_POS );
   }
 
   /**

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/RotationTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/RotationTest.java
@@ -170,9 +170,9 @@ public class RotationTest {
   @Test
   public void testCss() {
     assertEquals( TextRotation.D_90.getCss(),
-      "transform: rotate(-90deg); -ms-transform: rotate(-90deg); -webkit-transform: rotate(-90deg);" );
+      "transform: rotate(-90deg); -ms-transform: rotate(-90deg); -webkit-transform: rotate(-90deg); white-space: nowrap;" );
     assertEquals( TextRotation.D_270.getCss(),
-      "transform: rotate(90deg); -ms-transform: rotate(90deg); -webkit-transform: rotate(90deg);" );
+      "transform: rotate(90deg); -ms-transform: rotate(90deg); -webkit-transform: rotate(90deg); white-space: nowrap;" );
   }
 
   @Test

--- a/engine/core/test-src/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelCellStyleBuilderTest.java
+++ b/engine/core/test-src/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelCellStyleBuilderTest.java
@@ -1,0 +1,127 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.output.table.xls.helper;
+
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.core.style.StyleSheet;
+import org.pentaho.reporting.engine.classic.core.style.TextRotation;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by dima.prokopenko@gmail.com on 9/13/2016.
+ */
+public class ExcelCellStyleBuilderTest {
+
+  Workbook workbook = mock( Workbook.class );
+  XSSFCellStyle xlsxStyle = mock( XSSFCellStyle.class );
+  CellStyle xlsStyle = mock( CellStyle.class );
+
+  Font font = mock( Font.class );
+
+  HSSFCellStyleProducer.HSSFCellStyleKey styleKey = mock( HSSFCellStyleProducer.HSSFCellStyleKey.class );
+
+  @Before
+  public void beforeTest() {
+  }
+
+  @Test
+  public void testRotationXlsSet() {
+    when( workbook.createCellStyle() ).thenReturn( xlsxStyle );
+
+    ExcelCellStyleBuilder builder = new ExcelCellStyleBuilder( workbook );
+
+    builder.withRotation( TextRotation.D_90 );
+    builder.build();
+    verify( xlsxStyle, times( 1 ) ).setRotation( eq( (short) 90 ) );
+
+    builder.withRotation( TextRotation.D_270 );
+    builder.build();
+    verify( xlsxStyle, times( 1 ) ).setRotation( eq( (short) 180 ) );
+  }
+
+  @Test
+  public void testRotationXLSX() {
+    when( workbook.createCellStyle() ).thenReturn( xlsStyle );
+    ExcelCellStyleBuilder builder = new ExcelCellStyleBuilder( workbook );
+
+    builder.withRotation( TextRotation.D_90 );
+    builder.build();
+    verify( xlsStyle, times( 1 ) ).setRotation( eq( (short) 90 ) );
+
+    builder.withRotation( TextRotation.D_270 );
+    builder.build();
+    verify( xlsStyle, times( 1 ) ).setRotation( eq( (short) -90 ) );
+  }
+
+  @Test
+  public void testNullRotation() {
+    when( workbook.createCellStyle() ).thenReturn( xlsStyle );
+    ExcelCellStyleBuilder builder = new ExcelCellStyleBuilder( workbook );
+
+    builder.withRotation( null );
+    builder.build();
+    verify( xlsStyle, times( 0 ) ).setRotation( anyShort() );
+  }
+
+  @Test
+  public void testNullElementSttle() {
+    ExcelCellStyleBuilder builder = new ExcelCellStyleBuilder( workbook );
+
+    when( workbook.createCellStyle() ).thenReturn( xlsStyle );
+    builder.withElementStyle( null, styleKey );
+
+    verify( xlsStyle, times( 0 ) ).setAlignment( anyShort() );
+    verify( xlsStyle, times( 0 ) ).setVerticalAlignment( anyShort() );
+    verify( xlsStyle, times( 0 ) ).setFont( any() );
+    verify( xlsStyle, times( 0 ) ).setWrapText( anyBoolean() );
+    verify( xlsStyle, times( 0 ) ).setIndention( anyShort() );
+    verify( xlsStyle, times( 0 ) ).setDataFormat( anyShort() );
+  }
+
+  @Test
+  public void testElementStyleSet() {
+    when( workbook.createCellStyle() ).thenReturn( xlsStyle );
+    ExcelCellStyleBuilder builder = new ExcelCellStyleBuilder( workbook );
+    when( workbook.createCellStyle() ).thenReturn( xlsStyle );
+
+    when( styleKey.getHorizontalAlignment() ).thenReturn( (short) 13 );
+    when( styleKey.getVerticalAlignment() ).thenReturn( (short) 14 );
+    when( styleKey.isWrapText() ).thenReturn( true );
+    when( workbook.getFontAt( anyShort() ) ).thenReturn( font );
+    when( styleKey.getIndention() ).thenReturn( (short) 15 );
+
+    when( styleKey.getDataStyle() ).thenReturn( (short) -1 );
+
+    builder.withElementStyle( mock( StyleSheet.class ), styleKey );
+
+    verify( xlsStyle, times( 1 ) ).setAlignment( eq( (short) 13 ) );
+    verify( xlsStyle, times( 1 ) ).setVerticalAlignment( eq( (short) 14 ) );
+    verify( xlsStyle, times( 1 ) ).setFont( any() );
+    verify( xlsStyle, times( 1 ) ).setWrapText( eq( true ) );
+    verify( xlsStyle, times( 1 ) ).setIndention( eq( (short) 15 ) );
+    verify( xlsStyle, times( 0 ) ).setDataFormat( anyShort() );
+  }
+  
+}


### PR DESCRIPTION
When using css styles html rotate text from center by default. Change this to be more predicable: iff 90 rotate by left bottom, if -90 use left top corner. Prefer simple css over complex style- we have bands and other elements to align text in center or whatever required. Otherwise  - we have compute parent container size which is specified in pt points - means we can't determine pt->px. I would say here using java script could be a solution, but I assume we don't write inline javascript.