### PR TITLE
[BACKLOG-20450] Downstream update for mql-editor

### DIFF
--- a/designer/datasource-editor-pmd/pom.xml
+++ b/designer/datasource-editor-pmd/pom.xml
@@ -34,8 +34,8 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-mql-editor</artifactId>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-mql-editor-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -706,8 +706,8 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>pentaho</groupId>
-        <artifactId>pentaho-mql-editor</artifactId>
+        <groupId>org.pentaho</groupId>
+        <artifactId>pentaho-mql-editor-impl</artifactId>
         <version>${pentaho-mql-editor.version}</version>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
@pentaho/2-1b 
Depends on https://github.com/pentaho/mql-editor/pull/47