### PR TITLE
[PDI-15742] Unable to load a prpt from the repository in the Pentaho Reporting Output step

### DIFF
--- a/libraries/libloader/pom.xml
+++ b/libraries/libloader/pom.xml
@@ -149,5 +149,16 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
+      <version>${commons-vfs2.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/ResourceKey.java
+++ b/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/ResourceKey.java
@@ -12,11 +12,12 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.resourceloader;
 
+import org.apache.commons.vfs2.FileObject;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 
 import java.io.File;
@@ -127,6 +128,10 @@ public final class ResourceKey implements Serializable {
       if ( ObjectUtilities.equals( (File) identifier, (File) that.identifier ) == false ) {
         return false;
       }
+    } else if ( identifier instanceof FileObject && that.identifier instanceof FileObject ) {
+      if ( ( (FileObject) identifier ).getName().getURI().equals( ( (FileObject) that.identifier ).getName().getURI() ) == false ) {
+        return false;
+      }
     } else if ( !identifier.equals( that.identifier ) ) {
       if ( identifier instanceof byte[] && that.identifier instanceof byte[] ) {
         final byte[] me = (byte[]) identifier;
@@ -151,6 +156,8 @@ public final class ResourceKey implements Serializable {
         result = 29 * result + url.toString().hashCode();
       } else if ( identifier instanceof byte[] ) {
         result = 29 * result + Arrays.hashCode( (byte[]) identifier );
+      } else if ( identifier instanceof FileObject ) {
+        result = 29 * result + ( (FileObject) identifier ).getName().getURI().hashCode();
       } else {
         result = 29 * result + identifier.hashCode();
       }
@@ -183,6 +190,10 @@ public final class ResourceKey implements Serializable {
     if ( identifier instanceof String ) {
       return identifier.toString();
     }
+    if ( identifier instanceof FileObject ) {
+      return ( (FileObject) identifier ).getName().getURI();
+    }
+
     return null;
   }
 
@@ -199,12 +210,12 @@ public final class ResourceKey implements Serializable {
   }
 
   public String toString() {
-    return "ResourceKey{" +
-      "schema=" + schema +
-      ", identifier=" + identifier +
-      ", factoryParameters=" + factoryParameters +
-      ", parent=" + parent +
-      '}';
+
+    return String.format( "ResourceKey{schema=%s, identifier=%s, factoryParameters=%s, parent=%s}",
+            schema,
+            ( identifier instanceof FileObject ) ? ( (FileObject) identifier ).getName().getURI() : identifier,
+            factoryParameters,
+            parent );
   }
 }
 

--- a/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceData.java
+++ b/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceData.java
@@ -1,0 +1,105 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.resourceloader.loader.fileobject;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.pentaho.reporting.libraries.resourceloader.ResourceData;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
+import org.pentaho.reporting.libraries.resourceloader.ResourceLoadingException;
+import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
+import org.pentaho.reporting.libraries.resourceloader.loader.AbstractResourceData;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+
+public class FileObjectResourceData extends AbstractResourceData {
+  private ResourceKey key;
+  private FileObject fileObject;
+  private volatile int length;
+  private static final long serialVersionUID = 1L;
+
+  public FileObjectResourceData( final ResourceKey key ) throws ResourceLoadingException {
+    if ( key == null ) {
+      throw new NullPointerException();
+    }
+    final FileObject fileObject = (FileObject) key.getIdentifier();
+    try {
+      if ( fileObject.exists() == false ) {
+        throw new ResourceLoadingException( "File-handle given does not point to an existing file." );
+      }
+      if ( fileObject.isFile() == false ) {
+        throw new ResourceLoadingException( "File-handle given does not point to a regular file." );
+      }
+      if ( fileObject.isReadable() == false ) {
+        throw new ResourceLoadingException( "File '" + fileObject + "' is not readable." );
+      }
+    } catch ( FileSystemException fse ) {
+      throw new ResourceLoadingException( "Unable to create FileObjectResourceData : ", fse );
+    }
+
+    this.key = key;
+    this.fileObject = fileObject;
+  }
+
+  public InputStream getResourceAsStream( final ResourceManager caller ) throws ResourceLoadingException {
+    if ( caller == null ) {
+      throw new NullPointerException();
+    }
+    try {
+      final int buffer = (int) Math.max( 4096, Math.min( fileObject.getContent().getSize(), 128 * 1024 ) );
+      return new BufferedInputStream( fileObject.getContent().getInputStream(), buffer );
+    } catch ( Exception e ) {
+      throw new ResourceLoadingException( "Unable to open Stream: ", e );
+    }
+  }
+
+  public Object getAttribute( final String attrkey ) {
+    if ( attrkey == null ) {
+      throw new NullPointerException();
+    }
+    try {
+      if ( attrkey.equals( ResourceData.FILENAME ) ) {
+        return fileObject.getName().getBaseName();
+      }
+      if ( attrkey.equals( ResourceData.CONTENT_LENGTH ) ) {
+        return new Long( fileObject.getContent().getSize() );
+      }
+    } catch ( FileSystemException fse ) {
+
+    }
+
+    return null;
+  }
+
+  public long getVersion( final ResourceManager caller )
+        throws ResourceLoadingException {
+    if ( caller == null ) {
+      throw new NullPointerException();
+    }
+    try {
+      return fileObject.getContent().getLastModifiedTime();
+    } catch ( FileSystemException fse ) {
+      throw new ResourceLoadingException( "Unable to get version: ", fse );
+    }
+  }
+
+  public ResourceKey getKey() {
+    return key;
+  }
+}

--- a/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceLoader.java
+++ b/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceLoader.java
@@ -77,7 +77,9 @@ public class FileObjectResourceLoader implements ResourceLoader {
       } else if ( value instanceof String ) {
         //verify string value conforms to valid VFS URI
         UriParser.checkUriEncoding( String.valueOf( value ) );
-        final FileObject f = getFileObject( String.valueOf( value ) );
+        File file = new File( String.valueOf( value ) );
+
+        final FileObject f = VFS.getManager().resolveFile( file.toURI().toString() );
         if ( f.exists() && f.isFile() ) {
           return new ResourceKey( SCHEMA_NAME, f, factoryKeys );
         }
@@ -187,31 +189,4 @@ public class FileObjectResourceLoader implements ResourceLoader {
   public boolean isSupportedDeserializer( final String data ) {
     return SCHEMA_NAME.equals( ResourceKeyUtils.readSchemaFromString( data ) );
   }
-
-  private FileObject getFileObject( String vfsFilename ) throws FileSystemException {
-
-    boolean relativeFilename = true;
-    String[] schemes = VFS.getManager().getSchemes();
-    for ( int i = 0; i < schemes.length && relativeFilename; i++ ) {
-      if ( vfsFilename.startsWith( schemes[i] + ":" ) ) {
-        relativeFilename = false;
-      }
-    }
-
-    String filename;
-    if ( vfsFilename.startsWith( "\\\\" ) ) {
-      File file = new File( vfsFilename );
-      filename = file.toURI().toString();
-    } else {
-      if ( relativeFilename ) {
-        File file = new File( vfsFilename );
-        filename = file.getAbsolutePath();
-      } else {
-        filename = vfsFilename;
-      }
-    }
-
-    return VFS.getManager().resolveFile( filename );
-  }
-
 }

--- a/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceLoader.java
+++ b/libraries/libloader/src/main/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceLoader.java
@@ -1,0 +1,217 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.resourceloader.loader.fileobject;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.pentaho.reporting.libraries.resourceloader.ResourceData;
+import org.pentaho.reporting.libraries.resourceloader.ResourceException;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKeyCreationException;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKeyData;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKeyUtils;
+import org.pentaho.reporting.libraries.resourceloader.ResourceLoader;
+import org.pentaho.reporting.libraries.resourceloader.ResourceLoadingException;
+
+import java.net.URL;
+import java.util.Map;
+import java.io.File;
+
+public class FileObjectResourceLoader implements ResourceLoader {
+  public static final String SCHEMA_NAME = FileObjectResourceLoader.class.getName();
+  private static final Log logger = LogFactory.getLog( FileObjectResourceLoader.class );
+
+  public FileObjectResourceLoader() {
+  }
+
+ /**
+  * Checks, whether this resource loader implementation was responsible for creating this key.
+  *
+  * @param key
+  * @return
+  */
+  public boolean isSupportedKey( final ResourceKey key ) {
+    if ( key == null ) {
+      throw new NullPointerException();
+    }
+    if ( SCHEMA_NAME.equals( key.getSchema() ) ) {
+      return true;
+    }
+    return false;
+  }
+
+ /**
+  * Creates a new resource key from the given object and the factory keys.
+  *
+  * @param value
+  * @param factoryKeys
+  * @return the created key.
+  * @throws org.pentaho.reporting.libraries.resourceloader.ResourceKeyCreationException if creating the key failed.
+  */
+  public ResourceKey createKey( final Object value, final Map factoryKeys ) throws ResourceKeyCreationException {
+    try {
+      if ( value instanceof FileObject ) {
+        final FileObject f = (FileObject) value;
+        if ( f.exists() && f.isFile() ) {
+          return new ResourceKey( SCHEMA_NAME, f, factoryKeys );
+        }
+      } else if ( value instanceof String ) {
+        //verify string value conforms to valid VFS URI
+        UriParser.checkUriEncoding( String.valueOf( value ) );
+        final FileObject f = getFileObject( String.valueOf( value ) );
+        if ( f.exists() && f.isFile() ) {
+          return new ResourceKey( SCHEMA_NAME, f, factoryKeys );
+        }
+      }
+    } catch ( FileSystemException fse ) {
+      return null;
+    }
+    return null;
+  }
+
+ /**
+  * Derives a new resource key from the given key. If neither a path nor new factory-keys are given, the parent key is
+  * returned.
+  *
+  * @param parent      the parent
+  * @param path        the derived path (can be null).
+  * @param factoryKeys the optional factory keys (can be null).
+  * @return the derived key.
+  * @throws org.pentaho.reporting.libraries.resourceloader.ResourceKeyCreationException if the key cannot be derived
+  *                                                                                     for any reason.
+  */
+  public ResourceKey deriveKey( final ResourceKey parent, final String path, final Map factoryKeys )
+        throws ResourceKeyCreationException {
+    if ( isSupportedKey( parent ) == false ) {
+      throw new ResourceKeyCreationException( "Assertation: Unsupported parent key type" );
+    }
+
+    //For now return the resource parent-key as is
+    return parent;
+  }
+
+  public URL toURL( final ResourceKey key ) {
+    if ( key == null ) {
+      throw new NullPointerException();
+    }
+    if ( isSupportedKey( key ) == false ) {
+      throw new IllegalArgumentException( "Key format is not recognized." );
+    }
+
+    try {
+      final FileObject fileObject = (FileObject) key.getIdentifier();
+      return fileObject.getURL();
+    } catch ( FileSystemException e ) {
+      return null;
+    }
+  }
+
+  public ResourceData load( final ResourceKey key ) throws ResourceLoadingException {
+    if ( isSupportedKey( key ) == false ) {
+      throw new ResourceLoadingException( "Key format is not recognized." );
+    }
+    return new FileObjectResourceData( key );
+  }
+
+  public String serialize( final ResourceKey bundleKey, final ResourceKey key ) throws ResourceException {
+    // Validate the parameter
+    if ( key == null ) {
+      throw new NullPointerException( "The ResourceKey can not be null" );
+    }
+    if ( isSupportedKey( key ) == false ) {
+      throw new IllegalArgumentException( "Key format is not recognized." );
+    }
+    if ( !( key.getIdentifier() instanceof FileObject ) ) {
+      throw new IllegalArgumentException( "ResourceKey is invalid - identifier is not a File object" );
+    }
+
+    // Log information
+    logger.debug( "Serializing a FileObject Resource Key..." );
+    if ( key.getParent() != null ) {
+      throw new ResourceException( "Unable to serialize a FileObject-ResourceKey with a parent. "
+              + "This type is not expected to have a parent." );
+    }
+
+    // Create a string version of the identifier
+    try {
+      final FileObject fileObject = (FileObject) key.getIdentifier();
+      final String strIdentifier = fileObject.getName().getURI();
+      final String result = ResourceKeyUtils.createStringResourceKey(
+              key.getSchema().toString(), strIdentifier, key.getFactoryParameters() );
+      logger.debug( "Serialized FileObject Resource Key: [" + result + "]" );
+      return result;
+    } catch ( Exception ioe ) {
+      throw new IllegalArgumentException( "Could not determine fileObject URL specified in ResourceKey: "
+              + ioe.getMessage() );
+    }
+  }
+
+  public ResourceKey deserialize( final ResourceKey bundleKey, final String stringKey )
+        throws ResourceKeyCreationException {
+    // Parse the data
+    final ResourceKeyData keyData = ResourceKeyUtils.parse( stringKey );
+
+    // Validate the data
+    if ( SCHEMA_NAME.equals( keyData.getSchema() ) == false ) {
+      throw new ResourceKeyCreationException( "Serialized version of fileObject key does not contain correct schema" );
+    }
+
+    // Create a new fileObject based on the path provided
+    try {
+      final FileObject fileObject = VFS.getManager().resolveFile( keyData.getIdentifier() );
+      return new ResourceKey( SCHEMA_NAME, fileObject, keyData.getFactoryParameters() );
+    } catch ( FileSystemException fse ) {
+      throw new ResourceKeyCreationException( "Serialized version of fileObject key does not result into a valid FileObject" );
+    }
+  }
+
+  public boolean isSupportedDeserializer( final String data ) {
+    return SCHEMA_NAME.equals( ResourceKeyUtils.readSchemaFromString( data ) );
+  }
+
+  private FileObject getFileObject( String vfsFilename ) throws FileSystemException {
+
+    boolean relativeFilename = true;
+    String[] schemes = VFS.getManager().getSchemes();
+    for ( int i = 0; i < schemes.length && relativeFilename; i++ ) {
+      if ( vfsFilename.startsWith( schemes[i] + ":" ) ) {
+        relativeFilename = false;
+      }
+    }
+
+    String filename;
+    if ( vfsFilename.startsWith( "\\\\" ) ) {
+      File file = new File( vfsFilename );
+      filename = file.toURI().toString();
+    } else {
+      if ( relativeFilename ) {
+        File file = new File( vfsFilename );
+        filename = file.getAbsolutePath();
+      } else {
+        filename = vfsFilename;
+      }
+    }
+
+    return VFS.getManager().resolveFile( filename );
+  }
+
+}

--- a/libraries/libloader/src/main/resources/org/pentaho/reporting/libraries/resourceloader/loader.properties
+++ b/libraries/libloader/src/main/resources/org/pentaho/reporting/libraries/resourceloader/loader.properties
@@ -7,6 +7,7 @@ org.pentaho.reporting.libraries.resourceloader.loader.file=org.pentaho.reporting
 org.pentaho.reporting.libraries.resourceloader.loader.raw=org.pentaho.reporting.libraries.resourceloader.loader.raw.RawResourceLoader
 org.pentaho.reporting.libraries.resourceloader.loader.res=org.pentaho.reporting.libraries.resourceloader.loader.resource.ClassloaderResourceLoader
 org.pentaho.reporting.libraries.resourceloader.loader.zip=org.pentaho.reporting.libraries.resourceloader.loader.zip.ZipResourceLoader
+org.pentaho.reporting.libraries.resourceloader.loader.fileobject=org.pentaho.reporting.libraries.resourceloader.loader.fileobject.FileObjectResourceLoader
 
 #
 # The cache stuff. For now, this only defines *that* there are caches.

--- a/libraries/libloader/src/test/java/org/pentaho/reporting/libraries/resourceloader/ResourceKeyTest.java
+++ b/libraries/libloader/src/test/java/org/pentaho/reporting/libraries/resourceloader/ResourceKeyTest.java
@@ -12,16 +12,20 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.resourceloader;
 
 import junit.framework.TestCase;
 
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.VFS;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
 
 public class ResourceKeyTest extends TestCase {
   public ResourceKeyTest() {
@@ -78,6 +82,19 @@ public class ResourceKeyTest extends TestCase {
     assertNotNull( key );
     final ResourceKey key1 = manager.deriveKey( key, f2.getName() );
     assertNotNull( key1 );
+  }
+
+  public void testFileObjectKeyCreation()
+          throws ResourceKeyCreationException, IOException {
+    final ResourceManager manager = new ResourceManager();
+    manager.registerDefaults();
+
+    final FileObject fileObject =
+            VFS.getManager().resolveFile(
+                    Paths.get( "src/test/resources/org/pentaho/reporting/libraries/resourceloader/SVG.svg" ).toAbsolutePath().toString() );
+    assertNotNull( fileObject );
+    final ResourceKey key = manager.createKey( fileObject );
+    assertNotNull( key );
   }
 
   public void testMixedKeyDerivation()

--- a/libraries/libloader/src/test/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceLoaderTest.java
+++ b/libraries/libloader/src/test/java/org/pentaho/reporting/libraries/resourceloader/loader/fileobject/FileObjectResourceLoaderTest.java
@@ -1,0 +1,151 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2008 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+ */
+
+package org.pentaho.reporting.libraries.resourceloader.loader.fileobject;
+
+import junit.framework.TestCase;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.VFS;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKey;
+import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
+import org.pentaho.reporting.libraries.resourceloader.LibLoaderBoot;
+import org.pentaho.reporting.libraries.resourceloader.ParameterKey;
+import org.pentaho.reporting.libraries.resourceloader.ResourceKeyCreationException;
+import org.pentaho.reporting.libraries.resourceloader.FactoryParameterKey;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.nio.file.Paths;
+
+
+public class FileObjectResourceLoaderTest extends TestCase {
+  private static final String STRING_SERIALIZATION_PREFIX = "resourcekey:"; //$NON-NLS-1$
+  private static final String DESERIALIZE_PREFIX = STRING_SERIALIZATION_PREFIX + FileObjectResourceLoader.class.getName();
+
+  public FileObjectResourceLoaderTest() {
+  }
+
+  public FileObjectResourceLoaderTest( final String string ) {
+    super( string );
+  }
+
+  protected void setUp() throws Exception {
+    LibLoaderBoot.getInstance().start();
+  }
+
+  /**
+   * Tests the serialization of FileObject based resource keys
+   */
+  public void testSerializer() throws Exception {
+    final FileObjectResourceLoader fileObjectResourceLoader = new FileObjectResourceLoader();
+    final ResourceManager manager = new ResourceManager();
+    manager.registerDefaults();
+
+    ResourceKey key = null;
+    Map<ParameterKey, Object> factoryParameters = new HashMap<ParameterKey, Object>();
+    String serializedVersion = null;
+
+    // Test with null parameter
+    try {
+      serializedVersion = fileObjectResourceLoader.serialize( null, key );
+      fail( "Serialization with a null parameter should throw a NullPointerException" ); //$NON-NLS-1$
+    } catch ( NullPointerException npe ) {
+      // success
+    }
+
+    // Test with a resource key instead of a fileObject key
+    try {
+      key = manager.createKey( "res://org/pentaho/reporting/libraries/resourceloader/SVG.svg" ); //$NON-NLS-1$
+      serializedVersion = fileObjectResourceLoader.serialize( key, key );
+      fail( "The resource key should not be handled by the file object resource loader" ); //$NON-NLS-1$
+    } catch ( IllegalArgumentException iae ) {
+      // success
+    }
+
+    // Create a key from a fileObject
+    final FileObject fileObject =
+            VFS.getManager().resolveFile(
+                    Paths.get( "src/test/resources/org/pentaho/reporting/libraries/resourceloader/SVG.svg" ).toAbsolutePath().toString() );
+
+    key = manager.createKey( fileObject );
+    serializedVersion = fileObjectResourceLoader.serialize( key, key );
+    assertNotNull( "The returned key should not be null", key ); //$NON-NLS-1$
+    assertTrue( "Serialized version does not start with the correct header", serializedVersion //$NON-NLS-1$
+            .startsWith( STRING_SERIALIZATION_PREFIX ) );
+    assertTrue( "Serialized version does not contain the correct schema information", serializedVersion //$NON-NLS-1$
+            .startsWith( STRING_SERIALIZATION_PREFIX + fileObjectResourceLoader.getClass().getName() + ';' ) );
+    assertTrue( "Serialized version should contain the filename",
+            serializedVersion.endsWith( fileObject.getName().getBaseName() ) ); //$NON-NLS-1$
+  }
+
+  /**
+   * Tests the deserialization of FileObject based resource keys
+   */
+  public void testDeserializer() throws Exception {
+    final FileObjectResourceLoader fileObjectResourceLoader = new FileObjectResourceLoader();
+
+    // Create a key from a fileObject
+    final FileObject fileObject = VFS.getManager().resolveFile(
+            Paths.get( "src/test/resources/org/pentaho/reporting/libraries/resourceloader/SVG.svg" ).toAbsolutePath().toString() );
+
+    // Test deserializing invalid strings
+    try {
+      fileObjectResourceLoader.deserialize( null, null );
+      fail( "deserialize of a null string should throw an exception" );
+    } catch ( IllegalArgumentException iae ) {
+      // success
+    }
+
+    try {
+      fileObjectResourceLoader.deserialize( null, "" );
+      fail( "deserialize of an empty string should throw an exception" );
+    } catch ( ResourceKeyCreationException rkce ) {
+      // success
+    }
+
+    try {
+      fileObjectResourceLoader.deserialize( null,
+              STRING_SERIALIZATION_PREFIX + this.getClass().getName() + ';' + fileObject.getName().getURI() );
+      fail( "deserialize with an invalid resource class name should throw an exception" );
+    } catch ( ResourceKeyCreationException rkce ) {
+      // success
+    }
+
+    try {
+      fileObjectResourceLoader.deserialize( null, DESERIALIZE_PREFIX + ":/tmp" );
+      fail( "deserialize with an invalid file should thrown an exception" );
+    } catch ( ResourceKeyCreationException rkce ) {
+      // success
+    }
+
+    final ResourceKey key1 =
+            fileObjectResourceLoader.deserialize( null, DESERIALIZE_PREFIX + ';' + fileObject.getName().getURI()
+                    + ";\"\"\"f:this=that\"\":\"\"f:invalid\"\":\"\"f:null=\"\"\"" );
+    assertNotNull( key1 );
+    assertTrue( key1.getIdentifier() instanceof FileObject );
+    assertEquals( FileObjectResourceLoader.class.getName(), key1.getSchema() );
+    assertEquals( fileObject.getName().getURI(), ( (FileObject) key1.getIdentifier() ).getName().getURI() );
+    assertEquals( 2, key1.getFactoryParameters().size() );
+    assertTrue( !key1.getFactoryParameters().containsKey( new FactoryParameterKey( "invalid" ) ) );
+    assertTrue( key1.getFactoryParameters().containsKey( new FactoryParameterKey( "null" ) ) );
+    assertNull( key1.getFactoryParameters().get( new FactoryParameterKey( "null" ) ) );
+    assertEquals( "that", key1.getFactoryParameters().get( new FactoryParameterKey( "this" ) ) );
+
+  }
+
+}
+


### PR DESCRIPTION
1. Added new implementation of `ResourceData` and `ResourceLoader` for Apache VFS's `FileObject`.

2. Added this new `FileObjectResourceLoader` to `loader.properties`

@tmorgner @pentaho/rogueone 

Note: To be merged with: https://github.com/pentaho/pentaho-kettle/pull/6372