### PR TITLE
[PRD-4595] Errors from the datasource used in a SINGLEVALUEQUERY func…

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/FormulaExpression.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/FormulaExpression.java
@@ -12,13 +12,14 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2017 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineCoreModule;
 import org.pentaho.reporting.engine.classic.core.InvalidReportStateException;
 import org.pentaho.reporting.libraries.base.config.Configuration;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
@@ -67,7 +68,9 @@ public final class FormulaExpression extends AbstractExpression {
   }
 
   public Boolean getFailOnError() {
-    return failOnError;
+    return failOnError == null
+            ? "true".equals( getReportConfiguration().getConfigProperty( ClassicEngineCoreModule.STRICT_ERROR_HANDLING_KEY ) )
+            : failOnError;
   }
 
   public void setFailOnError( final Boolean failOnError ) {
@@ -159,7 +162,7 @@ public final class FormulaExpression extends AbstractExpression {
    */
   private Object computeRegularValue() {
     if ( formulaError != null ) {
-      if ( Boolean.TRUE.equals( failOnError ) ) {
+      if ( Boolean.TRUE.equals( getFailOnError() ) ) {
         throw new InvalidReportStateException( String.format(
             "Previously failed to evaluate formula-expression with error %s", // NON-NLS
             formulaError ) );
@@ -182,7 +185,7 @@ public final class FormulaExpression extends AbstractExpression {
       try {
         compiledFormula.initialize( context );
         final Object evaluate = compiledFormula.evaluate();
-        if ( Boolean.TRUE.equals( failOnError ) ) {
+        if ( Boolean.TRUE.equals( getFailOnError() ) ) {
           if ( evaluate instanceof ErrorValue ) {
             throw new InvalidReportStateException( String.format(
                 "Failed to evaluate formula-expression with error %s", // NON-NLS
@@ -204,7 +207,7 @@ public final class FormulaExpression extends AbstractExpression {
           FormulaExpression.logger.debug( "Failed to compute the regular value [" + formulaExpression + ']' );
         }
       }
-      if ( Boolean.TRUE.equals( failOnError ) ) {
+      if ( Boolean.TRUE.equals( getFailOnError() ) ) {
         throw new InvalidReportStateException( String.format( "Failed to evaluate formula-expression with error %s", // NON-NLS
             e.getMessage() ), e );
       }

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/FormulaFunction.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/FormulaFunction.java
@@ -12,13 +12,14 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2017 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineCoreModule;
 import org.pentaho.reporting.engine.classic.core.InvalidReportStateException;
 import org.pentaho.reporting.engine.classic.core.event.ReportEvent;
 import org.pentaho.reporting.libraries.base.config.Configuration;
@@ -83,7 +84,9 @@ public final class FormulaFunction extends AbstractFunction {
   }
 
   public Boolean getFailOnError() {
-    return failOnError;
+    return failOnError == null
+            ? "true".equals( getReportConfiguration().getConfigProperty( ClassicEngineCoreModule.STRICT_ERROR_HANDLING_KEY ) )
+            : failOnError;
   }
 
   public void setFailOnError( final Boolean failOnError ) {
@@ -246,7 +249,7 @@ public final class FormulaFunction extends AbstractFunction {
         try {
           initFormula.initialize( context );
           final Object evaluate = initFormula.evaluate();
-          if ( Boolean.TRUE.equals( failOnError ) ) {
+          if ( Boolean.TRUE.equals( getFailOnError() ) ) {
             if ( evaluate instanceof ErrorValue ) {
               throw new InvalidReportStateException( String.format(
                   "Failed to evaluate formula-expression with error %s", // NON-NLS
@@ -271,7 +274,7 @@ public final class FormulaFunction extends AbstractFunction {
           FormulaFunction.logger.debug( "Failed to compute the initial value [" + formulaExpression + ']' );
         }
       }
-      if ( Boolean.TRUE.equals( failOnError ) ) {
+      if ( Boolean.TRUE.equals( getFailOnError() ) ) {
         throw new InvalidReportStateException( String.format( "Failed to evaluate formula-function with error %s", // NON-NLS
             e.getMessage() ), e );
       }
@@ -286,7 +289,7 @@ public final class FormulaFunction extends AbstractFunction {
    */
   private Object computeRegularValue() {
     if ( formulaError != null ) {
-      if ( Boolean.TRUE.equals( failOnError ) ) {
+      if ( Boolean.TRUE.equals( getFailOnError() ) ) {
         throw new InvalidReportStateException( String.format(
             "Previously failed to evaluate formula-expression with error %s", // NON-NLS
             formulaError ) );
@@ -303,7 +306,7 @@ public final class FormulaFunction extends AbstractFunction {
       try {
         compiledFormula.initialize( context );
         final Object evaluate = compiledFormula.evaluate();
-        if ( Boolean.TRUE.equals( failOnError ) ) {
+        if ( Boolean.TRUE.equals( getFailOnError() ) ) {
           if ( evaluate instanceof ErrorValue ) {
             throw new InvalidReportStateException( String.format(
                 "Failed to evaluate formula-expression with error %s", // NON-NLS
@@ -325,7 +328,7 @@ public final class FormulaFunction extends AbstractFunction {
           FormulaFunction.logger.debug( "Failed to compute the regular value [" + formulaExpression + ']' );
         }
       }
-      if ( Boolean.TRUE.equals( failOnError ) ) {
+      if ( Boolean.TRUE.equals( getFailOnError() ) ) {
         throw new InvalidReportStateException( String.format( "Failed to evaluate formula-function with error %s", // NON-NLS
             e.getMessage() ), e );
       }

--- a/engine/core/src/main/resources/org/pentaho/reporting/engine/classic/core/config-description.xml
+++ b/engine/core/src/main/resources/org/pentaho/reporting/engine/classic/core/config-description.xml
@@ -297,7 +297,7 @@ org.pentaho.reporting.engine.classic.core.ParameterUiLayout=vertical
       <text>false</text>
     </enum>
   </key>
-  <key name="org.pentaho.reporting.engine.classic.core.StrictErrorHandling" global="true" hidden="false">
+  <key name="org.pentaho.reporting.engine.classic.core.StrictErrorHandling" hidden="false">
     <description>Defines a stricter error handling, if set to &apos;true&apos;, then all errors that occur during the
       report processing will cause the report processing to fail. It is safe to set this to &apos;true&apos;, as valid
       reports never throw exceptions.

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/RotationTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/RotationTest.java
@@ -256,6 +256,7 @@ public class RotationTest {
     URL url = getClass().getResource( "BACKLOG-10064.prpt" );
     MasterReport report = (MasterReport) new ResourceManager().createDirectly( url, MasterReport.class ).getResource();
     report.getReportConfiguration().setConfigProperty( HtmlTableModule.INLINE_STYLE, "true" );
+    report.getReportConfiguration().setConfigProperty( ClassicEngineCoreModule.STRICT_ERROR_HANDLING_KEY, "false" );
 
     List<String> elementsIdList = Arrays.asList("topLeft90","topCenter90","topRight90","topJustify90",
                                                 "topLeft-90","topCenter-90","topRight-90","topJustify-90",

--- a/engine/testcases/src/test/java/org/pentaho/reporting/engine/classic/bugs/Prd3514Test.java
+++ b/engine/testcases/src/test/java/org/pentaho/reporting/engine/classic/bugs/Prd3514Test.java
@@ -21,12 +21,7 @@ import junit.framework.TestCase;
 import net.sourceforge.barbecue.Barcode;
 import net.sourceforge.barbecue.env.EnvironmentFactory;
 import net.sourceforge.barbecue.env.HeadlessEnvironment;
-import org.pentaho.reporting.engine.classic.core.AttributeNames;
-import org.pentaho.reporting.engine.classic.core.Band;
-import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
-import org.pentaho.reporting.engine.classic.core.Element;
-import org.pentaho.reporting.engine.classic.core.MasterReport;
-import org.pentaho.reporting.engine.classic.core.SubReport;
+import org.pentaho.reporting.engine.classic.core.*;
 import org.pentaho.reporting.engine.classic.core.layout.ModelPrinter;
 import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.RenderBox;
@@ -84,6 +79,7 @@ public class Prd3514Test extends TestCase {
 
   public void testWeirdTocLayout() throws Exception {
     MasterReport report = DebugReportRunner.parseGoldenSampleReport( "Prd-3514.prpt" );
+    report.getReportConfiguration().setConfigProperty( ClassicEngineCoreModule.STRICT_ERROR_HANDLING_KEY, "false" );
     SubReport toc = (SubReport) report.getReportHeader().getElement( 0 );
     Band paragraph = (Band) toc.getItemBand().getElement( 1 );
     paragraph.setName( "outer-box" );

--- a/engine/testcases/src/test/java/org/pentaho/reporting/engine/classic/bugs/Prd3857Test.java
+++ b/engine/testcases/src/test/java/org/pentaho/reporting/engine/classic/bugs/Prd3857Test.java
@@ -18,11 +18,7 @@
 package org.pentaho.reporting.engine.classic.bugs;
 
 import junit.framework.TestCase;
-import org.pentaho.reporting.engine.classic.core.AttributeNames;
-import org.pentaho.reporting.engine.classic.core.Band;
-import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
-import org.pentaho.reporting.engine.classic.core.MasterReport;
-import org.pentaho.reporting.engine.classic.core.ReportProcessingException;
+import org.pentaho.reporting.engine.classic.core.*;
 import org.pentaho.reporting.engine.classic.core.layout.ModelPrinter;
 import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
 import org.pentaho.reporting.engine.classic.core.layout.model.RenderBox;
@@ -139,7 +135,7 @@ public class Prd3857Test extends TestCase {
     mgr.registerDefaults();
     final Resource directly = mgr.createDirectly( file, MasterReport.class );
     final MasterReport report = (MasterReport) directly.getResource();
-
+    report.getReportConfiguration().setConfigProperty( ClassicEngineCoreModule.STRICT_ERROR_HANDLING_KEY, "false" );
     //    report.setCompatibilityLevel(ClassicEngineBoot.computeVersionId(3, 8, 0));
 
     final LogicalPageBox logicalPageBox = DebugReportRunner.layoutPage( report, 0 );


### PR DESCRIPTION
[PRD-4595] Errors from the datasource used in a SINGLEVALUEQUERY function are consumed silently