### PR TITLE
[PRD-5987] 7.1 & 8.0: Drop Down Arrow Missing for Parameter Values in Hyperlink to Pentaho Repository prpt

### DIFF
--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2017 Hitachi Vantara..  All rights reserved.
+ *  Copyright (c) 2006 - 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.extensions.pentaho.drilldown.swing;
@@ -185,6 +185,7 @@ public class SwingRemoteDrillDownController {
     PentahoParameterRefreshHandler parameterRefreshHandler = new PentahoParameterRefreshHandler( pentahoPathWrapper, reportDesignerContext, drillDownUi.getEditorPanel() );
     table.addDrillDownParameterRefreshListener( parameterRefreshHandler );
     parameterRefreshHandler.setParameterTable( table );
+    table.setReportDesignerContext( reportDesignerContext );
 
     pentahoPathWrapper.addPropertyChangeListener( PentahoPathModel.LOCAL_PATH_PROPERTY,
             new CheckEmptyPathHandler( table ) );


### PR DESCRIPTION
@tmorgner 
The var designerContext from AbstractStringValueCellEditor.java wasn't being initiated.
Before refactoring the code under PRD-4160, this var was being initiated by DefaultXulDrillDownController (l.164) calling function setReportDesignContext.