### PR TITLE
[PPP-4496] Use of Vulnerable Component: Components/kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,6 @@
     <jt400.version>6.1</jt400.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <test.performance>false</test.performance>
-    <kafka-clients.version>0.10.2.1</kafka-clients.version>
     <pentaho-metaverse.version>9.1.0.0-SNAPSHOT</pentaho-metaverse.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
* [PPP-4496] Upgrading to version 0.10.2.2
* [PPP-4496] Removing version reference, maven-parent-pom will control version info.

Note: kafka-clients.version was left here due to the DependencyManagement overriding the dependency management of maven-parent-poms, it will still retrieve the version info from maven-parent-poms.

This is from a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/218
- https://github.com/pentaho/big-data-plugin/pull/2032
- https://github.com/pentaho/pdi-plugins-ee/pull/168
- https://github.com/pentaho/pentaho-platform/pull/4649
- https://github.com/pentaho/pentaho-reporting/pull/1327
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/152
- https://github.com/pentaho/pentaho-metadata-editor/pull/190
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/85
- https://github.com/pentaho/pentaho-kettle/pull/7309
- https://github.com/pentaho/pentaho-big-data-ee/pull/441