### PR TITLE
[BACKLOG-29416] PIR: Selecting empty values does not give the expecte…

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/parameters/DefaultReportParameterValidator.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/parameters/DefaultReportParameterValidator.java
@@ -12,11 +12,12 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2018 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2020 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.parameters;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.reporting.engine.classic.core.DataFactory;
@@ -298,12 +299,12 @@ public class DefaultReportParameterValidator implements ReportParameterValidator
     return null;
   }
 
-  private boolean isValueMissingForMandatoryParameterCheck( final ParameterDefinitionEntry entry,
-      final Object computedValue ) {
+  @VisibleForTesting
+  boolean isValueMissingForMandatoryParameterCheck( final ParameterDefinitionEntry entry, final Object computedValue ) {
     if ( entry.isMandatory() == false ) {
       return false;
     }
-    if ( computedValue == null || "".equals( computedValue ) ) {
+    if ( computedValue == null ) {
       return true;
     }
 


### PR DESCRIPTION
…d results in single selection prompts
Due to recent changes from PIR-1183 which normalize in the client side nulls and empty string validation, this is the only change needed in order to retrieve an empty report value from a parameter.
In my tests i did not found any problem, but this check dates as far as 2013, so i'm not sure this can cause any undesired effects. 
If the check remains then the server would Never! return correspondent empty values from a parameter that has empty string as a possibility.
@pentaho-lmartins @dcleao @diogofscmariano @wseyler 