### PR TITLE
[BACKLOG-23036] stop excluding mapreduce libs zip from assembly

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -467,7 +467,6 @@
               </goals>
               <configuration>
                 <includeArtifactIds>pentaho-big-data-plugin,pentaho-cassandra-plugin,pdi-xml-plugin,kettle-json-plugin</includeArtifactIds>
-                <excludes>**/pentaho-mapreduce-libraries.zip</excludes>
                 <outputDirectory>${stage.dir.designer}/plugins</outputDirectory>
               </configuration>
             </execution>


### PR DESCRIPTION
@emartin-pentaho @lgrill-pentaho @kcruzada @mbatchelor 