### PR TITLE
[PRD-4595]-Errors from the datasource used in a SINGLEVALUEQUERY function are consumed silently

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/base/common/ExpressionReadHandler.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/base/common/ExpressionReadHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2018 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.parser.base.common;
@@ -57,6 +57,7 @@ public class ExpressionReadHandler extends AbstractPropertyXmlReadHandler {
 
     final String className = attrs.getValue( getUri(), "class" );
     final String formula = attrs.getValue( getUri(), "formula" );
+    final String failOnError = attrs.getValue( getUri(), "failOnError" );
     if ( className == null ) {
       final String initial = attrs.getValue( getUri(), "initial" );
       if ( initial != null ) {
@@ -72,6 +73,9 @@ public class ExpressionReadHandler extends AbstractPropertyXmlReadHandler {
       } else {
         final FormulaExpression expression = new FormulaExpression();
         expression.setFormula( formula );
+        if ( failOnError != null ) {
+          expression.setFailOnError( Boolean.getBoolean( failOnError ) );
+        }
         this.expression = expression;
         this.expression.setName( expressionName );
         this.expression.setDependencyLevel( depLevel );

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/ExpressionWriterUtility.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/parser/bundle/writer/ExpressionWriterUtility.java
@@ -12,12 +12,10 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2018 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.parser.bundle.writer;
-
-import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -33,7 +31,6 @@ import org.pentaho.reporting.engine.classic.core.metadata.ResourceReference;
 import org.pentaho.reporting.engine.classic.core.modules.parser.base.common.DefaultExpressionPropertyWriteHandler;
 import org.pentaho.reporting.engine.classic.core.modules.parser.base.common.ExpressionPropertyWriteHandler;
 import org.pentaho.reporting.engine.classic.core.modules.parser.bundle.BundleNamespaces;
-import org.pentaho.reporting.engine.classic.core.modules.parser.ext.ExtParserModule;
 import org.pentaho.reporting.engine.classic.core.style.StyleKey;
 import org.pentaho.reporting.engine.classic.core.util.beans.BeanException;
 import org.pentaho.reporting.engine.classic.core.util.beans.BeanUtility;
@@ -47,6 +44,8 @@ import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 import org.pentaho.reporting.libraries.xmlns.common.AttributeList;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriter;
 import org.pentaho.reporting.libraries.xmlns.writer.XmlWriterSupport;
+
+import java.io.IOException;
 
 public class ExpressionWriterUtility {
   private static final Log logger = LogFactory.getLog( ExpressionWriterUtility.class );
@@ -276,6 +275,9 @@ public class ExpressionWriterUtility {
         return;
       }
       expressionAttrList.setAttribute( namespaceUri, "formula", fe.getFormula() ); // NON-NLS
+      if ( fe.getFailOnError() != null ) {
+        expressionAttrList.setAttribute( namespaceUri, "failOnError", fe.getFailOnError().toString() ); // NON-NLS
+      }
       writer.writeTag( namespaceUri, expressionTag, expressionAttrList, XmlWriterSupport.CLOSE );
       return;
     }
@@ -409,7 +411,7 @@ public class ExpressionWriterUtility {
 
     final ExpressionPropertyWriteHandler writeHandler = createWriteHandler( e, propertyName );
     if ( writeHandler instanceof BundleExpressionPropertyWriteHandler ) {
-      BundleExpressionPropertyWriteHandler bw = ( BundleExpressionPropertyWriteHandler ) writeHandler;
+      BundleExpressionPropertyWriteHandler bw = (BundleExpressionPropertyWriteHandler) writeHandler;
       bw.initBundleContext( bundle, state );
     }
     writeHandler.writeExpressionParameter( writer, beanUtility, propertyName, namespaceUri );
@@ -425,8 +427,7 @@ public class ExpressionWriterUtility {
       if ( writeHandlerRef != null ) {
         return writeHandlerRef.newInstance();
       }
-    }
-    catch ( Exception ex ) {
+    } catch ( Exception ex ) {
       logger.info( "No valid property metadata defined for " + e.getClass() + " on property " + key );
     }
     return new DefaultExpressionPropertyWriteHandler();

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/text/URLBuilderFunction.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/text/URLBuilderFunction.java
@@ -1,0 +1,103 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2006 - 2018 Hitachi Vantara and Contributors.  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.formula.function.text;
+
+import org.pentaho.reporting.libraries.formula.EvaluationException;
+import org.pentaho.reporting.libraries.formula.FormulaContext;
+import org.pentaho.reporting.libraries.formula.LibFormulaErrorValue;
+import org.pentaho.reporting.libraries.formula.function.Function;
+import org.pentaho.reporting.libraries.formula.function.ParameterCallback;
+import org.pentaho.reporting.libraries.formula.lvalues.TypeValuePair;
+import org.pentaho.reporting.libraries.formula.typing.Type;
+import org.pentaho.reporting.libraries.formula.typing.coretypes.TextType;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.pentaho.reporting.libraries.base.util.StringUtils.isEmpty;
+
+/**
+ * This function build url based on parts provided in parameters
+ *
+ * @author Dmitriy Stepanov
+ */
+public class URLBuilderFunction implements Function {
+  private static final long serialVersionUID = -3929896303552652226L;
+
+  public URLBuilderFunction() {
+  }
+
+  public TypeValuePair evaluate( final FormulaContext context, final ParameterCallback parameters )
+    throws EvaluationException {
+    final int parameterCount = parameters.getParameterCount();
+    if ( parameterCount < 2 || parameterCount > 3 ) {
+      throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_ARGUMENTS_VALUE );
+    }
+    final Type textType = parameters.getType( 0 );
+    final Object textValue = parameters.getValue( 0 );
+    final String textResult =
+      context.getTypeRegistry().convertToText( textType, textValue );
+
+    if ( textResult == null ) {
+      throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
+    }
+
+
+    final Type pathType = parameters.getType( 1 );
+    final Object pathValue = parameters.getValue( 1 );
+    final String pathResult = context.getTypeRegistry().convertToText( pathType, pathValue );
+    if ( pathResult == null ) {
+      throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
+    }
+    String paramResult = null;
+    if ( parameterCount == 3 ) {
+      final Type paramType = parameters.getType( 1 );
+      final Object paramValue = parameters.getValue( 1 );
+      paramResult = context.getTypeRegistry().convertToText( paramType, paramValue );
+      if ( paramResult == null ) {
+        throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
+      }
+    }
+    try {
+      URI uri = new URI( textResult ).resolve( pathResult ).normalize();
+      String query = null;
+      if ( !isEmpty( paramResult ) ) {
+        if ( uri.getQuery() == null ) {
+          query = paramResult;
+        } else {
+          query = query.concat( "&" ).concat( paramResult );
+        }
+      } else {
+        query = uri.getQuery();
+      }
+      uri = new URI( uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath(), query,
+        uri.getFragment() );
+
+      return new TypeValuePair( TextType.TYPE, uri.toURL().toString() );
+
+    } catch ( URISyntaxException | MalformedURLException e ) {
+      throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
+    }
+  }
+
+  public String getCanonicalName() {
+    return "URLBUILDER";
+  }
+
+}

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/text/URLBuilderFunctionDescription.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/text/URLBuilderFunctionDescription.java
@@ -1,0 +1,58 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2006 - 2018 Hitachi Vantara and Contributors.  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.formula.function.text;
+
+import org.pentaho.reporting.libraries.formula.function.AbstractFunctionDescription;
+import org.pentaho.reporting.libraries.formula.function.FunctionCategory;
+import org.pentaho.reporting.libraries.formula.typing.Type;
+import org.pentaho.reporting.libraries.formula.typing.coretypes.TextType;
+
+/**
+ * Describes URLBuilderFunction function.
+ *
+ * @author Dmitriy Stepanov
+ * @see URLBuilderFunction
+ */
+public class URLBuilderFunctionDescription extends AbstractFunctionDescription {
+  private static final long serialVersionUID = 6476113508712888095L;
+
+  public URLBuilderFunctionDescription() {
+    super( "URLBUILDER", "org.pentaho.reporting.libraries.formula.function.text.URLBuilder-Function" );
+  }
+
+  public FunctionCategory getCategory() {
+    return TextFunctionCategory.CATEGORY;
+  }
+
+  public int getParameterCount() {
+    return 3;
+  }
+
+  public Type getParameterType( final int position ) {
+    return TextType.TYPE;
+  }
+
+  public Type getValueType() {
+    return TextType.TYPE;
+  }
+
+  public boolean isParameterMandatory( final int position ) {
+    return position != 2;
+  }
+
+}

--- a/libraries/libformula/src/main/resources/org/pentaho/reporting/libraries/formula/function/text/URLBuilder-Function.properties
+++ b/libraries/libformula/src/main/resources/org/pentaho/reporting/libraries/formula/function/text/URLBuilder-Function.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2007 - 2018, Hitachi Vantara. All Rights Reserved.
+#
+
+display-name=URLBUILDER
+description=Build url based on parts provided in parameters. \
+  First parameter is used for base url. \
+  Second parameter resolved as path to base url. \
+  Third parameter is optional and acts like query.
+parameter.0.description=The base url that would be used.
+parameter.0.display-name=Url
+parameter.1.description=The path to be used.
+parameter.1.display-name=Path
+parameter.2.description=The query to be used (Optional).
+parameter.2.display-name=Query
+

--- a/libraries/libformula/src/main/resources/org/pentaho/reporting/libraries/formula/libformula.properties
+++ b/libraries/libformula/src/main/resources/org/pentaho/reporting/libraries/formula/libformula.properties
@@ -193,6 +193,8 @@ org.pentaho.reporting.libraries.formula.functions.text.Upper.class=org.pentaho.r
 org.pentaho.reporting.libraries.formula.functions.text.Upper.description=org.pentaho.reporting.libraries.formula.function.text.UpperFunctionDescription
 org.pentaho.reporting.libraries.formula.functions.text.UrlEncode.class=org.pentaho.reporting.libraries.formula.function.text.URLEncodeFunction
 org.pentaho.reporting.libraries.formula.functions.text.UrlEncode.description=org.pentaho.reporting.libraries.formula.function.text.URLEncodeFunctionDescription
+org.pentaho.reporting.libraries.formula.functions.text.UrlBuilder.class=org.pentaho.reporting.libraries.formula.function.text.URLBuilderFunction
+org.pentaho.reporting.libraries.formula.functions.text.UrlBuilder.description=org.pentaho.reporting.libraries.formula.function.text.URLBuilderFunctionDescription
 
 ##
 # Information functions


### PR DESCRIPTION


Fix for the missed function URLBUILDER which is used in drilldown.properties
Some default samples uses drilldown.

Fix for serialization into prpt failonerror property (before it was ignored).