### PR TITLE
[SP-4786] - Backport of PPP-4167 - Assembly "pre-classic-sdk" seems t…

### DIFF
--- a/assemblies/samples/Sample1.sh
+++ b/assemblies/samples/Sample1.sh
@@ -17,11 +17,4 @@
 # Copyright (c) 2013-2018 Hitachi Vantara..  All rights reserved.
 # -----------------------------------------------------------------------------------------------
 
-cp=".;./bin/"
-for jar in `ls -1 lib/*.jar`
-do
-    cp=${cp};${jar}
-done
-
-java -cp ${cp} org.pentaho.reporting.engine.classic.samples.Sample1
-
+java -cp "./bin:./lib/*"  org.pentaho.reporting.engine.classic.samples.Sample1

--- a/assemblies/samples/Sample2.sh
+++ b/assemblies/samples/Sample2.sh
@@ -17,11 +17,5 @@
 # Copyright (c) 2013-2018 Hitachi Vantara..  All rights reserved.
 # -----------------------------------------------------------------------------------------------
 
-cp=".;./bin/"
-for jar in `ls -1 lib/*.jar`
-do
-    cp=${cp};${jar}
-done
-
-java -cp ${cp} org.pentaho.reporting.engine.classic.samples.Sample2
+java -cp "./bin:./lib/*"  org.pentaho.reporting.engine.classic.samples.Sample2
 

--- a/assemblies/samples/Sample3.sh
+++ b/assemblies/samples/Sample3.sh
@@ -17,11 +17,5 @@
 # Copyright (c) 2013-2018 Hitachi Vantara..  All rights reserved.
 # -----------------------------------------------------------------------------------------------
 
-cp=".;./bin/"
-for jar in `ls -1 lib/*.jar`
-do
-    cp=${cp};${jar}
-done
-
-java -cp ${cp} org.pentaho.reporting.engine.classic.samples.Sample3
+java -cp "./bin:./lib/*"  org.pentaho.reporting.engine.classic.samples.Sample3
 

--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -66,7 +66,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <outputDirectory>./lib</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/assemblies/samples/src/assembly/assembly.xml
+++ b/assemblies/samples/src/assembly/assembly.xml
@@ -12,27 +12,36 @@
 
   <fileSets>
     <fileSet>
-      <directory>/src/main/java/</directory>
+      <directory>${basedir}/src/main/java/</directory>
       <outputDirectory>./source/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>/src/main/resources</directory>
+      <directory>${basedir}/src/main/resources</directory>
       <outputDirectory>./source/</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>.</directory>
       <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>.</directory>
+      <outputDirectory>.</outputDirectory>
       <excludes>
+        <exclude>*.sh</exclude>
         <exclude>/src/</exclude>
         <exclude>/target/</exclude>
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>/target/classes/</directory>
+      <directory>${basedir}/target/classes/</directory>
       <outputDirectory>./bin/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>/target/lib/</directory>
+      <directory>${basedir}/target/lib/</directory>
       <outputDirectory>./lib/</outputDirectory>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
…o be missing since 7.0 (8.2 Suite)

Cherry pick of:
https://github.com/pentaho/pentaho-reporting/pull/1209
https://github.com/pentaho/pentaho-reporting/pull/1213

No need to back port, it was already on 8.2 branch:
https://github.com/pentaho/pentaho-reporting/pull/1193

@RPAraujo @ppatricio 