### PR TITLE
[PPP-3566] Use of vulnerable component xerces:xercesImpl:2.9.1and 2.1…

### DIFF
--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -212,10 +212,6 @@
       <artifactId>secondstring</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.syslog4j</groupId>
       <artifactId>syslog4j</artifactId>
     </dependency>

--- a/designer/datasource-editor-mondrian/pom.xml
+++ b/designer/datasource-editor-mondrian/pom.xml
@@ -148,10 +148,6 @@
       <artifactId>jcifs</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>secondstring</groupId>
       <artifactId>secondstring</artifactId>
     </dependency>

--- a/designer/datasource-editor-olap4j/pom.xml
+++ b/designer/datasource-editor-olap4j/pom.xml
@@ -131,10 +131,6 @@
       <artifactId>jaxen</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
     </dependency>

--- a/designer/datasource-editor-pmd/pom.xml
+++ b/designer/datasource-editor-pmd/pom.xml
@@ -159,10 +159,6 @@
       <artifactId>jaxen</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
     </dependency>

--- a/designer/report-designer-extension-connectioneditor/pom.xml
+++ b/designer/report-designer-extension-connectioneditor/pom.xml
@@ -138,10 +138,6 @@
       <artifactId>jcifs</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>saxon</artifactId>
     </dependency>

--- a/designer/report-designer-extension-legacy-charts/pom.xml
+++ b/designer/report-designer-extension-legacy-charts/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>jcifs</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
     </dependency>

--- a/designer/report-designer-extension-pentaho/pom.xml
+++ b/designer/report-designer-extension-pentaho/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>jcifs</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
     </dependency>

--- a/designer/report-designer-extension-toc/pom.xml
+++ b/designer/report-designer-extension-toc/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>jcifs</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
     </dependency>

--- a/designer/report-designer-extension-wizard/pom.xml
+++ b/designer/report-designer-extension-wizard/pom.xml
@@ -36,10 +36,6 @@
       <artifactId>jcifs</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
     </dependency>

--- a/engine/demo/pom.xml
+++ b/engine/demo/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>jsch</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
     </dependency>

--- a/engine/extensions-mondrian/pom.xml
+++ b/engine/extensions-mondrian/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/engine/extensions-reportdesigner-parser/pom.xml
+++ b/engine/extensions-reportdesigner-parser/pom.xml
@@ -51,10 +51,6 @@
       <artifactId>secondstring</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
     </dependency>

--- a/engine/testcases/pom.xml
+++ b/engine/testcases/pom.xml
@@ -101,11 +101,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
       <scope>test</scope>

--- a/engine/tools/pom.xml
+++ b/engine/tools/pom.xml
@@ -103,10 +103,6 @@
       <artifactId>commons-compress</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>secondstring</groupId>
       <artifactId>secondstring</artifactId>
     </dependency>


### PR DESCRIPTION
…1.0 - CVE-2009-2625 and CVE-2013-4002

 - removed explicit xerces dependencies. test usages of xerces are only left