### PR TITLE
[PRD-4595] Errors from the datasource used in a SINGLEVALUEQUERY func…

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/FormulaExpression.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/FormulaExpression.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2017 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.function;
@@ -182,7 +182,7 @@ public final class FormulaExpression extends AbstractExpression {
       try {
         compiledFormula.initialize( context );
         final Object evaluate = compiledFormula.evaluate();
-        if ( Boolean.TRUE.equals( failOnError ) ) {
+        if ( compiledFormula.failOnError() ) {
           if ( evaluate instanceof ErrorValue ) {
             throw new InvalidReportStateException( String.format(
                 "Failed to evaluate formula-expression with error %s", // NON-NLS
@@ -204,7 +204,7 @@ public final class FormulaExpression extends AbstractExpression {
           FormulaExpression.logger.debug( "Failed to compute the regular value [" + formulaExpression + ']' );
         }
       }
-      if ( Boolean.TRUE.equals( failOnError ) ) {
+      if ( compiledFormula.failOnError() ) {
         throw new InvalidReportStateException( String.format( "Failed to evaluate formula-expression with error %s", // NON-NLS
             e.getMessage() ), e );
       }

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/formula/SingleValueQueryFunction.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/formula/SingleValueQueryFunction.java
@@ -39,6 +39,11 @@ public class SingleValueQueryFunction implements Function {
   public SingleValueQueryFunction() {
   }
 
+  @Override
+  public boolean failOnError() {
+    return true;
+  }
+
   public String getCanonicalName() {
     return "SINGLEVALUEQUERY";
   }

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/Formula.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/Formula.java
@@ -110,6 +110,10 @@ public class Formula implements Serializable, Cloneable {
     }
   }
 
+  public boolean failOnError() {
+    return rootReference.failOnError();
+  }
+
   public Object evaluate() {
     final TypeValuePair pair = evaluateTyped();
     final Object value = pair.getValue();

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/Function.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/Function.java
@@ -37,4 +37,8 @@ public interface Function extends Serializable {
   public TypeValuePair evaluate( FormulaContext context,
                                  ParameterCallback parameters )
     throws EvaluationException;
+
+  default boolean failOnError() {
+    return false;
+  }
 }

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/lvalues/FormulaFunction.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/lvalues/FormulaFunction.java
@@ -45,6 +45,15 @@ import org.pentaho.reporting.libraries.formula.typing.TypeRegistry;
 public class FormulaFunction extends AbstractLValue {
   private static final Log logger = LogFactory.getLog( FormulaFunction.class );
 
+  @Override
+  public boolean failOnError() {
+    if ( function != null ) {
+      return function.failOnError();
+    } else {
+      return false;
+    }
+  }
+
   private static class FormulaParameterCallback implements ParameterCallback {
     private TypeValuePair[] backend;
     private FormulaFunction function;

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/lvalues/LValue.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/lvalues/LValue.java
@@ -59,4 +59,8 @@ public interface LValue extends Serializable, Cloneable {
   public boolean isConstant();
 
   public ParsePosition getParsePosition();
+
+  default boolean failOnError() {
+    return false;
+  }
 }


### PR DESCRIPTION
[PRD-4595] Errors from the datasource used in a SINGLEVALUEQUERY function are consumed silently