### PR TITLE
[PDI-19103] "java.lang.IllegalArgumentException: Last encoded charact…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <pentaho-cassandra-plugin.version>9.2.0.0-SNAPSHOT</pentaho-cassandra-plugin.version>
     <pentaho-osgi-bundles.version>9.2.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <poi.version>4.1.1</poi.version>
-    <commons-codec.version>1.13</commons-codec.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <curvesapi.version>1.06</curvesapi.version>
     <commons-compress.version>1.20</commons-compress.version>


### PR DESCRIPTION
…er (before the paddings if any)" after upgrading Pentaho Spoon to 8.3.0.16 and higher

@bcostahitachivantara @smmribeiro 

Related PRs:
https://github.com/pentaho/maven-parent-poms/pull/265
https://github.com/pentaho/pentaho-analyzer/pull/2158