### PR TITLE
[CLEANUP] Refactor profile naming and activation.

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -87,24 +87,46 @@
   </dependencyManagement>
   <profiles>
     <profile>
-      <id>libraries</id>
-      <activation>
-        <property>
-          <name>!engine</name>
-        </property>
-      </activation>
+      <id>core</id>
       <modules>
         <module>core</module>
       </modules>
     </profile>
     <profile>
-      <id>engine</id>
+      <id>extensions</id>
+      <modules>
+        <module>extensions</module>
+        <module>extensions-cda</module>
+        <module>extensions-docsupport</module>
+        <module>extensions-drilldown</module>
+        <module>extensions-kettle</module>
+        <module>extensions-mondrian</module>
+        <module>extensions-olap4j</module>
+        <module>extensions-openerp</module>
+        <module>extensions-pentaho-metadata</module>
+        <module>legacy-charts</module>
+        <module>extensions-xpath</module>
+        <module>extensions-reportdesigner-parser</module>
+        <module>extensions-sampledata</module>
+        <module>extensions-scripting</module>
+        <module>extensions-charting</module>
+        <module>extensions-toc</module>
+        <module>legacy-functions</module>
+        <module>wizard-core</module>
+        <module>demo</module>
+        <module>testcases</module>
+        <module>samples</module>
+        <module>sdk</module>
+        <module>tools</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>all</id>
       <activation>
-        <property>
-          <name>!libraries</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <module>core</module>
         <module>extensions</module>
         <module>extensions-cda</module>
         <module>extensions-docsupport</module>


### PR DESCRIPTION
'libraries' built engine/core and and 'engine' built the reporting engine extensions. Not quite sane.
Also, you could not activate either profile with -P because of the property negated activations. Building either profile with -P would build all the modules in both profiles. That implementation would break any pipeline that tried to do standard -P profile activation.