### PR TITLE
[SP-4786] - Backport of PPP-4167 - Assembly "pre-classic-sdk" seems t…

### DIFF
--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -66,7 +66,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <outputDirectory>./lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/assemblies/samples/src/assembly/assembly.xml
+++ b/assemblies/samples/src/assembly/assembly.xml
@@ -12,11 +12,11 @@
 
   <fileSets>
     <fileSet>
-      <directory>/src/main/java/</directory>
+      <directory>${basedir}/src/main/java/</directory>
       <outputDirectory>./source/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>/src/main/resources</directory>
+      <directory>${basedir}/src/main/resources</directory>
       <outputDirectory>./source/</outputDirectory>
     </fileSet>
     <fileSet>
@@ -28,11 +28,11 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>/target/classes/</directory>
+      <directory>${basedir}/target/classes/</directory>
       <outputDirectory>./bin/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>/target/lib/</directory>
+      <directory>${basedir}/target/lib/</directory>
       <outputDirectory>./lib/</outputDirectory>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
…o be missing since 7.0 (8.2 Suite)

The original fix was already in 8.2 code base, it was only needed to back port the minor fix made after it - https://github.com/pentaho/pentaho-reporting/commit/6280083e7663b31d32ceed4aa1807eea9c363951

Did by cherry-pick.
@pentaho-lmartins and @bantonio82 