### PR TITLE
[PRD-5009] Formula editor does not handle complex terms properly

### DIFF
--- a/libraries/libformula-ui/src/main/java/org/pentaho/openformula/ui/model2/FormulaParser.java
+++ b/libraries/libformula-ui/src/main/java/org/pentaho/openformula/ui/model2/FormulaParser.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.openformula.ui.model2;
@@ -56,7 +56,7 @@ public class FormulaParser {
       buffer.append( c );
       position += 1;
       boolean inQuoting = ( '"' == c );
-      for (; position < data.length; position += 1 ) {
+      for ( ; position < data.length; position += 1 ) {
         final char c2 = data[ position ];
         if ( inQuoting == false && isToken( c2 ) ) {
           return buffer.toString();
@@ -175,8 +175,7 @@ public class FormulaParser {
             for ( int t = startElementIdx; t < i; t++ ) {
               buffer.append( elements[ t ].getText() );
             }
-            mergedList.add( new FormulaTextElement
-              ( document, document.getRootElement(), buffer.toString() ) );
+            mergedList.add( new FormulaTextElement( document, document.getRootElement(), buffer.toString() ) );
           }
           startElementIdx = -1;
         }
@@ -194,8 +193,7 @@ public class FormulaParser {
         for ( int t = startElementIdx; t < elements.length; t++ ) {
           buffer.append( elements[ t ].getText() );
         }
-        mergedList.add( new FormulaTextElement
-          ( document, document.getRootElement(), buffer.toString() ) );
+        mergedList.add( new FormulaTextElement( document, document.getRootElement(), buffer.toString() ) );
       }
     }
 
@@ -224,16 +222,19 @@ public class FormulaParser {
         final String text = buffer.substring( 0, startIdx );
         if ( text.trim().length() == 0 ) {
           // only leading and trailing whitespace wont cause us to create a new node.
-          mergedList.add( new FormulaFunctionElement
-            ( document, document.getRootElement(), buffer ) );
+          mergedList.add( new FormulaFunctionElement( document, document.getRootElement(), buffer ) );
           continue;
         }
 
-        mergedList.add( new FormulaTextElement
-          ( document, document.getRootElement(), text ) );
+        mergedList.add( new FormulaTextElement( document, document.getRootElement(), text ) );
       }
-      mergedList.add( new FormulaFunctionElement
-        ( document, document.getRootElement(), buffer.substring( startIdx ) ) );
+
+      if ( buffer.trim().equals( "(" ) ) {
+        mergedList.add( new FormulaOpenParenthesisElement( document, document.getRootElement() ) );
+      } else {
+        mergedList.add( new FormulaFunctionElement( document, document.getRootElement(), buffer.substring( startIdx ) ) );
+      }
+
     }
 
     mergedList.add( mergedValues[ mergedValues.length - 1 ] );

--- a/libraries/libformula-ui/src/test/java/org/pentaho/openformula/ui/FormulaDocumentTest.java
+++ b/libraries/libformula-ui/src/test/java/org/pentaho/openformula/ui/FormulaDocumentTest.java
@@ -12,16 +12,25 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.openformula.ui;
 
 import junit.framework.TestCase;
+import org.pentaho.openformula.ui.model2.FormulaClosingParenthesisElement;
 import org.pentaho.openformula.ui.model2.FormulaDocument;
+import org.pentaho.openformula.ui.model2.FormulaElement;
+import org.pentaho.openformula.ui.model2.FormulaOpenParenthesisElement;
+import org.pentaho.openformula.ui.model2.FormulaOperatorElement;
+import org.pentaho.openformula.ui.model2.FormulaParser;
 import org.pentaho.openformula.ui.model2.FormulaRootElement;
+import org.pentaho.openformula.ui.model2.FormulaSemicolonElement;
+import org.pentaho.openformula.ui.model2.FormulaTextElement;
 
 import javax.swing.text.BadLocationException;
+
+import static org.pentaho.openformula.ui.model2.FormulaParser.parseText;
 
 public class FormulaDocumentTest extends TestCase {
   public FormulaDocumentTest() {
@@ -56,5 +65,24 @@ public class FormulaDocumentTest extends TestCase {
     final FormulaRootElement element = doc.getRootElement();
     assertEquals( "Length", str.length(), doc.getLength() );
     assertEquals( "Number of elements: ", 17, element.getElementCount() );
+  }
+
+  public void testParseTextOpenParenthesisCorrectlyPRD5009()  {
+    FormulaDocument doc = new FormulaDocument();
+    final String str = "=IF((1=3);1;2)";
+    FormulaElement[] result = FormulaParser.parseText( doc, str );
+    assertEquals( "class of =", result[0].getClass(), FormulaOperatorElement.class );
+    assertEquals( "class of IF", result[1].getClass(), FormulaTextElement.class );
+    assertEquals( "class of (", result[2].getClass(), FormulaOpenParenthesisElement.class );
+    assertEquals( "class of (", result[3].getClass(), FormulaOpenParenthesisElement.class );
+    assertEquals( "class of 1", result[4].getClass(), FormulaTextElement.class );
+    assertEquals( "class of =", result[5].getClass(), FormulaOperatorElement.class );
+    assertEquals( "class of 3", result[6].getClass(), FormulaTextElement.class );
+    assertEquals( "class of )", result[7].getClass(), FormulaClosingParenthesisElement.class );
+    assertEquals( "class of ;", result[8].getClass(), FormulaSemicolonElement.class );
+    assertEquals( "class of 1", result[9].getClass(), FormulaTextElement.class );
+    assertEquals( "class of ;", result[10].getClass(), FormulaSemicolonElement.class );
+    assertEquals( "class of 2", result[11].getClass(), FormulaTextElement.class );
+    assertEquals( "class of )", result[12].getClass(), FormulaClosingParenthesisElement.class );
   }
 }


### PR DESCRIPTION
The open parenthesis characters were being normalized as FormulaFunctionElement's and not as FormulaOpenParenthesisElement's - bugging all the open and close parenthesis logic. 
This PR adds that clause, ensuring that.
@tmorgner 