### PR TITLE
[PRD-5914]-Property for "Word-Break" Unable to be Saved as "False" in Standard Report

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/layout/TextStyleReadHandler.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/layout/TextStyleReadHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2017 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.parser.bundle.layout;
@@ -142,7 +142,10 @@ public class TextStyleReadHandler extends AbstractXmlReadHandler implements Styl
     if ( textWrap != null ) {
       styleSheet.setStyleProperty( TextStyleKeys.TEXT_WRAP, parseTextWrap( textWrap ) );
     }
-
+    final String wordBreak = attrs.getValue( getUri(), "word-break" );
+    if ( wordBreak != null ) {
+      styleSheet.setBooleanStyleProperty( TextStyleKeys.WORDBREAK, "true".equals( wordBreak ) );
+    }
     final String textDirection = attrs.getValue( getUri(), "direction" );
     if ( textDirection != null ) {
       styleSheet.setStyleProperty( TextStyleKeys.DIRECTION, parseTextDirection( textDirection ) );

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/StyleWriterUtility.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/StyleWriterUtility.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2016 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2017 Object Refinery Ltd, Pentaho Corporation and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.parser.bundle.writer;
@@ -497,6 +497,10 @@ public class StyleWriterUtility {
     if ( style.isLocalKey( TextStyleKeys.TEXT_WRAP ) ) {
       final Object value = style.getStyleProperty( TextStyleKeys.TEXT_WRAP );
       bandStyleAtts.setAttribute( BundleNamespaces.STYLE, "text-wrap", value.toString() );
+    }
+    if ( style.isLocalKey( TextStyleKeys.WORDBREAK ) ) {
+      final Object value = style.getStyleProperty( TextStyleKeys.WORDBREAK );
+      bandStyleAtts.setAttribute( BundleNamespaces.STYLE, "word-break", value.toString() );
     }
     if ( style.isLocalKey( TextStyleKeys.DIRECTION ) ) {
       final Object value = style.getStyleProperty( TextStyleKeys.DIRECTION );

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/layout/TextStyleReaderHandlerTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/layout/TextStyleReaderHandlerTest.java
@@ -1,0 +1,53 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.parser.bundle.layout;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
+import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class TextStyleReaderHandlerTest {
+  private static String URI = "http://reporting.pentaho.org/namespaces/engine/classic/bundle/style/1.0";
+
+  @Before
+  public void setUp() throws Exception {
+    ClassicEngineBoot.getInstance().start();
+  }
+
+  @Test
+  public void testStartParsing() {
+    TextStyleReadHandler handler = Mockito.spy( new TextStyleReadHandler() ) ;
+    Mockito.doReturn( URI ).when( handler ).getUri();
+    ElementStyleSheet sheet = new ElementStyleSheet();
+    handler.setStyleSheet( sheet );
+    AttributesImpl attributes = new AttributesImpl();
+    attributes.addAttribute( URI,"word-break", "" , "boolean" , "false" );
+    try {
+      handler.startParsing( attributes );
+      Assert.assertFalse( sheet.getBooleanStyleProperty( TextStyleKeys.WORDBREAK ) );
+    } catch (SAXException e) {
+      Assert.fail();
+    }
+  }
+}

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/StyleWriterUtilityTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/StyleWriterUtilityTest.java
@@ -1,0 +1,54 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.parser.bundle.writer;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.style.ElementStyleSheet;
+import org.pentaho.reporting.engine.classic.core.style.TextStyleKeys;
+import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+public class StyleWriterUtilityTest {
+
+  @Before
+  public void setUp() throws Exception {
+    ClassicEngineBoot.getInstance().start();
+  }
+
+  @Test
+  public void testStartParsing() {
+    StringWriter stringWriter = new StringWriter();
+    XmlWriter writer = new XmlWriter( stringWriter );
+    writer.addImpliedNamespace( "http://reporting.pentaho.org/namespaces/engine/classic/bundle/style/1.0", "rep" );
+    ElementStyleSheet sheet = new ElementStyleSheet();
+    sheet.setBooleanStyleProperty( TextStyleKeys.WORDBREAK, false );
+    try {
+      StyleWriterUtility.writeTextStyles( writer, sheet );
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assert.fail();
+    }
+    String res = stringWriter.toString().replace( "\r", "" ).replace( "\n", "" );
+    Assert.assertEquals( "<rep:text-styles word-break=\"false\"/>", res );
+  }
+}


### PR DESCRIPTION
 - fixed, added unit tests