### PR TITLE
[BACKLOG-22526][CLEANUP] Promoting current spring-security.version to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
     <contiperf.version>2.2.0</contiperf.version>
     <feed4j.version>1.0</feed4j.version>
     <launcher.version>9.0.0.0-SNAPSHOT</launcher.version>
-    <spring-security.version>4.1.5.RELEASE</spring-security.version>
     <swt-linux.version>4.3.2</swt-linux.version>
     <jackcess.version>1.2.6</jackcess.version>
     <swingx.version>1.6.1</swingx.version>
@@ -1005,7 +1004,7 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>${spring-security.version}</version>
+        <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
         <exclusions>
           <exclusion>
             <artifactId>spring-beans</artifactId>


### PR DESCRIPTION
… maven-parent-pom

**Notes**
- This is not changing the current version
  - we are merely promoting it to maven-parent-pom as a cleanup + centralization effort
- Wingman **will** fail on these
  - the referenced dependency property version `spring-security.version` is not yet in play 
  - see related PR adding it to maven-parent-pom: https://github.com/pentaho/maven-parent-poms/pull/71

@pentaho/rogueone @pentaho-lmartins

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅

**List of PRs:**
- https://github.com/pentaho/maven-parent-poms/pull/71
- https://github.com/pentaho/marketplace/pull/153
- https://github.com/pentaho/pentaho-platform/pull/4231
- https://github.com/pentaho/pentaho-platform-ee/pull/1278
- https://github.com/pentaho/pentaho-kettle/pull/5752
- https://github.com/pentaho/pentaho-reporting/pull/1181
- https://github.com/pentaho/pdi-ee-plugin/pull/362
- https://github.com/pentaho/pentaho-osgi-bundles/pull/289
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/116
- https://github.com/pentaho/pentaho-metadata-editor/pull/130
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
