### PR TITLE
[PRD-4595] Errors from the datasource used in a SINGLEVALUEQUERY func…

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/formula/SingleValueQueryFunction.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/function/formula/SingleValueQueryFunction.java
@@ -120,7 +120,7 @@ public class SingleValueQueryFunction implements Function {
     } catch ( EvaluationException e ) {
       throw e;
     } catch ( Exception e ) {
-      SingleValueQueryFunction.logger.warn( "SingleValueQueryFunction: Failed to perform query", e );
+      SingleValueQueryFunction.logger.error( "SingleValueQueryFunction: Failed to perform query", e );
       throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_UNEXPECTED_VALUE );
     }
   }


### PR DESCRIPTION
…tion are consumed silently

 - logging error when SingleValueQuery cannot be evaluated