### PR TITLE
[SP-5370] Backport of PDI-17775 - Process Files step no longer suppor…

### DIFF
--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -228,10 +228,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>

--- a/engine/extensions-kettle/pom.xml
+++ b/engine/extensions-kettle/pom.xml
@@ -83,11 +83,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-digester</groupId>
       <artifactId>commons-digester</artifactId>
       <scope>compile</scope>

--- a/libraries/libloader/pom.xml
+++ b/libraries/libloader/pom.xml
@@ -152,7 +152,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>${commons-vfs2.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <groovy.version>2.4.8</groovy.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pentaho-cassandra-plugin.version>9.0.0.0-SNAPSHOT</pentaho-cassandra-plugin.version>
     <pentaho-osgi-bundles.version>9.0.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <poi.version>3.17</poi.version>


### PR DESCRIPTION
…ts HTTP scheme (9.0 Suite)

Cherry pick from: https://github.com/pentaho/pentaho-reporting/pull/1305

This PR is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/220
- https://github.com/pentaho/apache-vfs-browser/pull/61
- https://github.com/pentaho/big-data-plugin/pull/2035
- https://github.com/webdetails/cpk/pull/86
- https://github.com/pentaho/data-access/pull/1090
- https://github.com/pentaho/mondrian/pull/1197
- https://github.com/pentaho/pdi-jms-plugin/pull/75
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/103
- https://github.com/pentaho/pdi-plugins-ee/pull/170
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/83
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/52
- https://github.com/pentaho/pentaho-big-data-ee/pull/442
- https://github.com/pentaho/pentaho-commons-database/pull/178
- https://github.com/pentaho/pentaho-data-mining/pull/25
- https://github.com/pentaho/pentaho-det-ee/pull/615
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/22
- https://github.com/pentaho/pentaho-karaf-assembly/pull/634
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/286
- https://github.com/pentaho/pentaho-kettle/pull/7313
- https://github.com/pentaho/pentaho-metaverse/pull/620
- https://github.com/pentaho/pentaho-osgi-bundles/pull/362
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1503
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/340
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/789
- https://github.com/pentaho/pentaho-platform/pull/4651
- https://github.com/pentaho/pentaho-reporting/pull/1328
- https://github.com/pentaho/pentaho-s3-vfs/pull/93
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/16