### PR TITLE
[PPP-3584] PRD - Security Vulnerability when using XML file as datasource

### DIFF
--- a/designer/report-designer-assembly/resource/resources/classic-engine.properties
+++ b/designer/report-designer-assembly/resource/resources/classic-engine.properties
@@ -17,3 +17,5 @@ org.pentaho.reporting.engine.classic.core.performance.LogLevelProgress=true
 org.pentaho.reporting.engine.classic.core.performance.LogPageProgress=false
 org.pentaho.reporting.engine.classic.core.performance.LogRowProgress=false
 
+#Enable DDTs support
+org.pentaho.reporting.engine.classic.extensions.datasources.xpath.EnableDTDs=false

--- a/engine/core/source/org/pentaho/reporting/engine/classic/core/classic-engine.properties
+++ b/engine/core/source/org/pentaho/reporting/engine/classic/core/classic-engine.properties
@@ -394,3 +394,6 @@ org.pentaho.reporting.engine.classic.core.layout.AlwaysPrintFirstLineOfText=true
 
 # Normalizes data attributes so that the bulk of the data can be shared.
 org.pentaho.reporting.engine.classic.core.wizard.DataAttributeCache=org.pentaho.reporting.engine.classic.core.wizard.DefaultDataAttributeCache
+
+#Enable DTDs support
+org.pentaho.reporting.engine.classic.extensions.datasources.xpath.EnableDTDs=false

--- a/engine/extensions-xpath/ivy.xml
+++ b/engine/extensions-xpath/ivy.xml
@@ -22,6 +22,7 @@
 
         <!--  testing dependencies -->
         <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
+        <dependency org="org.mockito"         name="mockito-all"   rev="1.9.5"   conf="test->default" transitive="false" />
         <dependency org="${ivy.artifact.group}" name="pentaho-reporting-engine-classic-core-test"
                     rev="${project.revision}" transitive="false" changing="true" conf="test->default"/>
     </dependencies>

--- a/engine/extensions-xpath/source/org/pentaho/reporting/engine/classic/extensions/datasources/xpath/LegacyXPathTableModel.java
+++ b/engine/extensions-xpath/source/org/pentaho/reporting/engine/classic/extensions/datasources/xpath/LegacyXPathTableModel.java
@@ -12,16 +12,18 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.reporting.engine.classic.extensions.datasources.xpath;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.DataRow;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
 import org.pentaho.reporting.engine.classic.core.util.IntegerCache;
+import org.pentaho.reporting.libraries.base.config.Configuration;
 import org.pentaho.reporting.libraries.base.util.GenericObjectTable;
 import org.pentaho.reporting.libraries.resourceloader.ResourceData;
 import org.pentaho.reporting.libraries.resourceloader.ResourceLoadingException;
