### PR TITLE
[BACKLOG-19148]-java.lang.UnsupportedOperationException error in Pentaho Report Designer when publishing report to the server

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -184,11 +184,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
-      <artifactId>org.apache.karaf.jaas.modules</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/PentahoParameterRefreshHandler.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/PentahoParameterRefreshHandler.java
@@ -27,9 +27,8 @@ import org.apache.commons.vfs2.VFS;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.client.params.CookiePolicy;
 import org.pentaho.reporting.designer.core.ReportDesignerContext;
 import org.pentaho.reporting.designer.core.auth.AuthenticationData;
 import org.pentaho.reporting.designer.core.editor.ReportDocumentContext;
@@ -186,9 +185,8 @@ public class PentahoParameterRefreshHandler implements DrillDownParameterRefresh
     HttpClientManager.HttpClientBuilderFacade clientBuilder = HttpClientManager.getInstance().createBuilder();
 
     HttpClient client = clientBuilder.setSocketTimeout( WorkspaceSettings.getInstance().getConnectionTimeout() * 1000 )
-      .setCredentials( loginData.getUsername(), loginData.getPassword() ).build();
+      .setCredentials( loginData.getUsername(), loginData.getPassword() ).setCookieSpec( CookieSpecs.DEFAULT ).build();
 
-    client.getParams().setParameter( ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY );
     return client;
   }
 

--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/repository/actions/UpdateReservedCharsTask.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/repository/actions/UpdateReservedCharsTask.java
@@ -20,9 +20,8 @@ package org.pentaho.reporting.designer.extensions.pentaho.repository.actions;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.client.params.CookiePolicy;
 import org.pentaho.reporting.designer.core.auth.AuthenticationData;
 import org.pentaho.reporting.designer.core.settings.WorkspaceSettings;
 import org.pentaho.reporting.designer.extensions.pentaho.repository.util.PublishException;
