### PR TITLE
[BACKLOG-28357] Updates derby version, retrieves from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,6 @@
     <olap4j.version>1.2.0</olap4j.version>
     <httpclient.version>4.5.3</httpclient.version>
     <ehcache-core.version>2.5.1</ehcache-core.version>
-    <derby.version>10.2.1.6</derby.version>
     <equinox.version>3.3.0-v20070426</equinox.version>
     <jcommon.version>1.0.16</jcommon.version>
     <javax.ws.rs.version>1.1.1</javax.ws.rs.version>


### PR DESCRIPTION
Removal of the Apache Derby version in favor of retrieving a unified version from the Maven parent POM. At the time of this PR, the latest version of Apache Derby is 10.15.1.3. Other PRs related to this one are listed below:

https://github.com/pentaho/maven-parent-poms/pull/122
https://github.com/pentaho/pentaho-platform/pull/4399
https://github.com/pentaho/pentaho-kettle/pull/6402
https://github.com/pentaho/pentaho-reporting/pull/1256
https://github.com/pentaho/data-access/pull/1053