### PR TITLE
[PRD-6049] Report Sub Title 1 is not being exported in Excel [Excel +…

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/text/TextUtility.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/text/TextUtility.java
@@ -84,7 +84,7 @@ public class TextUtility {
     final long threshold = (long) ( fontSize * 1.005 );
     final long safeFontSize = (long) ( fontSize * 1.3 );
     final long totalAscentAndDescent = fontMetrics.getMaxAscent() + fontMetrics.getMaxDescent();
-    if ( fontSize <= totalAscentAndDescent  &&  totalAscentAndDescent  < threshold ) {
+    if ( fontSize < totalAscentAndDescent  &&  totalAscentAndDescent  < threshold ) {
       return new DefaultExtendedBaselineInfo( dominantBaseline, baselineInfo, 0, 0, safeFontSize,
               safeFontSize, underlinePosition, strikeThroughPosition );
     }


### PR DESCRIPTION
… Excel (2007)]

Fonts are OS specific. For instance, Arial (the default used font on templates) does not exist on Linux. So the actual compare function had to be changed to work on both OS's. Equals case was removed.

@ricardosilva88 @pentaho-lmartins 