### PR TITLE
[PRD-5988] In reopened Hyperlink Dialog the 'Location' selector on the top left is set to 'Self' instead of the originally selected 'Pentaho Repository'

### DIFF
--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownController.java
@@ -48,7 +48,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Controller of the Swing analog for sugar-xaction-drilldown.xul dialog.
@@ -119,10 +122,11 @@ public class SwingRemoteDrillDownController {
     // Server URL field
     JTextField serverUrlField =
         drillDownUi.getComponent( SwingRemoteDrillDownUi.ComponentLookup.SERVER_URL_FIELD );
+
     serverUrlField.getDocument().addDocumentListener( new DocumentBindingListener() {
       @Override
       protected void setData( String data ) {
-        pentahoPathWrapper.setLocalPath( data );
+        pentahoPathWrapper.setServerPath( data );
       }
     } );
 
@@ -140,11 +144,32 @@ public class SwingRemoteDrillDownController {
     // Path field
     JTextField pathField =
         drillDownUi.getComponent( SwingRemoteDrillDownUi.ComponentLookup.PATH_FIELD );
-    serverUrlField.getDocument().addDocumentListener( new DocumentBindingListener() {
+    pathField.getDocument().addDocumentListener( new DocumentBindingListener() {
       @Override
       protected void setData( String data ) {
-        pentahoPathWrapper.setServerPath( data );
-      }
+        if ( data == null || data.isEmpty() ) {
+          return;
+        }
+
+        DrillDownParameter parameterPath = new DrillDownParameter( "::pentaho-path", new String( "\"" + data + "\"" ) );
+
+        DrillDownParameter[] currentParams = modelWrapper.getDrillDownParameter();
+        ArrayList<DrillDownParameter> currentParamsList = new ArrayList<>( Arrays.asList( currentParams ) );
+
+        Optional<DrillDownParameter> lookupItem = currentParamsList.stream().
+                filter( a -> a.getName().equals( "::pentaho-path" ) ).findFirst();
+
+        if ( lookupItem.isPresent() ) {
+          lookupItem.get().setFormulaFragment( new String( "\"" + data + "\"" ) );
+        } else {
+          currentParamsList.add( parameterPath );
+        }
+
+        DrillDownParameter[] result = currentParamsList.toArray( new DrillDownParameter[currentParamsList.size()] );
+        ( drillDownUi.<DrillDownParameterTable>getComponent(
+                        SwingRemoteDrillDownUi.ComponentLookup.PARAMETER_TABLE
+                ) ).setDrillDownParameter( result );
+        }
     } );
 
     // Browse button
@@ -186,6 +211,7 @@ public class SwingRemoteDrillDownController {
     table.addDrillDownParameterRefreshListener( parameterRefreshHandler );
     parameterRefreshHandler.setParameterTable( table );
     table.setReportDesignerContext( reportDesignerContext );
+
 
     pentahoPathWrapper.addPropertyChangeListener( PentahoPathModel.LOCAL_PATH_PROPERTY,
             new CheckEmptyPathHandler( table ) );
@@ -283,6 +309,7 @@ public class SwingRemoteDrillDownController {
    * PropertyChangeListener for model wrapper.
    */
   private class ModelWrapperUpdateHandler implements PropertyChangeListener {
+
     @Override
     public void propertyChange( PropertyChangeEvent evt ) {
       AuthenticationData loginData = pentahoPathWrapper.getLoginData();
@@ -361,9 +388,21 @@ public class SwingRemoteDrillDownController {
      * {@inheritDoc}
      */
     public void propertyChange( final PropertyChangeEvent evt ) {
-      modelWrapper.setDrillDownParameter( ( drillDownUi.<DrillDownParameterTable>getComponent(
-          SwingRemoteDrillDownUi.ComponentLookup.PARAMETER_TABLE
-      ) ).getDrillDownParameter() );
+      ArrayList<DrillDownParameter> filterParams = new ArrayList<>();
+      DrillDownParameter[] unfilterParams = ( drillDownUi.<DrillDownParameterTable>getComponent(
+              SwingRemoteDrillDownUi.ComponentLookup.PARAMETER_TABLE
+      ) ).getDrillDownParameter();
+
+      for ( DrillDownParameter param : unfilterParams ) {
+        if ( param.getType() == DrillDownParameter.Type.SYSTEM && param.getFormulaFragment() != null
+                && !param.getFormulaFragment().equals( "NA()" ) ) {
+          filterParams.add( param );
+        } else if ( param.getType() != DrillDownParameter.Type.SYSTEM ) {
+          filterParams.add( param );
+        }
+      }
+
+      modelWrapper.setDrillDownParameter( filterParams.toArray( new DrillDownParameter[filterParams.size()] ) );
     }
   }
 

--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownUi.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownUi.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2017 Hitachi Vantara..  All rights reserved.
+ *  Copyright (c) 2006 - 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.extensions.pentaho.drilldown.swing;
@@ -325,7 +325,7 @@ public class SwingRemoteDrillDownUi implements DrillDownUi {
   ) throws DrillDownUiException {
     this.reportDesignerContext = reportDesignerContext;
     this.wrapper = new DrillDownModelWrapper( model );
-    model.setDrillDownConfig( SwingRemoteDrillDownUiProfile.NAME_DEFAULT );
+    model.setDrillDownConfig( SwingRemoteDrillDownUiProfile.DEFAULT_PROFILE );
 
     // Check model and init default values
     if ( getModel().isLimitedEditor() ) {

--- a/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownUiProfile.java
+++ b/designer/report-designer-extension-pentaho/src/main/java/org/pentaho/reporting/designer/extensions/pentaho/drilldown/swing/SwingRemoteDrillDownUiProfile.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2017 Hitachi Vantara..  All rights reserved.
+ *  Copyright (c) 2006 - 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.designer.extensions.pentaho.drilldown.swing;
@@ -35,16 +35,32 @@ public class SwingRemoteDrillDownUiProfile implements DrillDownUiProfile {
   private DrillDownProfile drillDownProfile;
 
   /** The names that SwingRemoteDrillDownUi is able to handle. */
-  private static final String[] NAMES_HANDLE = { "remote-sugar" };
+  private String[] names_handler;
 
-  /** Default name of the profile. */
-  public static final String NAME_DEFAULT = NAMES_HANDLE[ 0 ];
+  public static final String DEFAULT_PROFILE = "remote-sugar";
 
   /**
    * Create an implementation of SwingRemoteDrillDownUiProfile for Swing version of sugar-xaction-drilldown.xul dialog.
    */
   public SwingRemoteDrillDownUiProfile() {
-    drillDownProfile = DrillDownProfileMetaData.getInstance().getDrillDownProfile( NAME_DEFAULT );
+
+    final DrillDownProfile[] profiles =
+            DrillDownProfileMetaData.getInstance().getDrillDownProfileByGroup( "pentaho-sugar" );
+
+    names_handler = new String[ profiles.length ];
+    for ( int i = 0; i < names_handler.length; i++ ) {
+      names_handler[ i ] = profiles[ i ].getName();
+    }
+
+    if ( names_handler.length != 0 ) {
+      drillDownProfile = DrillDownProfileMetaData.getInstance().getDrillDownProfile( names_handler[ 0 ] );
+    } else {
+      DrillDownProfile[] drillProfiles = DrillDownProfileMetaData.getInstance().getDrillDownProfiles();
+
+      if ( drillProfiles.length != 0 ) {
+        drillDownProfile = drillProfiles[ 0 ];
+      }
+    }
   }
 
   /**
@@ -72,8 +88,8 @@ public class SwingRemoteDrillDownUiProfile implements DrillDownUiProfile {
    */
   @Override
   public boolean canHandle( String profileName ) {
-    for ( int i = 0; i < NAMES_HANDLE.length; i++ ) {
-      final String name = NAMES_HANDLE[ i ];
+    for ( int i = 0; i < names_handler.length; i++ ) {
+      final String name = names_handler[ i ];
       if ( name.equals( profileName ) ) {
         return true;
       }


### PR DESCRIPTION
This commit will fix both PRD-5988, PRD-5970 and PRD-5971. It was very hard to keep PRD working if both changes had been made separately, so I did both changes in same commit. 

Major changes are: Corrected drilldown default profile configuration; Added an handler to set ::pentaho-path on drill down formula and a Parameter filter mechanism to avoid empty ("NA()") system params on Drill down formula (which causes problems on opening hyperlinks to other reports). Some other minor adjustments were made on swing drill down classes. 

@tmorgner 