### PR TITLE
[PPP-4459] Use of Vulnerable Component: org.eclipse.paho:org.eclipse.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <test.performance>false</test.performance>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>
-    <paho.version>1.2.0</paho.version>
     <pentaho-metaverse.version>9.1.0.0-SNAPSHOT</pentaho-metaverse.version>
   </properties>
   <dependencyManagement>
@@ -2548,11 +2547,6 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka-clients.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.paho</groupId>
-        <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-        <version>${paho.version}</version>
       </dependency>
       <dependency>
         <groupId>pentaho</groupId>


### PR DESCRIPTION
…paho.client.mqttv3: CVE-2019-11777

* Dependency management moved to the parent POM.

This is a series of PRs, see https://github.com/pentaho/maven-parent-poms/pull/202 for details.