### PR TITLE
[PRD-5412] CSV Output changes the alignment of header row and adds a trailing separator to the report

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/fast/csv/CsvTemplateProducer.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/fast/csv/CsvTemplateProducer.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2017 Hitachi Vantara..  All rights reserved.
+ *  Copyright (c) 2006 - 2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.output.fast.csv;
@@ -100,6 +100,11 @@ public class CsvTemplateProducer implements FastExportTemplateProducer {
                 .getHeight(), null );
         if ( rectangle.isOrigin( col, row ) == false ) {
           // A spanned cell ..
+          /* [PRD-5412] Since it is a spanned cell with no actual content within it, we need to print a separator here
+             so that we can accurately set the cells (this was previously a copy from the Excel Template producer, but
+             they handle spanned cells differently.
+          */
+          writer.print( quoter.getSeparator() );
           continue;
         }
 

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/output/fast/csv/CsvTemplateProducerTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/output/fast/csv/CsvTemplateProducerTest.java
@@ -1,0 +1,144 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ *  terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ *  Foundation.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License along with this
+ *  program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *  or from the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+ *
+ *  Copyright (c) 2019 Hitachi Vantara..  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.modules.output.fast.csv;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.reporting.engine.classic.core.filter.types.AutoLayoutBoxType;
+import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
+import org.pentaho.reporting.engine.classic.core.layout.model.ParagraphRenderBox;
+import org.pentaho.reporting.engine.classic.core.layout.model.RenderBox;
+import org.pentaho.reporting.engine.classic.core.layout.model.context.NodeLayoutProperties;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
+import org.pentaho.reporting.engine.classic.core.layout.style.SimpleStyleSheet;
+import org.pentaho.reporting.engine.classic.core.modules.output.fast.template.TemplatingOutputProcessor;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.base.SheetLayout;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.base.TableContentProducer;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.base.TableRectangle;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.csv.CSVTableModule;
+import org.pentaho.reporting.engine.classic.core.style.StyleSheet;
+import org.pentaho.reporting.engine.classic.core.util.InstanceID;
+import org.pentaho.reporting.libraries.base.config.HierarchicalConfiguration;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * @author David Griffen
+ */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( { InstanceID.class, LogicalPageBox.class, NodeLayoutProperties.class, OutputProcessorMetaData.class,
+  ParagraphRenderBox.class, RenderBox.class, SheetLayout.class, TableRectangle.class, TemplatingOutputProcessor.class } )
+@SuppressStaticInitializationFor( { "org.pentaho.reporting.engine.classic.core.layout.style.SimpleStyleSheet",
+  "org.pentaho.reporting.engine.classic.core.layout.model.context.NodeLayoutProperties",
+  "org.pentaho.reporting.engine.classic.core.filter.types.AutoLayoutBoxType" } )
+public class CsvTemplateProducerTest {
+
+  private static final String COMPLETE_TEMPLATE = CSVTableModule.SEPARATOR_DEFAULT + CSVTableModule.SEPARATOR_DEFAULT
+    + CSVTableModule.SEPARATOR_DEFAULT + System.lineSeparator() + "$(0)" + CSVTableModule.SEPARATOR_DEFAULT
+    + "$(0)" + CSVTableModule.SEPARATOR_DEFAULT + "$(0)" + System.lineSeparator() + CSVTableModule.SEPARATOR_DEFAULT
+    + CSVTableModule.SEPARATOR_DEFAULT + CSVTableModule.SEPARATOR_DEFAULT + System.lineSeparator();
+
+  private StyleSheet styleSheet;
+  private SheetLayout sheetLayout;
+  private NodeLayoutProperties nodeLayoutProperties;
+  private OutputProcessorMetaData metaData;
+  private TableContentProducer contentProducer;
+  private CsvTemplateProducer csvTemplateProducer;
+
+  @Before
+  public void setUp() throws Exception {
+    styleSheet = mock( StyleSheet.class );
+    sheetLayout = mock( SheetLayout.class );
+    metaData = mock( OutputProcessorMetaData.class );
+    nodeLayoutProperties = mock( NodeLayoutProperties.class );
+    HierarchicalConfiguration configuration = mock( HierarchicalConfiguration.class );
+    when( metaData.getConfiguration() ).thenReturn( configuration );
+    when( configuration.getConfigProperty( CSVTableModule.SEPARATOR,
+      CSVTableModule.SEPARATOR_DEFAULT ) ).thenReturn( CSVTableModule.SEPARATOR_DEFAULT );
+    contentProducer = spy( new TableContentProducer( sheetLayout, metaData ) );
+    csvTemplateProducer = new CsvTemplateProducer( metaData, sheetLayout, null );
+  }
+
+  /**
+   * [PRD-5412] Verifying the method will produce the appropriate CSV template when the content is null, if it contains
+   * information, and if it is an empty spanned cell (it still needs to print a Content Separated Value character if
+   * a column/row is empty).
+   */
+  @Test
+  public void testProduceTemplate() {
+    InstanceID instanceId = mock( InstanceID.class );
+    LogicalPageBox pageBox = mock( LogicalPageBox.class );
+    RenderBox content = mock( ParagraphRenderBox.class );
+    TableRectangle rectangle = mock( TableRectangle.class );
+    mockStatic( TemplatingOutputProcessor.class );
+    Long contentOffset = 0L;
+
+    Whitebox.setInternalState( SimpleStyleSheet.class, "EMPTY_STYLE",
+      new SimpleStyleSheet( styleSheet ) );
+    Whitebox.setInternalState( NodeLayoutProperties.class, "SIMPLE_NODE_ID", new InstanceID() );
+    Whitebox.setInternalState( AutoLayoutBoxType.class, "INSTANCE", new AutoLayoutBoxType() );
+
+    when( TemplatingOutputProcessor.produceTableLayout( pageBox, sheetLayout, metaData ) ).thenReturn( contentProducer );
+    when( contentProducer.getColumnCount() ).thenReturn( 3 );
+    when( contentProducer.getFinishedRows() ).thenReturn( 0 );
+    when( contentProducer.getFilledRows() ).thenReturn( 3 );
+
+    when( content.isCommited() ).thenReturn( true );
+    when( content.getX() ).thenReturn( 100000L );
+    when( content.getY() ).thenReturn( 100000L );
+    when( content.getWidth() ).thenReturn( 185600000L );
+    when( content.getHeight() ).thenReturn( 6200000L );
+    when( sheetLayout.getTableBounds( content.getX(), content.getY() + contentOffset,
+      content.getWidth(), content.getHeight(), null ) ).thenReturn( rectangle );
+
+    when( content.getNodeLayoutProperties() ).thenReturn( nodeLayoutProperties );
+    when( nodeLayoutProperties.getInstanceId() ).thenReturn( instanceId );
+
+    // First line should be null content, to show that it will print the separators only.
+    for ( int i = 0; i < 3; i++ ) {
+      when( contentProducer.getContent( 0, i ) ).thenReturn( null );
+      when( contentProducer.getContentOffset( 0, i ) ).thenReturn( contentOffset );
+    }
+    // Second line should print content, we're mocking it with a single InstanceID, so it will print the same
+    // value multiple times (3x)
+    for ( int i = 0; i < 3; i++ ) {
+      when( contentProducer.getContent( 1, i ) ).thenReturn( content );
+      when( contentProducer.getContentOffset( 1, i ) ).thenReturn( contentOffset );
+      when( rectangle.isOrigin( i, 1 ) ).thenReturn( true );
+    }
+    // Third line would contain content, but it's actually an empty spanned cell, so it should see this and still
+    // print a separator for the CSV template. We have to print the separator to signify a move to the next column
+    for ( int i = 0; i < 3; i++ ) {
+      when( contentProducer.getContent( 2, i ) ).thenReturn( content );
+      when( contentProducer.getContentOffset( 2, i ) ).thenReturn( contentOffset );
+      when( rectangle.isOrigin( i, 2 ) ).thenReturn( false );
+    }
+
+    csvTemplateProducer.produceTemplate( pageBox );
+    assertEquals( csvTemplateProducer.getTemplate(), COMPLETE_TEMPLATE );
+  }
+}


### PR DESCRIPTION
* [PRD-5412] Added in a line for printing the separator when there's a spanned cell (empty cell). This ensures that the empty cell gets represented and we move on to the next column/row pair.
* [PRD-5412] Updating copyright year
* [PRD-5412] Adding Test file to verify producing a template.