### PR TITLE
[BACKLOG-19695] Update commons-vfs2 artifact version from 2.1 to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <groovy.version>2.4.8</groovy.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
-    <commons-vfs2.version>2.1-20150824</commons-vfs2.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pentaho-cassandra-plugin.version>8.1.0.0-SNAPSHOT</pentaho-cassandra-plugin.version>
     <pentaho-osgi-bundles.version>8.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <poi.version>3.17</poi.version>


### PR DESCRIPTION
**Warning:** To be merged together with all other projects that need this change, **please do not merge** until then 

**This PR relates to:**
https://github.com/pentaho/pentaho-commons-database/pull/152
https://github.com/pentaho/apache-vfs-browser/pull/42
https://github.com/pentaho/data-access/pull/992
https://github.com/pentaho/mondrian/pull/1033
https://github.com/pentaho/pdi-jms-plugin/pull/53
https://github.com/pentaho/pdi-platform-utils-plugin/pull/92
https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/76
https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/39
https://github.com/pentaho/big-data-plugin/pull/1340
https://github.com/pentaho/pentaho-cassandra-plugin/pull/106
https://github.com/pentaho/pentaho-data-mining/pull/15
https://github.com/pentaho/pentaho-det-ee/pull/531
https://github.com/pentaho/pentaho-ee/pull/1072
https://github.com/pentaho/pentaho-hadoop-shims/pull/733
https://github.com/pentaho/pentaho-hdfs-vfs/pull/20
https://github.com/pentaho/pentaho-kettle/pull/5051
https://github.com/pentaho/pentaho-reporting/pull/1112
https://github.com/pentaho/pentaho-platform/pull/4077
https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1254
https://github.com/pentaho/pentaho-platform-plugin-geo/pull/242
https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/693
https://github.com/pentaho/pentaho-s3-vfs/pull/31