### PR TITLE
[PRD-6049] Report Sub Title 1 is not being exported in Excel [Excel +…

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/text/TextUtility.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/text/TextUtility.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2018 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2019 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.layout.text;
@@ -83,7 +83,8 @@ public class TextUtility {
     final long fontSize = fontMetrics.getMaxHeight();
     final long threshold = (long) ( fontSize * 1.005 );
     final long safeFontSize = (long) ( fontSize * 1.3 );
-    if ( ( fontMetrics.getMaxAscent() + fontMetrics.getMaxDescent() ) < threshold ) {
+    final long totalAscentAndDescent = fontMetrics.getMaxAscent() + fontMetrics.getMaxDescent();
+    if ( fontSize <= totalAscentAndDescent  &&  totalAscentAndDescent  < threshold ) {
       return new DefaultExtendedBaselineInfo( dominantBaseline, baselineInfo, 0, 0, safeFontSize,
               safeFontSize, underlinePosition, strikeThroughPosition );
     }

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/layout/text/TextUtilityTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/layout/text/TextUtilityTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2018 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2019 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.layout.text;
@@ -63,6 +63,42 @@ public class TextUtilityTest {
     when( fontMetrics.getMaxHeight() ).thenReturn( maxHeight );
     when( fontMetrics.getMaxAscent() ).thenReturn( (long) 7500 );
     when( fontMetrics.getMaxDescent() ).thenReturn( (long) 7500 );
+    BaselineInfo baseLineInfo = new BaselineInfo();
+    baseLineInfo.setDominantBaseline(BaselineInfo.MIDDLE);
+    when( fontMetrics.getBaselines( anyInt(), any(BaselineInfo.class))).thenReturn( baseLineInfo );
+
+    DefaultExtendedBaselineInfo baseLine = (DefaultExtendedBaselineInfo)TextUtility.createPaddedBaselineInfo( 'x', fontMetrics, null );
+    Assert.assertTrue( baseLine.getBaselines()[ExtendedBaselineInfo.AFTER_EDGE] >= RenderableText.convert(maxHeight) );
+  }
+
+  @Test
+  public void testCreateCorrectBaselineWithMaxHeightGreaterThanAscentPlusDescent() throws Exception {
+    PowerMockito.mockStatic( TextUtility.class );
+    when(TextUtility.createPaddedBaselineInfo( anyInt(), any(FontMetrics.class), any(BaselineInfo.class) )).thenCallRealMethod();
+
+    long maxHeight = (long) 15000;
+    FontMetrics fontMetrics = mock( FontMetrics.class );
+    when( fontMetrics.getMaxHeight() ).thenReturn( maxHeight );
+    when( fontMetrics.getMaxAscent() ).thenReturn( (long) 4500 );
+    when( fontMetrics.getMaxDescent() ).thenReturn( (long) 4500 );
+    BaselineInfo baseLineInfo = new BaselineInfo();
+    baseLineInfo.setDominantBaseline(BaselineInfo.MIDDLE);
+    when( fontMetrics.getBaselines( anyInt(), any(BaselineInfo.class))).thenReturn( baseLineInfo );
+
+    DefaultExtendedBaselineInfo baseLine = (DefaultExtendedBaselineInfo)TextUtility.createPaddedBaselineInfo( 'x', fontMetrics, null );
+    Assert.assertEquals( baseLine.getBaselines()[ExtendedBaselineInfo.AFTER_EDGE], RenderableText.convert(maxHeight) );
+  }
+
+  @Test
+  public void testCreateCorrectBaselineWithMaxHeightLowerThanAscentPlusDescent() throws Exception {
+    PowerMockito.mockStatic( TextUtility.class );
+    when(TextUtility.createPaddedBaselineInfo( anyInt(), any(FontMetrics.class), any(BaselineInfo.class) )).thenCallRealMethod();
+
+    long maxHeight = (long) 15000;
+    FontMetrics fontMetrics = mock( FontMetrics.class );
+    when( fontMetrics.getMaxHeight() ).thenReturn( maxHeight );
+    when( fontMetrics.getMaxAscent() ).thenReturn( (long) 15000 );
+    when( fontMetrics.getMaxDescent() ).thenReturn( (long) 15000 );
     BaselineInfo baseLineInfo = new BaselineInfo();
     baseLineInfo.setDominantBaseline(BaselineInfo.MIDDLE);
     when( fontMetrics.getBaselines( anyInt(), any(BaselineInfo.class))).thenReturn( baseLineInfo );


### PR DESCRIPTION
… Excel (2007)]

This case was a side-effect of https://github.com/pentaho/pentaho-reporting/pull/1129.
Adding extra padding was causing cell overlap on Excel, since the font space reserved (plus extra padding) was bigger than the initial reserved, causing, in this case, the "sub title 1" omission.
Added a new logic to apply the previous fix only when "getMaxHeight() <= getMaxAscent() + getMaxDescent()". 

@tmorgner could you please review this? This actually fixes both cases but I'm not sure if it is enough.

@ricardosilva88 @pentaho-lmartins 