### PR TITLE
[PIR-1172] - L10N - Untranslated string in PIR prompt.

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -162,6 +162,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -194,11 +199,6 @@
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-testng</artifactId>
       <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/parameters/Messages.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/parameters/Messages.java
@@ -12,15 +12,17 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.parameters;
 
+import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 import org.pentaho.reporting.libraries.base.util.ResourceBundleSupport;
 
 import java.util.Locale;
+import java.util.ResourceBundle;
 
 public class Messages extends ResourceBundleSupport {
   private static Messages instance;
@@ -40,5 +42,25 @@ public class Messages extends ResourceBundleSupport {
   private Messages() {
     super( Locale.getDefault(), "org.pentaho.reporting.engine.classic.core.parameters.messages", ObjectUtilities
         .getClassLoader( Messages.class ) );
+  }
+
+  /**
+   * Refreshes the locale based on pentaho platform information and not from system default
+   * @return the refreshed locale
+   */
+  @Override
+  public Locale getLocale() {
+    Locale refreshedLocale = LocaleHelper.getLocale();
+    return ( refreshedLocale != null ) ? refreshedLocale : super.getLocale();
+  }
+
+  /**
+   * Retrieves and refreshes the resource information
+   * @return the resources
+   */
+  @Override
+  protected ResourceBundle getResources() {
+    ResourceBundle refreshedResources = ResourceBundle.getBundle( getResourceBase(), getLocale(), getSourceClassLoader() );
+    return refreshedResources != null ? refreshedResources : super.getResources();
   }
 }

--- a/libraries/libbase/pom.xml
+++ b/libraries/libbase/pom.xml
@@ -28,14 +28,19 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-platform-core</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/libraries/libbase/src/main/java/org/pentaho/reporting/libraries/base/util/ResourceBundleSupport.java
+++ b/libraries/libbase/src/main/java/org/pentaho/reporting/libraries/base/util/ResourceBundleSupport.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.base.util;
@@ -20,8 +20,12 @@ package org.pentaho.reporting.libraries.base.util;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JMenu;
+import javax.swing.KeyStroke;
+import java.awt.Image;
+import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
@@ -151,6 +155,14 @@ public class ResourceBundleSupport {
   }
 
   /**
+   * The source class loader of the resource bundle.
+   * @return the resource bundle's source class loader.
+   */
+  protected final ClassLoader getSourceClassLoader() {
+    return this.sourceClassLoader;
+  }
+
+  /**
    * Gets a string for the given key from this resource bundle or one of its parents. If the key is a link, the link is
    * resolved and the referenced string is returned instead.
    *
@@ -163,6 +175,11 @@ public class ResourceBundleSupport {
   public synchronized String strictString( final String key ) {
     if ( key == null ) {
       throw new NullPointerException();
+    }
+
+    // locale might be changed in meanwhile
+    if ( locale != getLocale() ) {
+      cache.clear();
     }
 
     final String retval = this.cache.get( key );
@@ -186,22 +203,18 @@ public class ResourceBundleSupport {
     }
 
     if ( this.lookupPath.contains( key ) ) {
-      throw new MissingResourceException
-        ( "InfiniteLoop in resource lookup",
-          getResourceBase(), this.lookupPath.toString() );
+      throw new MissingResourceException( "InfiniteLoop in resource lookup", getResourceBase(), this.lookupPath.toString() );
     }
-    final String fromResBundle = this.resources.getString( key );
+    final String fromResBundle = this.getResources().getString( key );
     if ( fromResBundle.length() > 0 && fromResBundle.charAt( 0 ) == '@' ) {
       if ( fromResBundle.length() > 1 && fromResBundle.charAt( 1 ) == '@' ) {
         // global forward ...
         final int idx = fromResBundle.indexOf( '@', 2 );
         if ( idx == -1 ) {
-          throw new MissingResourceException
-            ( "Invalid format for global lookup key.", getResourceBase(), key );
+          throw new MissingResourceException( "Invalid format for global lookup key.", getResourceBase(), key );
         }
         try {
-          final ResourceBundle res = ResourceBundle.getBundle
-            ( fromResBundle.substring( 2, idx ), locale, sourceClassLoader );
+          final ResourceBundle res = ResourceBundle.getBundle( fromResBundle.substring( 2, idx ), locale, sourceClassLoader );
           return res.getString( fromResBundle.substring( idx + 1 ) );
         } catch ( Exception e ) {
           logger.error( "Error during global lookup", e );
@@ -581,8 +594,7 @@ public class ResourceBundleSupport {
       throw new IllegalArgumentException( "Key is empty." );
     }
     int character = keyString.charAt( 0 );
-    if ( keyString.startsWith( "VK_" ) ) // NON-NLS
-    {
+    if ( keyString.startsWith( "VK_" ) ) { // NON-NLS
       try {
         final Field f = KeyEvent.class.getField( keyString );
         final Integer keyCode = (Integer) f.get( null );
@@ -720,5 +732,13 @@ public class ResourceBundleSupport {
    */
   public Locale getLocale() {
     return locale;
+  }
+
+  /**
+   * Returns the resources for this resource bundle.
+   * @return the resources.
+   */
+  protected ResourceBundle getResources() {
+    return resources;
   }
 }


### PR DESCRIPTION
* Fixed the retrieval of L10N info.

@pentaho-lmartins , @graimundo , @mbatchelor , @pamval Please review and merge if it's all ok.
Note: I didn't add the usual unit test in this commit, because the change was regarding the retrieve of a value between different repos (i.e. pentaho-reporting and pentaho-platform-core), but also because the testable result is highly dependent on the specific system configured locale.