### PR TITLE
[SP-5410] Backport of PPP-4459 - Use of Vulnerable Component: org.ecl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <test.performance>false</test.performance>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>
-    <paho.version>1.2.0</paho.version>
     <pentaho-metaverse.version>9.0.0.0-SNAPSHOT</pentaho-metaverse.version>
   </properties>
   <dependencyManagement>
@@ -2549,11 +2548,6 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka-clients.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.paho</groupId>
-        <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-        <version>${paho.version}</version>
       </dependency>
       <dependency>
         <groupId>pentaho</groupId>


### PR DESCRIPTION
…ipse.paho:org.eclipse.paho.client.mqttv3: CVE-2019-11777 (9.0 Suite)

Cherry-pick of #1320 into 9.0 branch.
Related with https://github.com/pentaho/maven-parent-poms/pull/215.