### PR TITLE
Revert "[PRD-6070] Date Picker showing incorrect value when client is in diff…"

### DIFF
--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/datetime/TodayFunction.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/datetime/TodayFunction.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.formula.function.datetime;
@@ -42,7 +42,7 @@ public class TodayFunction implements Function {
     throws EvaluationException {
     final Date now = DateUtil.now( context );
 
-    final Date date = DateUtil.normalizeDate( now, DateTimeType.DATETIME_TYPE );
-    return new TypeValuePair( DateTimeType.DATETIME_TYPE, date );
+    final Date date = DateUtil.normalizeDate( now, DateTimeType.DATE_TYPE );
+    return new TypeValuePair( DateTimeType.DATE_TYPE, date );
   }
 }

--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/datetime/YesterdayFunction.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/datetime/YesterdayFunction.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.formula.function.datetime;
@@ -45,8 +45,8 @@ public class YesterdayFunction implements Function {
     throws EvaluationException {
     final Date yesterday = yesterday( context );
 
-    final Date date = DateUtil.normalizeDate( yesterday, DateTimeType.DATETIME_TYPE );
-    return new TypeValuePair( DateTimeType.DATETIME_TYPE, date );
+    final Date date = DateUtil.normalizeDate( yesterday, DateTimeType.DATE_TYPE );
+    return new TypeValuePair( DateTimeType.DATE_TYPE, date );
   }
 
   private static Date yesterday( final FormulaContext context ) {

--- a/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/datetime/NowFunctionTest.java
+++ b/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/datetime/NowFunctionTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.formula.function.datetime;
@@ -32,7 +32,7 @@ public class NowFunctionTest extends FormulaTestBase {
     return new Object[][]
       {
         { "NOW()>DATE(2006;1;3)", Boolean.TRUE },
-        { "NOW()=TODAY()", Boolean.TRUE },
+        { "INT(NOW())=TODAY()", Boolean.TRUE },
       };
   }
 

--- a/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/datetime/TodayFunctionTest.java
+++ b/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/datetime/TodayFunctionTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2019 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.formula.function.datetime;
@@ -32,7 +32,7 @@ public class TodayFunctionTest extends FormulaTestBase {
     return new Object[][]
       {
         { "TODAY()>DATE(2006;1;3)", Boolean.TRUE },
-        { "TODAY()=NOW()", Boolean.TRUE },
+        { "INT(TODAY())=TODAY()", Boolean.TRUE },
       };
   }
 

--- a/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/datetime/YesterdayFunctionTest.java
+++ b/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/datetime/YesterdayFunctionTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.formula.function.datetime;
@@ -32,7 +32,7 @@ public class YesterdayFunctionTest extends FormulaTestBase {
   }
 
   private Date createYesterdaysDate() {
-    final GregorianCalendar gcal = new GregorianCalendar( 2011, Calendar.APRIL, 6, 15, 0, 0 );
+    final GregorianCalendar gcal = new GregorianCalendar( 2011, Calendar.APRIL, 6, 0, 0, 0 );
     gcal.setTimeZone( getContext().getLocalizationContext().getTimeZone() );
     return gcal.getTime();
   }


### PR DESCRIPTION
Reverts pentaho/pentaho-reporting#1282

@pentaho-lmartins 
PR to revert this issue, since it already breaks tests in cda and also according to Thomas Morgner, this can only bring other kinds of errors