### PR TITLE
[PRD-5563] - added flag -Dswing.useSystemFontSettings=false to report…

### DIFF
--- a/designer/report-designer-assembly/resource/report-designer.bat
+++ b/designer/report-designer-assembly/resource/report-designer.bat
@@ -15,4 +15,4 @@ set PENTAHO_JAVA_HOME=%_PENTAHO_JAVA_HOME%
 :callSetEnv
 call "%~dp0set-pentaho-env.bat"
 
-start "Pentaho Report Designer" "%_PENTAHO_JAVA%" -Xms1024m -Xmx2048m -XX:MaxPermSize=256m -jar "%~dp0launcher.jar" %*
+start "Pentaho Report Designer" "%_PENTAHO_JAVA%" -Dswing.useSystemFontSettings=false -Xms1024m -Xmx2048m -XX:MaxPermSize=256m -jar "%~dp0launcher.jar" %*


### PR DESCRIPTION
…-designer.bat

@tmorgner @pamval @pedrofvteixeira please review

According to documentation: http://docs.oracle.com/javase/7/docs/technotes/guides/swing/1.4/w2k_props.html
This can be a problem in font compatibility, adding this flag fixes the issue and only affects Windows clients.