@@ -45,9 +44,9 @@ public class UpdateReservedCharsTask implements AuthenticatedServerTask {
     HttpClientManager.HttpClientBuilderFacade clientBuilder = HttpClientManager.getInstance().createBuilder();
     HttpClient client =
       clientBuilder.setSocketTimeout( WorkspaceSettings.getInstance().getConnectionTimeout() * 1000 )
-        .setCredentials( loginData.getUsername(), loginData.getPassword() ).build();
+        .setCredentials( loginData.getUsername(), loginData.getPassword() ).setCookieSpec( CookieSpecs.DEFAULT )
+        .build();
 
-    client.getParams().setParameter( ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY );
     return client;
   }
 

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/util/HttpClientManager.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/util/HttpClientManager.java
@@ -72,6 +72,10 @@ public class HttpClientManager {
     private CredentialsProvider provider;
     private int connectionTimeout;
     private int socketTimeout;
+    private int maxRedirects;
+    private String cookieSpec;
+    private Boolean allowCircularRedirects = false;
+    private Boolean rejectRelativeRedirect = true;
     private HttpHost proxy;
 
     public HttpClientBuilderFacade setConnectionTimeout( int connectionTimeout ) {
@@ -81,6 +85,26 @@ public class HttpClientManager {
 
     public HttpClientBuilderFacade setSocketTimeout( int socketTimeout ) {
       this.socketTimeout = socketTimeout;
+      return this;
+    }
+
+    public HttpClientBuilderFacade allowCircularRedirects( ) {
+      this.allowCircularRedirects = true;
+      return this;
+    }
+
+    public HttpClientBuilderFacade allowRelativeRedirect( ) {
+      this.rejectRelativeRedirect = false;
+      return this;
+    }
+
+    public HttpClientBuilderFacade setMaxRedirects( int maxRedirects ) {
+      this.maxRedirects = maxRedirects;
+      return this;
+    }
+
+    public HttpClientBuilderFacade setCookieSpec( final String cookieSpec ) {
+      this.cookieSpec = cookieSpec;
       return this;
     }
 
@@ -125,6 +149,20 @@ public class HttpClientManager {
       if ( proxy != null ) {
         requestConfigBuilder.setProxy( proxy );
       }
+      if ( cookieSpec != null ) {
+        requestConfigBuilder.setCookieSpec( cookieSpec );
+      }
+      if ( maxRedirects > 0 ) {
+        requestConfigBuilder.setMaxRedirects( maxRedirects );
+      }
+      if ( allowCircularRedirects ) {
+        requestConfigBuilder.setCircularRedirectsAllowed( true );
+      }
+      if ( !rejectRelativeRedirect ) {
+        requestConfigBuilder.setRelativeRedirectsAllowed( true );
+      }
+
+      // RequestConfig built
       httpClientBuilder.setDefaultRequestConfig( requestConfigBuilder.build() );
 
       if ( provider != null ) {

--- a/engine/extensions-cda/src/main/java/org/pentaho/reporting/engine/classic/extensions/datasources/cda/HttpQueryBackend.java
+++ b/engine/extensions-cda/src/main/java/org/pentaho/reporting/engine/classic/extensions/datasources/cda/HttpQueryBackend.java
@@ -23,9 +23,8 @@ import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.client.params.CookiePolicy;
 import org.pentaho.reporting.engine.classic.core.DataRow;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
 import org.pentaho.reporting.engine.classic.core.util.HttpClientManager;
@@ -89,8 +88,8 @@ public class HttpQueryBackend extends CdaQueryBackend {
   protected HttpClient getHttpClient() {
     if ( client == null ) {
       HttpClientManager.HttpClientBuilderFacade clientBuilder = HttpClientManager.getInstance().createBuilder();
-      client = clientBuilder.setCredentials( getUsername(), getPassword() ).build();
-      client.getParams().setParameter( ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY );
+      client = clientBuilder.setCredentials( getUsername(), getPassword() )
+        .setCookieSpec( CookieSpecs.DEFAULT ).build();
     }
     return client;
   }

--- a/libraries/libpensol/src/main/java/org/pentaho/reporting/libraries/pensol/PentahoSolutionFileProvider.java
+++ b/libraries/libpensol/src/main/java/org/pentaho/reporting/libraries/pensol/PentahoSolutionFileProvider.java
@@ -30,7 +30,6 @@ import org.apache.commons.vfs2.provider.GenericFileName;
 import org.apache.commons.vfs2.provider.LayeredFileName;
 import org.apache.commons.vfs2.provider.LayeredFileNameParser;
 import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.util.StringUtil;
@@ -145,11 +144,9 @@ public class PentahoSolutionFileProvider extends AbstractOriginatingFileProvider
     final PentahoSolutionsFileSystemConfigBuilder configBuilder = new PentahoSolutionsFileSystemConfigBuilder();
     final int timeOut = configBuilder.getTimeOut( fileSystemOptions );
     clientBuilder.setSocketTimeout( Math.max( 0, timeOut ) );
-    CloseableHttpClient httpClient = clientBuilder.build();
 
     return new WebSolutionFileSystem( genericRootName, fileSystemOptions,
-      new LocalFileModel( outerName.getURI(), httpClient,
-        userName, password, hostName, port )
+      new LocalFileModel( outerName.getURI(), clientBuilder, userName, password, hostName, port )
     );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1025,11 +1025,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.karaf.jaas</groupId>
-        <artifactId>org.apache.karaf.jaas.modules</artifactId>
-        <version>${karaf.vesrion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.karaf.jaas</groupId>
         <artifactId>org.apache.karaf.jaas.boot</artifactId>
         <version>${karaf.vesrion}</version>
       </dependency>


### PR DESCRIPTION
Removed org.apache.karaf.jaas.modules-x.x.x.jar http://jira.pentaho.com/browse/BACKLOG-18473 
Contained old version of http-client inside.