### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -132,18 +132,6 @@
       <artifactId>jersey-bundle</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.jsendnsca</groupId>
       <artifactId>jsendnsca</artifactId>
     </dependency>

--- a/designer/datasource-editor-mondrian/pom.xml
+++ b/designer/datasource-editor-mondrian/pom.xml
@@ -87,18 +87,6 @@
       <artifactId>jersey-bundle</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.jsendnsca</groupId>
       <artifactId>jsendnsca</artifactId>
     </dependency>

--- a/designer/datasource-editor-olap4j/pom.xml
+++ b/designer/datasource-editor-olap4j/pom.xml
@@ -83,18 +83,6 @@
       <artifactId>jersey-bundle</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.jsendnsca</groupId>
       <artifactId>jsendnsca</artifactId>
     </dependency>

--- a/designer/datasource-editor-pmd/pom.xml
+++ b/designer/datasource-editor-pmd/pom.xml
@@ -98,18 +98,6 @@
       <artifactId>jersey-bundle</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.jsendnsca</groupId>
       <artifactId>jsendnsca</artifactId>
     </dependency>

--- a/designer/report-designer-extension-connectioneditor/pom.xml
+++ b/designer/report-designer-extension-connectioneditor/pom.xml
@@ -77,18 +77,6 @@
       <artifactId>jersey-bundle</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.jsendnsca</groupId>
       <artifactId>jsendnsca</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
     <javax.mail.version>1.6.1</javax.mail.version>
     <xmlunit.version>1.3</xmlunit.version>
     <plugin.sortpom.version>2.4.0</plugin.sortpom.version>
-    <jetty.version>8.1.15.v20140411</jetty.version>
     <ehcache.version>2.5.1</ehcache.version>
     <trilead-ssh2.version>build213</trilead-ssh2.version>
     <xmlbeans.version>2.6.0</xmlbeans.version>
@@ -490,21 +489,6 @@
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-bundle</artifactId>
         <version>${jersey.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-continuation</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.jsendnsca</groupId>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )
[PDI-11851] Improve the jetty server version of Carte Server
[PPP-4402] Use of Vulnerable Component: jetty-server & jetty-util (CVE-2019-10246 | CVE-2019-10247)


To better cope with the synchronization with the Karaf upgrade, it was decided that the Jetty upgrade was to be split into two phases: the first would basically consist on centralizing the Jetty version on the parent POM (leaving the version as it is); the second phase (to be integrated into the Karaf upgrade development) would include the upgrade itself and any other changes required.

This PR belongs to phase 1 (check [maven-parent-poms#161](https://github.com/pentaho/maven-parent-poms/pull/161) for the complete list of PRs for phase 1).

**For this specific PR:**
Removed unused Jetty dependencies!