@@ -29,11 +31,16 @@ import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import javax.swing.table.AbstractTableModel;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathVariableResolver;
@@ -50,6 +57,8 @@ import java.util.StringTokenizer;
 
 public class LegacyXPathTableModel extends AbstractTableModel {
   private static final Log logger = LogFactory.getLog( LegacyXPathTableModel.class );
+  public static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+  public static final String XPATH_ENABLE_DTDS = "org.pentaho.reporting.engine.classic.extensions.datasources.xpath.EnableDTDs";
 
   private static class InternalXPathVariableResolver implements XPathVariableResolver {
     private final DataRow parameters;
@@ -96,12 +105,14 @@ public class LegacyXPathTableModel extends AbstractTableModel {
       columnTypes = new ArrayList<Class>();
       columnNames = new ArrayList<String>();
 
+      DocumentBuilderFactory dbf = calculateDocumentBuilderFactory( ClassicEngineBoot.getInstance().getGlobalConfig() );
+
       final XPath xPath = XPathFactory.newInstance().newXPath();
       xPath.setXPathVariableResolver( new InternalXPathVariableResolver( parameters ) );
 
       // load metadata (number of rows, row names, row types)
 
-      final String nodeValue = computeColDeclaration( xmlResource, resourceManager, xPath );
+      final String nodeValue = computeColDeclaration( xmlResource, resourceManager, xPath, dbf.newDocumentBuilder() );
       if ( nodeValue != null ) {
         final StringTokenizer stringTokenizer = new StringTokenizer( nodeValue, "," );
         while ( stringTokenizer.hasMoreTokens() ) {
@@ -194,18 +205,32 @@ public class LegacyXPathTableModel extends AbstractTableModel {
     }
   }
 
+  private DocumentBuilderFactory calculateDocumentBuilderFactory( final Configuration configuration ) throws ParserConfigurationException {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setXIncludeAware( false );
+    if ( !"true".equals( configuration
+            .getConfigProperty( XPATH_ENABLE_DTDS ) ) ) {
+      dbf.setFeature( DISALLOW_DOCTYPE_DECL, true );
+    }
+    return dbf;
+  }
+
   private String computeColDeclaration( final ResourceData xmlResource,
                                         final ResourceManager resourceManager,
-                                        final XPath xPath )
-    throws XPathExpressionException, ResourceLoadingException, IOException {
-    final Node pi = evaluateNode( xPath, "/processing-instruction('pentaho-dataset')", xmlResource, resourceManager );
+                                        final XPath xPath, final DocumentBuilder builder )
+          throws XPathExpressionException, ResourceLoadingException, IOException, ParserConfigurationException, SAXException {
+
+
+
+
+    final Node pi = evaluateNode( xPath.compile( "/processing-instruction('pentaho-dataset')" ), xmlResource, resourceManager, builder );
     if ( pi != null ) {
       final String text = pi.getNodeValue();
       if ( text.length() > 0 ) {
         return text;
       }
     }
-    final Node types = evaluateNode( xPath, "/comment()", xmlResource, resourceManager );
+    final Node types = evaluateNode( xPath.compile( "/comment()" ), xmlResource, resourceManager, builder );
     if ( types != null ) {
       final String text = types.getNodeValue();
       if ( text.length() > 0 ) {
@@ -213,7 +238,7 @@ public class LegacyXPathTableModel extends AbstractTableModel {
       }
     }
 
-    final Node resultsetComment = evaluateNode( xPath, "/result-set/comment()", xmlResource, resourceManager );
+    final Node resultsetComment = evaluateNode( xPath.compile( "/result-set/comment()" ), xmlResource, resourceManager, builder );
     if ( resultsetComment != null ) {
       final String text = resultsetComment.getNodeValue();
       if ( text.length() > 0 ) {
@@ -247,12 +272,13 @@ public class LegacyXPathTableModel extends AbstractTableModel {
     }
   }
 
-  private Node evaluateNode( final XPath xpath, final String xpathQuery,
-                             final ResourceData xmlResourceData, final ResourceManager resourceManager )
-    throws XPathExpressionException, ResourceLoadingException, IOException {
+  private Node evaluateNode( final XPathExpression xPathExpression,
+                            final ResourceData xmlResourceData, final ResourceManager resourceManager, final DocumentBuilder builder )
+          throws XPathExpressionException, ResourceLoadingException, IOException, SAXException {
     final InputStream stream = xmlResourceData.getResourceAsStream( resourceManager );
     try {
-      return (Node) xpath.evaluate( xpathQuery, new InputSource( stream ), XPathConstants.NODE );
+      return (Node) xPathExpression.evaluate( builder.parse( new InputSource( stream ) ), XPathConstants.NODE );
+
     } finally {
       stream.close();
     }

--- a/engine/extensions-xpath/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/xpath/LegacyXPathTableModelTest.java
+++ b/engine/extensions-xpath/test-src/org/pentaho/reporting/engine/classic/extensions/datasources/xpath/LegacyXPathTableModelTest.java
@@ -1,0 +1,62 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+
+
+package org.pentaho.reporting.engine.classic.extensions.datasources.xpath;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
+import org.pentaho.reporting.libraries.base.config.Configuration;
+import org.pentaho.reporting.libraries.base.config.ModifiableConfiguration;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class LegacyXPathTableModelTest {
+
+    @Test
+    public void testCalculateDocumentBuilderFactory() throws ReportDataFactoryException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, ParserConfigurationException {
+
+        Method method =  LegacyXPathTableModel.class.getDeclaredMethod( "calculateDocumentBuilderFactory", Configuration.class );
+        method.setAccessible( true );
+        LegacyXPathTableModel legacyXPathTableModel = Mockito.mock( LegacyXPathTableModel.class );
+
+        //disable DTDs
+        ModifiableConfiguration disableDTDsPropertyConfig = ClassicEngineBoot.getInstance().getEditableConfig();
+        disableDTDsPropertyConfig.setConfigProperty( LegacyXPathTableModel.XPATH_ENABLE_DTDS, "false" );
+        DocumentBuilderFactory documentBuilderFactoryDisableDTDs = ( DocumentBuilderFactory ) method.invoke( legacyXPathTableModel, disableDTDsPropertyConfig );
+        Assert.assertTrue( documentBuilderFactoryDisableDTDs.getFeature( LegacyXPathTableModel.DISALLOW_DOCTYPE_DECL ) );
+
+        //disable DTDs missing config
+        ModifiableConfiguration missingPropertyConfig = ClassicEngineBoot.getInstance().getEditableConfig();
+        DocumentBuilderFactory documentBuilderFactoryMissingProperty = ( DocumentBuilderFactory ) method.invoke( legacyXPathTableModel, missingPropertyConfig );
+        Assert.assertTrue( documentBuilderFactoryMissingProperty.getFeature( LegacyXPathTableModel.DISALLOW_DOCTYPE_DECL ) );
+
+        //enable DTDs
+        ModifiableConfiguration enableDTDsPropertyConfig = ClassicEngineBoot.getInstance().getEditableConfig();
+        enableDTDsPropertyConfig.setConfigProperty( LegacyXPathTableModel.XPATH_ENABLE_DTDS, "true" );
+        DocumentBuilderFactory documentBuilderFactoryEnableDTDs = ( DocumentBuilderFactory ) method.invoke( legacyXPathTableModel, enableDTDsPropertyConfig );
+        Assert.assertFalse( documentBuilderFactoryEnableDTDs.getFeature( LegacyXPathTableModel.DISALLOW_DOCTYPE_DECL ) );
+
+    }
+
+}


### PR DESCRIPTION
[PPP-3584] PRD - Security Vulnerability when using XML file as datasource

- disable default support DTD in pentaho report designer
- add property for enable/disable support DTD

@pamval  