### PR TITLE
[BACKLOG-27573] - Replaced Felix framework 4.4.1 with OSGi core 5.0.0.

### DIFF
--- a/assemblies/prd-ce/pom.xml
+++ b/assemblies/prd-ce/pom.xml
@@ -175,11 +175,22 @@
       <artifactId>javax.servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <!-- TODO: When replacing felix framework implementation for OSGi core specification 4.3.1 which is the spec
+         we aim at (see pentaho-parent-pom ) in our Karaf 3.0.3 assembly an error occurs:
+         ERROR: Bundle org.ops4j.pax.url.mvn [1] Error starting mvn:org.ops4j.pax.url/pax-url-aether/2.3.0
+         (java.lang.NoSuchMethodError: >org.osgi.framework.wiring.BundleWire.getProvider()
+
+         In this assembly we are using Felix Framework 4.2.1, which is partially OSGi 5.0 complaint. In particular,
+         it is complaint with the org.osgi.framework.wiring.BundleWire.getProvider() method.
+         For this reason we are explicitly overriding OSGi core to 5.0.0 here.
+         -->
     <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>org.apache.felix.framework</artifactId>
-      <scope>compile</scope>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>5.0.0</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.main</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <sapdb.version>7.4.4</sapdb.version>
     <akka.version>2.3.3</akka.version>
     <postgresql.version>42.1.1</postgresql.version>
-    <felix.version>4.4.1</felix.version>
     <json-simple.version>1.1</json-simple.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <mimepull.version>1.9.3</mimepull.version>
@@ -989,11 +988,6 @@
             <groupId>org.springframework</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>org.apache.felix.framework</artifactId>
-        <version>${felix.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
When replacing felix framework implementation for OSGi core specification 4.3.1 which is the spec we aim at (see pentaho-parent-pom ) in our Karaf 3.0.3 assembly an error occurs:
```
ERROR: Bundle org.ops4j.pax.url.mvn [1] Error starting mvn:org.ops4j.pax.url/pax-url-aether/2.3.0
      (java.lang.NoSuchMethodError: >org.osgi.framework.wiring.BundleWire.getProvider()
```
In this assembly we are using Felix Framework 4.2.1, which is partially OSGi 5.0 complaint. In particular, it is complaint with the org.osgi.framework.wiring.BundleWire.getProvider() method.
For this reason we are explicitly overriding OSGi core to 5.0.0 here.

@nantunes please review