### PR TITLE
[PRD-5956] - PRD parameter viewer not handling timezones correctly

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/gui/base/parameters/DatePickerParameterComponent.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/gui/base/parameters/DatePickerParameterComponent.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.gui.base.parameters;
@@ -199,8 +199,7 @@ public class DatePickerParameterComponent extends JPanel implements ParameterCom
     this.updateContext.addChangeListener( new DateUpdateHandler( parameterName ) );
   }
 
-  private DateFormat
-    createDateFormat( final String parameterFormatString, final Locale locale, final TimeZone timeZone ) {
+  DateFormat createDateFormat( final String parameterFormatString, final Locale locale, final TimeZone timeZone ) {
     if ( parameterFormatString != null ) {
       try {
         final SimpleDateFormat dateFormat = new SimpleDateFormat( parameterFormatString, locale );
@@ -214,7 +213,11 @@ public class DatePickerParameterComponent extends JPanel implements ParameterCom
       }
     }
 
-    return DateFormat.getDateTimeInstance( DateFormat.LONG, DateFormat.LONG, locale );
+    DateFormat dateTimeInstance = DateFormat.getDateTimeInstance( DateFormat.LONG, DateFormat.LONG, locale );
+    dateTimeInstance.setTimeZone( timeZone );
+    dateTimeInstance.setLenient( false );
+
+    return dateTimeInstance;
   }
 
   private void setDate( final Object value ) {

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/gui/base/parameters/DatePickerParameterComponentTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/gui/base/parameters/DatePickerParameterComponentTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2000 - 2017 Hitachi Vantara, Simba Management Limited and Contributors...  All rights reserved.
+ * Copyright (c) 2000 - 2018 Hitachi Vantara, Simba Management Limited and Contributors...  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.gui.base.parameters;
@@ -21,12 +21,16 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -112,5 +116,25 @@ public class DatePickerParameterComponentTest {
       }
     }
     return field;
+  }
+
+  @Test
+  public void testCreateDateFormat_null() {
+    DateFormat dateFormat = comp.createDateFormat( null, Locale.getDefault(), TimeZone.getDefault() );
+    verifyCommonDateFormats( dateFormat );
+    assertThat( dateFormat, instanceOf( DateFormat.class ) );
+  }
+
+  @Test
+  public void testCreateDateFormat_ddMMyyyy() {
+    DateFormat dateFormat = comp.createDateFormat( "dd.MM.yyyy", Locale.getDefault(), TimeZone.getDefault() );
+    verifyCommonDateFormats( dateFormat );
+    assertThat( dateFormat, instanceOf( SimpleDateFormat.class ) );
+  }
+
+  private void verifyCommonDateFormats( DateFormat dateFormat ) {
+    assertThat( dateFormat, is( notNullValue() ) );
+    assertFalse( dateFormat.isLenient() );
+    assertEquals( TimeZone.getDefault(), dateFormat.getTimeZone() );
   }
 }


### PR DESCRIPTION
* Always set the timezone and disable the lenient parsing flag when a date format is created.