### PR TITLE
[BACKLOG-10623] Upgrade the platform (non-OSGi side) to Spring Security 4 - spring.framework upgraded to 4.3.2.RELEASE - spring.security upgraded to 4.1.3.RELEASE

### DIFF
--- a/designer/report-designer-assembly/build.properties
+++ b/designer/report-designer-assembly/build.properties
@@ -26,7 +26,7 @@ dependency.kettle.group=pentaho-kettle
 dependency.kettle.revision=7.0-SNAPSHOT
 dependency.documentation.revision=6.0.0.0
 dependency.oss-licenses.revision=7.0-SNAPSHOT
-dependency.spring.security.revision=2.0.8.RELEASE
+dependency.spring.security.revision=4.1.3.RELEASE
 dependency.pdi-dataservice-client-plugin.revision=7.0-SNAPSHOT
 
 junit.maxmemory=1024m

--- a/engine/extensions-kettle/build.properties
+++ b/engine/extensions-kettle/build.properties
@@ -29,6 +29,6 @@ dependency.reporting-library.revision=7.0-SNAPSHOT
 library.group=pentaho-library
 
 dependency.pentaho-simple-jndi.revision=1.0.0
-dependency.spring.framework.revision=3.2.14.RELEASE
+dependency.spring.framework.revision=4.3.2.RELEASE
 
 dependency.javassist.revision=3.20.0-GA


### PR DESCRIPTION
@pentaho/rogueone 
Part of Spring 4 upgrade.