### PR TITLE
[BACKLOG-19411] - Fixed problem with detecting parent directory when …

### DIFF
--- a/assemblies/winlinux/src/main/resources/resource/Report-Designer.command
+++ b/assemblies/winlinux/src/main/resources/resource/Report-Designer.command
@@ -1,4 +1,4 @@
-cd `dirname $0`
+cd "$(dirname "$0")"
 
 # if a BASE_DIR argument has been passed to this .command, use it
 if [ -n "$1" ] && [ -d "$1" ] && [ -x "$1" ]; then


### PR DESCRIPTION
…directory name has spaces