### PR TITLE
[SP-4171] Backport of PRD-2943 - Hitting save on subreport tab does not reset the change flag for the other subreports and master reports. (7.1 Suite)

### DIFF
--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/ReportRenderContext.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/editor/ReportRenderContext.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara.  All rights reserved.
 */
 
 package org.pentaho.reporting.designer.core.editor;
@@ -50,10 +50,11 @@ import org.pentaho.reporting.libraries.base.util.StringUtils;
 import org.pentaho.reporting.libraries.docbundle.ODFMetaAttributeNames;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 
-import javax.swing.*;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import java.awt.*;
+import java.awt.Image;
 import java.beans.BeanInfo;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -80,8 +81,8 @@ public class ReportRenderContext implements ReportDocumentContext {
 
     public void nodeChanged( final ReportModelEvent event ) {
       AbstractReportDefinition report = context.getReportDefinition();
-      if ( event.getElement() == report &&
-        event.getType() == ReportModelEvent.NODE_PROPERTIES_CHANGED ) {
+      if ( event.getElement() == report
+        && event.getType() == ReportModelEvent.NODE_PROPERTIES_CHANGED ) {
         context.setTabName( computeTabName( report ) );
       }
     }
@@ -89,8 +90,8 @@ public class ReportRenderContext implements ReportDocumentContext {
     private String computeTabName( final AbstractReportDefinition report ) {
       if ( report instanceof MasterReport ) {
         final MasterReport mreport = (MasterReport) report;
-        final Object title = mreport.getBundle().getMetaData().getBundleAttribute
-          ( ODFMetaAttributeNames.DublinCore.NAMESPACE, ODFMetaAttributeNames.DublinCore.TITLE );
+        final Object title = mreport.getBundle().getMetaData().getBundleAttribute(
+          ODFMetaAttributeNames.DublinCore.NAMESPACE, ODFMetaAttributeNames.DublinCore.TITLE );
         if ( title instanceof String ) {
           return (String) title;
         }
@@ -102,18 +103,18 @@ public class ReportRenderContext implements ReportDocumentContext {
       }
 
       final String theSavePath =
-        (String) report.getAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME );// NON-NLS
+        (String) report.getAttribute( ReportDesignerBoot.DESIGNER_NAMESPACE, ReportDesignerBoot.LAST_FILENAME ); // NON-NLS
       if ( !StringUtils.isEmpty( theSavePath ) ) {
         final String fileName = IOUtils.getInstance().getFileName( theSavePath );
         return IOUtils.getInstance().stripFileExtension( fileName );
       }
 
       if ( report instanceof MasterReport ) {
-        return Messages.getString( "ReportDesignerFrame.TabName.UntitledReport" );// NON-NLS
+        return Messages.getString( "ReportDesignerFrame.TabName.UntitledReport" ); // NON-NLS
       } else if ( report instanceof CrosstabElement ) {
-        return Messages.getString( "ReportDesignerFrame.TabName.UntitledCrosstab" );// NON-NLS
+        return Messages.getString( "ReportDesignerFrame.TabName.UntitledCrosstab" ); // NON-NLS
       } else {
-        return Messages.getString( "ReportDesignerFrame.TabName.UntitledSubReport" );// NON-NLS
+        return Messages.getString( "ReportDesignerFrame.TabName.UntitledSubReport" ); // NON-NLS
       }
     }
   }
@@ -175,6 +176,7 @@ public class ReportRenderContext implements ReportDocumentContext {
   private final HashMap<String, Object> properties;
   private final DataSchemaManager dataSchemaManager;
   private final boolean bandedContext;
+  private final ReportDocumentContext parentContext;
   private final ArrayList<ReportDataChangeListener> dataChangeListeners;
   private String tabName;
   private Icon icon;
@@ -219,6 +221,7 @@ public class ReportRenderContext implements ReportDocumentContext {
     this.zoomModel.addZoomModelListener( new ZoomUpdateHandler() );
 
     this.bandedContext = computeBandedContext( parentContext );
+    this.parentContext = parentContext;
 
     this.dataSchemaManager = new AsynchronousDataSchemaManager( masterReportElement, report );
     this.dataSchemaManager.addChangeListener( new DataSchemaManagerUpdateHandler() );
@@ -250,6 +253,7 @@ public class ReportRenderContext implements ReportDocumentContext {
 
     prepareAuthenticationStore( globalAuthenticationStore );
     prepareIcon();
+    resetChangeTracker();
   }
 
   private UndoManager createUndoManager() {
@@ -364,11 +368,19 @@ public class ReportRenderContext implements ReportDocumentContext {
   }
 
   public boolean isChanged() {
-    return getMasterReportElement().getChangeTracker() != changeTracker;
+    if ( parentContext != null ) {
+      return parentContext.isChanged();
+    } else {
+      return getMasterReportElement().getChangeTracker() != changeTracker;
+    }
   }
 
   public void resetChangeTracker() {
-    this.changeTracker = getMasterReportElement().getChangeTracker();
+    if ( parentContext != null ) {
+      parentContext.resetChangeTracker();
+    } else {
+      changeTracker = getMasterReportElement().getChangeTracker();
+    }
   }
 
   public UndoManager getUndo() {

--- a/designer/report-designer/src/test/java/org/pentaho/reporting/designer/Prd2943Test.java
+++ b/designer/report-designer/src/test/java/org/pentaho/reporting/designer/Prd2943Test.java
@@ -1,0 +1,125 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2018 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.designer;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.reporting.designer.core.auth.GlobalAuthenticationStore;
+import org.pentaho.reporting.designer.core.editor.ReportDocumentContext;
+import org.pentaho.reporting.designer.core.editor.ReportRenderContext;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.MasterReport;
+import org.pentaho.reporting.engine.classic.core.SubReport;
+import org.pentaho.reporting.engine.classic.core.style.ElementStyleKeys;
+
+public class Prd2943Test {
+  protected MasterReport report;
+  private SubReport subReport;
+  private GlobalAuthenticationStore authStore;
+  private SubReport siblingSubReport;
+
+  @Before
+  public void setUp() throws Exception {
+    ClassicEngineBoot.getInstance().start();
+    authStore = new GlobalAuthenticationStore();
+
+    report = new MasterReport();
+    subReport = new SubReport();
+    siblingSubReport = new SubReport();
+    report.getReportHeader().addSubReport( subReport );
+    report.getReportFooter().addSubReport( siblingSubReport );
+  }
+
+  @Test
+  public void dirtyFlagDependsOnStateChangesMasterReportVersion() {
+    // CloseReportAction#performCloseReport is a static method so we cannot mock the calls within it.
+    // The sources show that the method depends on ReportDesignerDocumentContext#isReportFileModified to indicate
+    // whether a report is clean.
+    //
+    // When saving a report, the change tracker is reset to indicate that the report is not considered
+    // a modified report.
+
+    ReportDocumentContext masterContext = new ReportRenderContext( report );
+    Assert.assertFalse( masterContext.isChanged() );
+
+    ReportDocumentContext subreportContext = new ReportRenderContext( report, subReport, masterContext, authStore );
+    Assert.assertFalse( subreportContext.isChanged() );
+
+    ReportDocumentContext siblingContext = new ReportRenderContext( report, siblingSubReport, masterContext, authStore );
+    Assert.assertFalse( siblingContext.isChanged() );
+
+    // When we modify a report element, we trigger a change in the change tracker on the master report
+    // and any subreport that is parent to the element being changed.
+    report.getReportHeader().getStyle().setStyleProperty( ElementStyleKeys.POS_X, 10f );
+
+    // Changing a master report element does not make changes to a subreport. But as subreports all live in
+    // the same PRPT bundle, the report in memory is no longer representing the same state as the report on
+    // disk. Therefore this flag should report "true" to indicate that.
+    Assert.assertTrue( masterContext.isChanged() );
+    Assert.assertTrue( subreportContext.isChanged() );
+    Assert.assertTrue( siblingContext.isChanged() );
+
+    // when we save an report, the report-context's #resetChangeTracker method is called. This should
+    // reset the flag for the report, and by extension to all subreports that share the same master-report
+    // (as all are saved to the same file bundle).
+    masterContext.resetChangeTracker();
+    Assert.assertFalse( masterContext.isChanged() );
+    Assert.assertFalse( subreportContext.isChanged() );
+    Assert.assertFalse( siblingContext.isChanged() );
+  }
+
+  @Test
+  public void dirtyFlagDependsOnStateChangesSubReportVersion() {
+    // CloseReportAction#performCloseReport is a static method so we cannot mock the calls within it.
+    // The sources show that the method depends on ReportDesignerDocumentContext#isReportFileModified to indicate
+    // whether a report is clean.
+    //
+    // When saving a report, the change tracker is reset to indicate that the report is not considered
+    // a modified report.
+
+    ReportDocumentContext masterContext = new ReportRenderContext( report );
+    Assert.assertFalse( masterContext.isChanged() );
+
+    ReportDocumentContext subreportContext = new ReportRenderContext( report, subReport, masterContext, authStore );
+    Assert.assertFalse( subreportContext.isChanged() );
+
+    ReportDocumentContext siblingContext = new ReportRenderContext( report, siblingSubReport, masterContext, authStore );
+    Assert.assertFalse( siblingContext.isChanged() );
+
+    // When we modify a report element, we trigger a change in the change tracker on the master report
+    // and any subreport that is parent to the element being changed.
+    subReport.getReportHeader().getStyle().setStyleProperty( ElementStyleKeys.POS_X, 10f );
+
+    // all subreports live in the same PRPT bundle, so any change to any element in the report
+    // definition should trigger the dirty flag. The report in memory is no longer representing
+    // the same state as the report on disk. Therefore this flag should report "true" to indicate that.
+    Assert.assertTrue( masterContext.isChanged() );
+    Assert.assertTrue( subreportContext.isChanged() );
+    Assert.assertTrue( siblingContext.isChanged() );
+
+    // when we save an report, the report-context's #resetChangeTracker method is called. This should
+    // reset the flag for the report, and by extension to all subreports that share the same master-report
+    // (as all are saved to the same file).
+    subreportContext.resetChangeTracker();
+    Assert.assertFalse( masterContext.isChanged() );
+    Assert.assertFalse( subreportContext.isChanged() );
+    Assert.assertFalse( siblingContext.isChanged() );
+
+  }
+}


### PR DESCRIPTION
- backport of #1096