### PR TITLE
[BACKLOG-11906] - fix formula computation for empty label and data format

### DIFF
--- a/designer/report-designer/ivy.xml
+++ b/designer/report-designer/ivy.xml
@@ -60,13 +60,14 @@
 
     <!-- testing dependencies -->
     <!-- Testing Dependencies -->
-    <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>
+    <dependency org="junit" name="junit" rev="4.12" transitive="false" conf="test->default"/>
     <dependency org="org.hsqldb" name="hsqldb" rev="2.3.2" transitive="false" conf="test->default"/>
     <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3" transitive="false" conf="test->default"/>
     <dependency org="pentaho" name="simple-jndi" rev="${dependency.pentaho-simple-jndi.revision}" transitive="false" conf="test->default"/>
     <dependency org="xmlunit" name="xmlunit" rev="1.3" conf="test->default"/>
     <dependency org="${reporting-engine.group}" name="pentaho-reporting-engine-classic-core-test" rev="${project.revision}"
                 transitive="false" conf="test->default"/>
+    <dependency org="org.mockito" name="mockito-all" rev="1.10.19" conf="test->default" />
 
     <exclude org="xml-apis" module="xml-apis"/>
   </dependencies>

--- a/designer/report-designer/test-src/org/pentaho/reporting/designer/core/editor/parameters/ParameterDialogTest.java
+++ b/designer/report-designer/test-src/org/pentaho/reporting/designer/core/editor/parameters/ParameterDialogTest.java
@@ -1,0 +1,208 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2006 - 2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.designer.core.editor.parameters;
+
+import java.awt.GraphicsEnvironment;
+import javax.swing.JTextField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.pentaho.reporting.designer.core.ReportDesignerContext;
+import org.pentaho.reporting.designer.core.util.FormulaEditorPanel;
+import org.pentaho.reporting.engine.classic.core.parameters.ParameterAttributeNames;
+import org.pentaho.reporting.engine.classic.core.parameters.ParameterContext;
+import org.pentaho.reporting.engine.classic.core.parameters.ParameterDefinitionEntry;
+
+/**
+ * Created by dima.prokopenko@gmail.com on 10/26/2016.
+ */
+public class ParameterDialogTest {
+
+  private ReportDesignerContext context;
+  private ParameterDefinitionEntry parameter;
+  private ParameterType type;
+  private ParameterDialog dialog;
+  private ParameterContext parameterContext;
+
+  @Before
+  public void before() {
+    assumeFalse( GraphicsEnvironment.isHeadless() );
+
+    context = mock( ReportDesignerContext.class );
+    parameter = mock( ParameterDefinitionEntry.class );
+    when( parameter.getValueType() ).thenReturn( String.class );
+    type = mock( ParameterType.class );
+
+    parameterContext = mock( ParameterContext.class );
+
+    dialog = new ParameterDialog( context );
+
+    dialog.dataFormatField = mock( JTextField.class );
+    dialog.dataFormatFormula = mock( FormulaEditorPanel.class );
+    dialog.labelTextField = mock( JTextField.class );
+    dialog.labelFormula = mock( FormulaEditorPanel.class );
+  }
+
+  @Test
+  public void testCreateDialogJustLabel() {
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.LABEL
+    ), any() ) ).thenReturn( "val" );
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.LABEL_FORMULA
+    ), any() ) ).thenReturn( null );
+
+    dialog.updateFromParameter( parameter );
+
+    verify( dialog.labelTextField, times( 1 ) ).setText( eq( "val" ) );
+    verify( dialog.labelFormula, times( 1 ) ).setFormula( null );
+  }
+
+  @Test
+  public void testCreateDialogLabelAndFormula() {
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.LABEL
+    ), any() ) ).thenReturn( "val" );
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.LABEL_FORMULA
+    ), any() ) ).thenReturn( "=TRUE()" );
+
+    dialog.updateFromParameter( parameter );
+
+    verify( dialog.labelTextField, times( 1 ) ).setText( eq( "val" ) );
+    verify( dialog.labelFormula, times( 1 ) ).setFormula( "=TRUE()" );
+  }
+
+  @Test
+  public void testCreateDialogLabelAndFormulaAreSame() {
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.LABEL
+    ), any() ) ).thenReturn( "=TRUE()" );
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.LABEL_FORMULA
+    ), any() ) ).thenReturn( "=TRUE()" );
+
+    dialog.updateFromParameter( parameter );
+
+    verify( dialog.labelTextField, times( 1 ) ).setText( eq( "" ) );
+    verify( dialog.labelFormula, times( 1 ) ).setFormula( "=TRUE()" );
+  }
+
+  @Test
+  public void testCreateDialogDataFormat() {
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.DATA_FORMAT
+    ), any() ) ).thenReturn( "yyyy" );
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.DATA_FORMAT_FORMULA
+    ), any() ) ).thenReturn( null );
+
+    dialog.updateFromParameter( parameter );
+
+    verify( dialog.dataFormatField, times( 1 ) ).setText( eq( "yyyy" ) );
+    verify( dialog.dataFormatFormula, times( 1 ) ).setFormula( null );
+  }
+
+  @Test
+  public void testCreateDialogDataFormatAndFormula() {
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.DATA_FORMAT
+    ), any() ) ).thenReturn( "yyyy" );
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.DATA_FORMAT_FORMULA
+    ), any() ) ).thenReturn( "=ERROR()" );
+
+    dialog.updateFromParameter( parameter );
+
+    verify( dialog.dataFormatField, times( 1 ) ).setText( eq( "yyyy" ) );
+    verify( dialog.dataFormatFormula, times( 1 ) ).setFormula( "=ERROR()" );
+  }
+
+  @Test
+  public void testCreateDialogDataFormatAndFormulaSame() {
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.DATA_FORMAT
+    ), any() ) ).thenReturn( "=ERROR()" );
+    when( parameter.getParameterAttribute( anyString(), eq(
+      ParameterAttributeNames.Core.DATA_FORMAT_FORMULA
+    ), any() ) ).thenReturn( "=ERROR()" );
+
+    dialog.updateFromParameter( parameter );
+
+    verify( dialog.dataFormatField, times( 1 ) ).setText( eq( "" ) );
+    verify( dialog.dataFormatFormula, times( 1 ) ).setFormula( "=ERROR()" );
+  }
+
+  @Test
+  public void testSaveParameterLabel() {
+    when( dialog.labelFormula.getFormula() ).thenReturn( null );
+    when( dialog.dataFormatFormula.getFormula() ).thenReturn( null );
+
+    ParameterDefinitionEntry entry = dialog.createQuerylessParameter( "paramName", "paramLabel",
+      new Object(), "yyy", false, type );
+
+    final String actualDataFormat = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.DATA_FORMAT, parameterContext );
+    final String actualLabel = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.LABEL, parameterContext );
+
+    assertEquals( "paramLabel", actualLabel );
+    assertEquals( "yyy", actualDataFormat );
+
+    final String labelFormula = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.LABEL_FORMULA, parameterContext );
+    final String dataFormatFormula = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.DATA_FORMAT_FORMULA, parameterContext );
+
+    assertEquals( null, labelFormula );
+    assertEquals( null, dataFormatFormula );
+  }
+
+  @Test
+  public void testSaveParameterLabelFormulaRepalce() {
+    when( dialog.labelFormula.getFormula() ).thenReturn( "=FOR1" );
+    when( dialog.dataFormatFormula.getFormula() ).thenReturn( "=FOR2" );
+
+    ParameterDefinitionEntry entry = dialog.createQuerylessParameter( "paramName", "",
+      new Object(), "", false, type );
+
+    final String actualDataFormat = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.DATA_FORMAT, parameterContext );
+    final String actualLabel = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.LABEL, parameterContext );
+
+    assertEquals( "=FOR1", actualLabel );
+    assertEquals( "=FOR2", actualDataFormat );
+
+    final String labelFormula = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.LABEL_FORMULA, parameterContext );
+    final String dataFormatFormula = entry.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.DATA_FORMAT_FORMULA, parameterContext );
+
+    assertEquals( "=FOR1", labelFormula );
+    assertEquals( "=FOR2", dataFormatFormula );
+  }
+}


### PR DESCRIPTION
The tricky part is that if label of data format fields is empty, but formula are used - no attribute is set for label or data format. So having approach to add '-formula' will not help since we don't have such attributes at all.
In parameter dialog, as far as in bundle writers like [here](https://github.com/pentaho/pentaho-reporting/blob/497ca68305ea5183d8af0972aae339512791aae4/engine/core/source/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/DataDefinitionFileWriter.java#L218) we will not save empty attributes.

So in case of label of formula fields are empty - we will just write formula value there. On UI if we found that label value is equal to formula value - we just set empty text field. When going to save - replace empty with formula value again.