### PR TITLE
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/libraries/libloader/build.properties
+++ b/libraries/libloader/build.properties
@@ -16,3 +16,5 @@ junit.sysprop.user.region=US
 junit.sysprop.user.timezone=UTC
 junit.sysprop.java.awt.headless=true
 junit.sysprop.file.encoding=UTF-8
+
+dependency.batik.revision=1.7.1

--- a/libraries/libloader/ivy.xml
+++ b/libraries/libloader/ivy.xml
@@ -23,19 +23,19 @@
 		<dependency org="${ivy.artifact.group}" name="libpixie" rev="${project.revision}" transitive="true" changing="true" />
 
 		<!--  external 'optional' dependencies -->
-		<dependency org="org.apache.xmlgraphics" name="batik-anim" rev="1.7" conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="1.7" conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-bridge" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-css" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-dom" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-ext" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-gui-util" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-gvt" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-parser" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-script" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-svg-dom" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.7"  conf="default_external->default" transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-xml" rev="1.7"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-anim" rev="${dependency.batik.revision}" conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="${dependency.batik.revision}" conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-bridge" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-css" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-dom" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-ext" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-gui-util" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-gvt" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-parser" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-script" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-svg-dom" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-util" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-xml" rev="${dependency.batik.revision}"  conf="default_external->default" transitive="false"/>
         <dependency org="xml-apis" name="xml-apis-ext" rev="1.3.04" conf="default_external->default" transitive="false"/>
 
         <dependency org="rhino" name="js" rev="1.7R1" conf="default_external->default"/>


### PR DESCRIPTION
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (6.1 Suite)