### PR TITLE
Revert "[BACKLOG-22526] vulnerable component spring-security: upgrade from 4.…"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <contiperf.version>2.2.0</contiperf.version>
     <feed4j.version>1.0</feed4j.version>
     <launcher.version>8.1.0.0-SNAPSHOT</launcher.version>
-    <spring-security.version>4.1.5.RELEASE</spring-security.version>
+    <spring-security.version>4.1.3.RELEASE</spring-security.version>
     <swt-linux.version>4.3.2</swt-linux.version>
     <jackcess.version>1.2.6</jackcess.version>
     <swingx.version>1.6.1</swingx.version>


### PR DESCRIPTION
Reverts pentaho/pentaho-reporting#1127

@pentaho/rogueone @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

**List or PRs**

- https://github.com/pentaho/marketplace/pull/149
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/37
- https://github.com/pentaho/pentaho-metadata-editor/pull/124
- https://github.com/pentaho/pentaho-kettle/pull/5275
- https://github.com/pentaho/pentaho-platform/pull/4111
- https://github.com/pentaho/pentaho-platform-ee/pull/1266
- https://github.com/pentaho/pentaho-karaf-assembly/pull/441
- https://github.com/pentaho/pdi-ee-plugin/pull/357
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/107
- https://github.com/pentaho/pentaho-reporting/pull/1134
- https://github.com/pentaho/pentaho-osgi-bundles/pull/265