### PR TITLE
[PRD-5785]-Morphing Resource Labels clearing out SubReport

### DIFF
--- a/libraries/libxml/source/org/pentaho/reporting/libraries/xmlns/common/AttributeMap.java
+++ b/libraries/libxml/source/org/pentaho/reporting/libraries/xmlns/common/AttributeMap.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+* Copyright (c) 2001 - 2016 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.xmlns.common;
@@ -137,13 +137,13 @@ public class AttributeMap<T> implements Serializable, Cloneable {
     }
 
     if ( content == null ) {
-      if ( value != null ) {
-        content = new LinkedHashMap<DualKey, T>();
-        content.put( new DualKey( namespace, attribute ), value );
-      }
-      return null;
+      content = new LinkedHashMap<DualKey, T>();
     }
-    return content.put( new DualKey( namespace, attribute ), value );
+    if ( value != null ) {
+      return content.put( new DualKey( namespace, attribute ), value );
+    } else {
+      return content.remove( new DualKey( namespace, attribute ) );
+    }
   }
 
   /**

--- a/libraries/libxml/test-src/org/pentaho/reporting/libraries/xmlns/common/AttributeMapTest.java
+++ b/libraries/libxml/test-src/org/pentaho/reporting/libraries/xmlns/common/AttributeMapTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.xmlns.common;
@@ -109,6 +109,19 @@ public class AttributeMapTest extends TestCase {
 
     final ObjectInputStream oin = new ObjectInputStream( new ByteArrayInputStream( bo.toByteArray() ) );
     return (AttributeMap<T>) oin.readObject();
+  }
+
+  public void testSetAttribute() {
+    final AttributeMap<String> e = new AttributeMap<String>();
+    String s1 = e.setAttribute( "Namespace1", "Attr1", "value1" );
+    assertEquals( null, s1 );
+    assertEquals( e.keySet().size(), 1 );
+    s1 = e.setAttribute( "Namespace1", "Attr1", null );
+    assertEquals( "value1", s1 );
+    assertEquals( e.keySet().size(), 0 );
+    s1 = e.setAttribute( "Namespace1", "Attr1", null );
+    assertEquals( null, s1 );
+    assertEquals( e.keySet().size(), 0 );
   }
 
 }


### PR DESCRIPTION
 - check the value for null, and remove the entry from the attribute-map