### PR TITLE
Revert "Merge pull request #1328 from gryphendowre/SP-5370"

### DIFF
--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -228,6 +228,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>

--- a/engine/extensions-kettle/pom.xml
+++ b/engine/extensions-kettle/pom.xml
@@ -83,6 +83,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-digester</groupId>
       <artifactId>commons-digester</artifactId>
       <scope>compile</scope>

--- a/libraries/libloader/pom.xml
+++ b/libraries/libloader/pom.xml
@@ -152,6 +152,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
+      <version>${commons-vfs2.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <groovy.version>2.4.8</groovy.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pentaho-cassandra-plugin.version>9.0.0.0-SNAPSHOT</pentaho-cassandra-plugin.version>
     <pentaho-osgi-bundles.version>9.0.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <poi.version>3.17</poi.version>


### PR DESCRIPTION
This reverts commit 80a4bab4d57dfd5f06855b7a6e5fcffc372d92ca, reversing
changes made to dce179b93206b927263ce6735c19df4fb00e07bf.

This Revert PR is part of a series:
- https://github.com/pentaho/maven-parent-poms/pull/229
- https://github.com/pentaho/apache-vfs-browser/pull/62
- https://github.com/pentaho/big-data-plugin/pull/2040
- https://github.com/webdetails/cpk/pull/87
- https://github.com/pentaho/data-access/pull/1091
- https://github.com/pentaho/mondrian/pull/1202
- https://github.com/pentaho/pdi-jms-plugin/pull/76
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/104
- https://github.com/pentaho/pdi-plugins-ee/pull/174
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/84
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/53
- https://github.com/pentaho/pentaho-big-data-ee/pull/444
- https://github.com/pentaho/pentaho-commons-database/pull/179
- https://github.com/pentaho/pentaho-data-mining/pull/26
- https://github.com/pentaho/pentaho-det-ee/pull/616
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/23
- https://github.com/pentaho/pentaho-karaf-assembly/pull/635
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/290
- https://github.com/pentaho/pentaho-kettle/pull/7334
- https://github.com/pentaho/pentaho-metaverse/pull/621
- https://github.com/pentaho/pentaho-osgi-bundles/pull/363
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1504
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/341
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/790
- https://github.com/pentaho/pentaho-platform/pull/4658
- https://github.com/pentaho/pentaho-reporting/pull/1342
- https://github.com/pentaho/pentaho-s3-vfs/pull/94
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/17