### PR TITLE
[PRD-6122] Strip trailing slash from JCRSolutionFileModel url

### DIFF
--- a/libraries/libpensol/src/main/java/org/pentaho/reporting/libraries/pensol/JCRSolutionFileModel.java
+++ b/libraries/libpensol/src/main/java/org/pentaho/reporting/libraries/pensol/JCRSolutionFileModel.java
@@ -102,7 +102,7 @@ public class JCRSolutionFileModel implements SolutionFileModel {
     if ( url == null ) {
       throw new NullPointerException();
     }
-    this.url = url;
+    this.url = stripTrailingSlash( url );
     descriptionEntries = new HashMap<FileName, String>();
 
     final ClientConfig config = new DefaultClientConfig();
@@ -121,10 +121,14 @@ public class JCRSolutionFileModel implements SolutionFileModel {
 
   // package-local constructor for testing purposes
   JCRSolutionFileModel( String url, Client client, boolean loadTreePartially ) {
-    this.url = url;
+    this.url = stripTrailingSlash( url );
     this.descriptionEntries = new HashMap<FileName, String>();
     this.client = client;
     this.loadTreePartially = loadTreePartially;
+  }
+
+  private String stripTrailingSlash( String url ) {
+    return url.endsWith( SLASH ) ? url.substring( 0, url.length() - 1) : url;
   }
 
   public void refresh() throws IOException {


### PR DESCRIPTION
This PR fixes issues publishing reports to a Pentaho server configured to serve content from an empty context path (ie, http://localhost:8080, not http://localhost:8080/pentaho)