### PR TITLE
[PRD-5631] If report-designer.sh is launched from any directory other than its own, karaf fails to start

### DIFF
--- a/assemblies/mac/src/main/resources/resource/report-designer.sh
+++ b/assemblies/mac/src/main/resources/resource/report-designer.sh
@@ -4,10 +4,9 @@
 #  WARNING: Pentaho Report Designer needs JDK 1.7 or newer to run.
 #
 
-DIR_REL=`dirname $0`
+DIR_REL=`dirname "$0"`
 cd $DIR_REL
 DIR=`pwd`
-cd -
 
 . "$DIR/set-pentaho-env.sh"
 setPentahoEnv

--- a/assemblies/mac/src/main/resources/resource/set-pentaho-env.sh
+++ b/assemblies/mac/src/main/resources/resource/set-pentaho-env.sh
@@ -36,11 +36,10 @@
 # -----------------------------------------------------------------------------
 
 setPentahoEnv() {
-  DIR_REL=`dirname $0`
+  DIR_REL=`dirname "$0"`
   cd $DIR_REL
   DIR=`pwd`
-  cd -
-	
+
   if [ -n "$PENTAHO_JAVA" ]; then
     __LAUNCHER="$PENTAHO_JAVA"
   else

--- a/assemblies/winlinux/src/main/resources/resource/report-designer.sh
+++ b/assemblies/winlinux/src/main/resources/resource/report-designer.sh
@@ -4,10 +4,9 @@
 #  WARNING: Pentaho Report Designer needs JDK 1.7 or newer to run.
 #
 
-DIR_REL=`dirname $0`
+DIR_REL=`dirname "$0"`
 cd $DIR_REL
 DIR=`pwd`
-cd -
 
 . "$DIR/set-pentaho-env.sh"
 setPentahoEnv

--- a/assemblies/winlinux/src/main/resources/resource/set-pentaho-env.sh
+++ b/assemblies/winlinux/src/main/resources/resource/set-pentaho-env.sh
@@ -36,11 +36,10 @@
 # -----------------------------------------------------------------------------
 
 setPentahoEnv() {
-  DIR_REL=`dirname $0`
+  DIR_REL=`dirname "$0"`
   cd $DIR_REL
   DIR=`pwd`
-  cd -
-	
+
   if [ -n "$PENTAHO_JAVA" ]; then
     __LAUNCHER="$PENTAHO_JAVA"
   else


### PR DESCRIPTION
- the problem with launcher directory was fixed