### PR TITLE
[PRD-3954] DRILLDOWN Formula Editor, the Location resets unexpectedly

### DIFF
--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/PentahoPathModel.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/PentahoPathModel.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.extensions.pentaho.drilldown;
@@ -184,6 +184,9 @@ public class PentahoPathModel implements XulEventSource {
   }
 
   public void setLocalPath( final String localPath ) {
+    if ( ObjectUtilities.equal( localPath, this.localPath ) ) {
+      return;
+    }
     final String oldValue = this.localPath;
     this.localPath = localPath;
     this.propertyChangeSupport.firePropertyChange( LOCAL_PATH_PROPERTY, oldValue, localPath );

--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2015 Pentaho Corporation..  All rights reserved.
+ *  Copyright (c) 2006 - 2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.extensions.pentaho.drilldown.swing;
@@ -39,7 +39,6 @@ import org.pentaho.reporting.engine.classic.core.parameters.ReportParameterDefin
 import org.pentaho.reporting.engine.classic.extensions.drilldown.DrillDownProfile;
 import org.pentaho.reporting.engine.classic.extensions.drilldown.DrillDownProfileMetaData;
 import org.pentaho.reporting.libraries.base.util.StringUtils;
-import org.pentaho.reporting.libraries.formula.util.FormulaUtil;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -49,7 +48,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
 import java.util.HashMap;
 
 /**
@@ -248,55 +246,6 @@ public class SwingRemoteDrillDownController {
   }
 
   /**
-   * Filter parameters of the drilldown parameter table.
-   * (Copied from superclass)
-   *
-   * @param parameters parameters array.
-   * @return filtered parameters array.
-   */
-  private DrillDownParameter[] filterParameterSuper( final DrillDownParameter[] parameters ) {
-    final ArrayList<DrillDownParameter> list = new ArrayList<DrillDownParameter>( parameters.length );
-    for ( int i = 0; i < parameters.length; i++ ) {
-      final DrillDownParameter downParameter = parameters[ i ];
-      if ( StringUtils.isEmpty( downParameter.getFormulaFragment() ) ) {
-        continue;
-      }
-      list.add( downParameter );
-    }
-    return list.toArray( new DrillDownParameter[ list.size() ] );
-  }
-
-  /**
-   * Filter parameters of the drilldown parameter table.
-   *
-   * @param parameters parameters array.
-   * @return filtered parameters array.
-   */
-  protected DrillDownParameter[] filterParameter( final DrillDownParameter[] parameters ) {
-    // modify the parameter model.
-    final ArrayList<DrillDownParameter> list = new ArrayList<DrillDownParameter>();
-    boolean pathAdded = false;
-    for ( int i = 0; i < parameters.length; i++ ) {
-      final DrillDownParameter drillDownParameter = parameters[i];
-      if ( "::pentaho-path".equals( drillDownParameter.getName() ) && pathAdded == false ) {
-        list.add( new DrillDownParameter( "::pentaho-path", FormulaUtil.quoteString( pentahoPathWrapper.getLocalPath() ) ) );
-        pathAdded = true;
-      } else {
-        if ( !( "solution".equals( drillDownParameter.getName() ) || "path".equals( drillDownParameter.getName() ) || "name"
-                .equals( drillDownParameter.getName() ) ) ) {
-          list.add( drillDownParameter );
-        }
-      }
-    }
-    if ( pathAdded == false ) {
-      list.add( 0, new DrillDownParameter( "::pentaho-path", FormulaUtil
-              .quoteString( pentahoPathWrapper.getLocalPath() ) ) );
-    }
-    return filterParameterSuper( list.toArray( new DrillDownParameter[list.size()] ) );
-
-  }
-
-  /**
    * Service task to perform after BI-server authentication.
    */
   private class LoginCompleteTask implements AuthenticatedServerTask {
@@ -381,7 +330,7 @@ public class SwingRemoteDrillDownController {
 
     public void propertyChange( final PropertyChangeEvent evt ) {
       if ( PentahoPathModel.LOCAL_PATH_PROPERTY.equals( evt.getPropertyName() ) ) {
-        modelWrapper.setDrillDownParameter( filterParameter( modelWrapper.getDrillDownParameter() ) );
+        modelWrapper.setDrillDownParameter( modelWrapper.getDrillDownParameter() );
         modelWrapper.setDrillDownConfig( pentahoPathWrapper.getDrillDownProfile() );
       } else if ( PentahoPathModel.USE_REMOTE_SERVER_PROPERTY.equals( evt.getPropertyName() ) ) {
         modelWrapper.setDrillDownConfig( pentahoPathWrapper.getDrillDownProfile() );
@@ -411,9 +360,9 @@ public class SwingRemoteDrillDownController {
      * {@inheritDoc}
      */
     public void propertyChange( final PropertyChangeEvent evt ) {
-      modelWrapper.setDrillDownParameter( filterParameter( ( drillDownUi.<DrillDownParameterTable>getComponent(
+      modelWrapper.setDrillDownParameter( ( drillDownUi.<DrillDownParameterTable>getComponent(
           SwingRemoteDrillDownUi.ComponentLookup.PARAMETER_TABLE
-      ) ).getDrillDownParameter() ) );
+      ) ).getDrillDownParameter() );
     }
   }
 

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/DrillDownFunctionParameterEditor.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/DrillDownFunctionParameterEditor.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.reporting.designer.core.editor.drilldown;
@@ -25,11 +25,13 @@ import org.pentaho.reporting.designer.core.ReportDesignerContext;
 import org.pentaho.reporting.designer.core.editor.ReportDocumentContext;
 import org.pentaho.reporting.designer.core.util.ReportDesignerFunctionParameterEditor;
 
-import javax.swing.*;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.EventListenerList;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Component;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -56,7 +58,7 @@ public class DrillDownFunctionParameterEditor implements ReportDesignerFunctionP
           eventListenerList.getListeners( ParameterUpdateListener.class );
         String formula = editor.getDrillDownFormula();
         if ( formula == null ) {
-          formula = "=DRILLDOWN(\"Text\"; \"Text\"; Any)";  // NON-NLS
+          formula = "DRILLDOWN(\"Text\"; \"Text\"; \"Any\")";  // NON-NLS
         }
         for ( int i = 0; i < parameterUpdateListeners.length; i++ ) {
           final ParameterUpdateListener listener = parameterUpdateListeners[ i ];
@@ -121,8 +123,8 @@ public class DrillDownFunctionParameterEditor implements ReportDesignerFunctionP
     editor.setEditFormulaFragment( true );
     editor.setLimitedEditor( true );
     editor.addPropertyChangeListener( "drillDownFormula", new DrillDownUpdateListener() );
-    editor.addPropertyChangeListener
-      ( DrillDownEditor.DRILL_DOWN_UI_PROFILE_PROPERTY, new DrillDownProfileChangeHandler() );
+    editor.addPropertyChangeListener( DrillDownEditor.DRILL_DOWN_UI_PROFILE_PROPERTY,
+            new DrillDownProfileChangeHandler() );
 
     eventListenerList = new EventListenerList();
 
@@ -175,8 +177,8 @@ public class DrillDownFunctionParameterEditor implements ReportDesignerFunctionP
     if ( activeContext == null ) {
       return new String[ 0 ];
     }
-    final HashSet<String> columnNames = new HashSet<String>
-      ( Arrays.asList( activeContext.getReportDataSchemaModel().getColumnNames() ) );
+    final HashSet<String> columnNames =
+            new HashSet<String>( Arrays.asList( activeContext.getReportDataSchemaModel().getColumnNames() ) );
     final ArrayList<String> retval = new ArrayList<String>();
     for ( int i = 0; i < fieldDefinitions.length; i++ ) {
       final FieldDefinition fieldDefinition = fieldDefinitions[ i ];

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/basic/DefaultXulDrillDownController.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/basic/DefaultXulDrillDownController.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.reporting.designer.core.editor.drilldown.basic;
@@ -29,7 +29,7 @@ import org.pentaho.ui.xul.binding.BindingFactory;
 import org.pentaho.ui.xul.binding.DefaultBindingFactory;
 import org.pentaho.ui.xul.dom.Document;
 
-import javax.swing.*;
+import javax.swing.SwingUtilities;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -42,7 +42,7 @@ public class DefaultXulDrillDownController implements XulDrillDownController {
      * @param evt A PropertyChangeEvent object describing the event source and the property that has changed.
      */
     public void propertyChange( final PropertyChangeEvent evt ) {
-      wrapper.setDrillDownParameter( filterParameter( table.getDrillDownParameter() ) );
+      wrapper.setDrillDownParameter( table.getDrillDownParameter() );
     }
   }
 
@@ -129,34 +129,34 @@ public class DefaultXulDrillDownController implements XulDrillDownController {
     bindingFactory.setDocument( doc );
     bindingFactory.setBindingType( Binding.Type.BI_DIRECTIONAL );
     wrapper = new DrillDownModelWrapper( model );
-    final XulComponent pathElement = doc.getElementById( "path" );//NON-NLS
+    final XulComponent pathElement = doc.getElementById( "path" ); //NON-NLS
     if ( pathElement != null ) {
-      bindingFactory.createBinding( wrapper, DrillDownModel.DRILL_DOWN_PATH_PROPERTY, "path", "value" );//NON-NLS
+      bindingFactory.createBinding( wrapper, DrillDownModel.DRILL_DOWN_PATH_PROPERTY, "path", "value" ); //NON-NLS
     }
-    final XulComponent configElement = doc.getElementById( "config" );//NON-NLS
+    final XulComponent configElement = doc.getElementById( "config" ); //NON-NLS
     if ( configElement != null ) {
-      bindingFactory.createBinding( wrapper, DrillDownModel.DRILL_DOWN_CONFIG_PROPERTY, "config", "value" );//NON-NLS
+      bindingFactory.createBinding( wrapper, DrillDownModel.DRILL_DOWN_CONFIG_PROPERTY, "config", "value" ); //NON-NLS
     }
-    final XulComponent linkTargetElement = doc.getElementById( "link-target" );//NON-NLS
+    final XulComponent linkTargetElement = doc.getElementById( "link-target" ); //NON-NLS
     if ( linkTargetElement != null ) {
-      bindingFactory.createBinding( wrapper, DrillDownModel.TARGET_FORMULA_PROPERTY, "link-target", "value" );//NON-NLS
+      bindingFactory.createBinding( wrapper, DrillDownModel.TARGET_FORMULA_PROPERTY, "link-target", "value" ); //NON-NLS
     }
-    final XulComponent linkTooltipElement = doc.getElementById( "link-tooltip" );//NON-NLS
+    final XulComponent linkTooltipElement = doc.getElementById( "link-tooltip" ); //NON-NLS
     if ( linkTooltipElement != null ) {
       bindingFactory
-        .createBinding( wrapper, DrillDownModel.TOOLTIP_FORMULA_PROPERTY, "link-tooltip", "value" );//NON-NLS
+        .createBinding( wrapper, DrillDownModel.TOOLTIP_FORMULA_PROPERTY, "link-tooltip", "value" ); //NON-NLS
     }
-    final XulComponent previewElement = doc.getElementById( "preview" );//NON-NLS
+    final XulComponent previewElement = doc.getElementById( "preview" ); //NON-NLS
     if ( previewElement != null ) {
       final BindingFactory singleSourceBinding = new DefaultBindingFactory();
       singleSourceBinding.setBindingType( Binding.Type.ONE_WAY );
       singleSourceBinding.setDocument( doc );
-      singleSourceBinding.createBinding( wrapper, "preview", "preview", "value" );//NON-NLS
+      singleSourceBinding.createBinding( wrapper, "preview", "preview", "value" ); //NON-NLS
     }
 
     // we manage the binding between the table and the outside world manually
     wrapper.refresh();
-    final XulComponent paramTableElement = doc.getElementById( "parameter-table" );//NON-NLS
+    final XulComponent paramTableElement = doc.getElementById( "parameter-table" ); //NON-NLS
     if ( paramTableElement instanceof XulDrillDownParameterTable ) {
       final XulDrillDownParameterTable parameterTable = (XulDrillDownParameterTable) paramTableElement;
       table = parameterTable.getTable();
@@ -168,7 +168,7 @@ public class DefaultXulDrillDownController implements XulDrillDownController {
     }
 
     if ( model.isLimitedEditor() ) {
-      final XulComponent tooltipAndTargetElement = doc.getElementById( "tooltip-and-target-panel" );//NON-NLS
+      final XulComponent tooltipAndTargetElement = doc.getElementById( "tooltip-and-target-panel" ); //NON-NLS
       if ( tooltipAndTargetElement != null ) {
         tooltipAndTargetElement.setVisible( false );
       }

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/model/DrillDownModel.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/model/DrillDownModel.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.reporting.designer.core.editor.drilldown.model;
@@ -160,19 +160,18 @@ public class DrillDownModel {
         final LValue value = parser.parse( formula );
         if ( value instanceof FormulaFunction ) {
           final FormulaFunction function = (FormulaFunction) value;
-          if ( "DRILLDOWN".equals( function.getFunctionName() ) ) // NON-NLS
-          {
+          if ( "DRILLDOWN".equals( function.getFunctionName() ) ) { // NON-NLS
             updateModelFromFunction( function );
             return true;
           }
         }
-        DebugLog.log( "Fall through on formula " + formula );//NON-NLS
+        DebugLog.log( "Fall through on formula " + formula ); //NON-NLS
       } catch ( Exception e ) {
         // plain value ..
-        DebugLog.log( "Failed with formula " + formulaWithPrefix, e );//NON-NLS
+        DebugLog.log( "Failed with formula " + formulaWithPrefix, e ); //NON-NLS
       }
     } else {
-      DebugLog.log( "formula is empty " + formulaWithPrefix );//NON-NLS
+      DebugLog.log( "formula is empty " + formulaWithPrefix ); //NON-NLS
     }
     return false;
   }
@@ -194,8 +193,7 @@ public class DrillDownModel {
     }
 
     final DrillDownParameter[] downParameters = getDrillDownParameter();
-    if ( StringUtils.isEmpty( getDrillDownPath() ) &&
-      downParameters.length == 0 ) {
+    if ( StringUtils.isEmpty( getDrillDownPath() ) && downParameters.length == 0 ) {
       return null;
     }
 
@@ -225,6 +223,7 @@ public class DrillDownModel {
       builder.append( "; " ); // NON-NLS
       final String formulaFragment = downParameter.getFormulaFragment();
       if ( StringUtils.isEmpty( formulaFragment ) ) {
+        builder.append( "NA()" );
         continue;
       }
 

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/swing/SwingGenericUrlDrillDownUi.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/swing/SwingGenericUrlDrillDownUi.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2016 Pentaho Corporation..  All rights reserved.
+ *  Copyright (c) 2006 - 2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.core.editor.drilldown.swing;
@@ -43,7 +43,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
 import java.util.HashMap;
 
 /**
@@ -230,22 +229,8 @@ public class SwingGenericUrlDrillDownUi implements DrillDownUi {
      * {@inheritDoc}
      */
     public void propertyChange( final PropertyChangeEvent evt ) {
-      wrapper.setDrillDownParameter( filterParameter( table.getDrillDownParameter() ) );
+      wrapper.setDrillDownParameter( table.getDrillDownParameter() );
     }
-
-    private DrillDownParameter[] filterParameter( final DrillDownParameter[] parameter ) {
-      final ArrayList<DrillDownParameter> list = new ArrayList<DrillDownParameter>( parameter.length );
-      for ( int i = 0; i < parameter.length; i++ ) {
-        final DrillDownParameter downParameter = parameter[ i ];
-        if ( StringUtils.isEmpty( downParameter.getFormulaFragment() ) ) {
-          continue;
-        }
-
-        list.add( downParameter );
-      }
-      return list.toArray( new DrillDownParameter[ list.size() ] );
-    }
-
   }
 
   /**

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/swing/SwingSelfDrillDownUi.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/drilldown/swing/SwingSelfDrillDownUi.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2016 Pentaho Corporation..  All rights reserved.
+ *  Copyright (c) 2006 - 2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.core.editor.drilldown.swing;
@@ -30,7 +30,6 @@ import org.pentaho.reporting.designer.core.editor.drilldown.model.DrillDownParam
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.parameters.ParameterDefinitionEntry;
 import org.pentaho.reporting.engine.classic.core.parameters.ReportParameterDefinition;
-import org.pentaho.reporting.libraries.base.util.StringUtils;
 
 import javax.swing.JPanel;
 import javax.swing.SpringLayout;
@@ -40,7 +39,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
 import java.util.HashMap;
 
 /**
@@ -198,22 +196,8 @@ public class SwingSelfDrillDownUi implements DrillDownUi {
      * {@inheritDoc}
      */
     public void propertyChange( final PropertyChangeEvent evt ) {
-      wrapper.setDrillDownParameter( filterParameter( table.getDrillDownParameter() ) );
+      wrapper.setDrillDownParameter( table.getDrillDownParameter() );
     }
-
-    private DrillDownParameter[] filterParameter( final DrillDownParameter[] parameter ) {
-      final ArrayList<DrillDownParameter> list = new ArrayList<DrillDownParameter>( parameter.length );
-      for ( int i = 0; i < parameter.length; i++ ) {
-        final DrillDownParameter downParameter = parameter[ i ];
-        if ( StringUtils.isEmpty( downParameter.getFormulaFragment() ) ) {
-          continue;
-        }
-
-        list.add( downParameter );
-      }
-      return list.toArray( new DrillDownParameter[ list.size() ] );
-    }
-
   }
 
   /**


### PR DESCRIPTION
- removed unnecessary parameters filtration;
- added a check before event creation;
- fixed formula creation - created formula now is valid by default;
- fixed unreported bug with '=' duplication on location changing;