### PR TITLE
[BACKLOG-22526] Use of vulnerable component spring-security 4.1.3 CVE…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <contiperf.version>2.2.0</contiperf.version>
     <feed4j.version>1.0</feed4j.version>
     <launcher.version>9.0.0.0-SNAPSHOT</launcher.version>
-    <spring-security.version>4.1.3.RELEASE</spring-security.version>
+    <spring-security.version>4.1.5.RELEASE</spring-security.version>
     <swt-linux.version>4.3.2</swt-linux.version>
     <jackcess.version>1.2.6</jackcess.version>
     <swingx.version>1.6.1</swingx.version>


### PR DESCRIPTION
…-2018-1199

**Minor patch upgrade**: from `4.1.3 RELEASE` to `4.1.5 RELEASE`

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs:
- https://github.com/pentaho/pentaho-platform/pull/4229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/288
- https://github.com/pentaho/pentaho-platform-ee/pull/1276
- https://github.com/pentaho/pentaho-kettle/pull/5750
- https://github.com/pentaho/pentaho-reporting/pull/1179
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/115
- https://github.com/pentaho/pdi-ee-plugin/pull/361
- https://github.com/pentaho/pentaho-karaf-assembly/pull/478
- https://github.com/pentaho/pentaho-metadata-editor/pull/128
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/38
- https://github.com/pentaho/marketplace/pull/152