### PR TITLE
[BACKLOG-25122] Check if KettleEnvironment is initializing

### DIFF
--- a/engine/extensions-kettle/src/main/java/org/pentaho/reporting/engine/classic/extensions/datasources/kettle/KettleDataFactoryModuleInitializer.java
+++ b/engine/extensions-kettle/src/main/java/org/pentaho/reporting/engine/classic/extensions/datasources/kettle/KettleDataFactoryModuleInitializer.java
@@ -30,8 +30,9 @@ public class KettleDataFactoryModuleInitializer implements ModuleInitializer {
     try {
       logger.debug( "DEFAULT_PLUGIN_BASE_FOLDERS=" + Const.DEFAULT_PLUGIN_BASE_FOLDERS );
 
-      // init kettle without simplejndi
-      if ( KettleEnvironment.isInitialized() == false ) {
+      // check if anybody already initialized Kettle
+      if ( !KettleEnvironment.isInitializing() && !KettleEnvironment.isInitialized() ) {
+        // init kettle without simplejndi
         KettleEnvironment.init( false );
 
         // Route logging from Kettle to Apache Commons Logging...

--- a/engine/extensions-pentaho-metadata/src/main/java/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PmdDataFactoryModule.java
+++ b/engine/extensions-pentaho-metadata/src/main/java/org/pentaho/reporting/engine/classic/extensions/datasources/pmd/PmdDataFactoryModule.java
@@ -55,8 +55,9 @@ public class PmdDataFactoryModule extends AbstractModule {
    */
   public void initialize( final SubSystem subSystem ) throws ModuleInitializeException {
     try {
-      // init kettle without simplejndi
-      if ( KettleEnvironment.isInitialized() == false ) {
+      // check if anybody already initialized Kettle
+      if ( !KettleEnvironment.isInitializing() && !KettleEnvironment.isInitialized() ) {
+        // init kettle without simplejndi
         KettleEnvironment.init( false );
       }
     } catch ( Throwable e ) {


### PR DESCRIPTION
When `KettleDataFactoryModuleInitializer` and `PmdDataFactoryModule` were implemented (5 to 6 years ago), `KettleEnvironment.isInitialized()` was non-blocking, immediately returning `true` or `false`. That changed with https://github.com/pentaho/pentaho-kettle/commit/7bf2b1550d1edb2c924c8d0256e695e36d24cbed#diff-32d4495761ec89b49baf892cbdcd2bfbR186 (4 years ago). Now it only returns immediately if nobody tried to initialize Kettle, but blocks otherwise, always returning `true` unless the initialization fails.

Although the initial behaviour (and even the purpose) of the function changed, it had no impact other than potentially slowing down the reporting engine initialization, but preventing multiple unwanted Kettle initializations.

However, when porting CDA to OSGi, this created a deadlock: 
 - Kettle initialization is the one starting the OSGi container (karaf);
 - Kettle waits until the OSGi container initializes;
 - The CDA bundle initializes the reporting engine;
 - The reporting engine waits until Kettle initializes;
 - That never happens, because they are waiting for each other.

Assuming the purpose of the code at `KettleDataFactoryModuleInitializer` and `PmdDataFactoryModule` was only to initialize Kettle if nobody haven't done so already, and not necessarily needing to wait for it to be fully initialized, I'm proposing this fix.

Needs https://github.com/pentaho/pentaho-kettle/pull/5767.

@pentaho/millenniumfalcon and @tmorgner please review.