### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <commons-codec.version>1.9</commons-codec.version>
     <bouncycastl.version>138</bouncycastl.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <xml-apis.version>1.3.04</xml-apis.version>
+    <xml-apis-ext.version>1.3.04</xml-apis-ext.version>
     <javax.mail.version>1.4.7</javax.mail.version>
     <xmlunit.version>1.3</xmlunit.version>
     <plugin.sortpom.version>2.4.0</plugin.sortpom.version>
@@ -187,7 +187,6 @@
     <runITs>false</runITs>
     <cglib.version>2.2</cglib.version>
     <jt400.version>6.1</jt400.version>
-    <xerces.version>2.8.1</xerces.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <test.performance>false</test.performance>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>
@@ -2210,7 +2209,7 @@
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis-ext</artifactId>
-        <version>${xml-apis.version}</version>
+        <version>${xml-apis-ext.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>
@@ -2413,11 +2412,6 @@
         <groupId>org.databene</groupId>
         <artifactId>contiperf</artifactId>
         <version>${contiperf.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>${xerces.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 