### PR TITLE
[CLEANUP] Make ReportEnvironmentDataRowTest independent of the system locale

### DIFF
--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/ReportEnvironmentDataRowTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/ReportEnvironmentDataRowTest.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2017 Hitachi Vantara..  All rights reserved.
+ *  Copyright (c) 2006 - 2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core;

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/ReportEnvironmentDataRowTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/ReportEnvironmentDataRowTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 
 public class ReportEnvironmentDataRowTest {
   @Before
@@ -33,13 +34,16 @@ public class ReportEnvironmentDataRowTest {
   @Test
   public void ensure_reportEnvironment_properties_are_published_as_fields() {
     DefaultReportEnvironment re = new DefaultReportEnvironment( ClassicEngineBoot.getInstance().getGlobalConfig() );
+    // ensure the unit test does not depend on the configuration of the machine it is run
+    re.setLocale( new Locale( "de", "DE", "WeirdLocalAccent" ) );
+
     ReportEnvironmentDataRow dr = new ReportEnvironmentDataRow( re );
     final HashSet<Object> names = new HashSet<>();
     names.addAll( Arrays.asList( dr.getColumnNames() ) );
     Assert
       .assertTrue( names.containsAll( Arrays.asList( "env::locale", "env::locale-language", "env::locale-short" ) ) );
-    Assert.assertEquals( "en_US", dr.get( "env::locale" ) );
-    Assert.assertEquals( "en_US", dr.get( "env::locale-short" ) );
-    Assert.assertEquals( "en", dr.get( "env::locale-language" ) );
+    Assert.assertEquals( "de_DE_WeirdLocalAccent", dr.get( "env::locale" ) );
+    Assert.assertEquals( "de_DE", dr.get( "env::locale-short" ) );
+    Assert.assertEquals( "de", dr.get( "env::locale-language" ) );
   }
 }


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.