### PR TITLE
[SP-6107] Upgrades log4j2

### DIFF
--- a/assemblies/prd-ce/pom.xml
+++ b/assemblies/prd-ce/pom.xml
@@ -293,13 +293,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -371,11 +366,6 @@
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-engine</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>kettle-log4j-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/assemblies/prd-ce/src/main/resources/resource/resources/log4j2.xml
+++ b/assemblies/prd-ce/src/main/resources/resource/resources/log4j2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <RollingFile name="FILE" fileName="logs/prd.log" filePattern="logs/prd.log.%i" append="true">
+      <PatternLayout pattern="%d %-5p [%c] %m%n"/>
+      <SizeBasedTriggeringPolicy size="500KB" />
+      <DefaultRolloverStrategy max="1" fileIndex="min"/>
+    </RollingFile>
+	<RollingFile name="FILE" fileName="logs/prd-perfStats.log" filePattern="logs/prd-perfStats.log.%i" append="true">
+      <PatternLayout pattern="%d %-5p [%c] %m%n"/>
+      <SizeBasedTriggeringPolicy size="500KB" />
+      <DefaultRolloverStrategy max="1" fileIndex="min"/>
+    </RollingFile>
+    <Console name="CONSOLE">
+      <PatternLayout>
+        <Pattern>%d{ABSOLUTE} %-5p [%c{1}] %m%n</Pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+	<Logger name="org.pentaho.reporting.libraries.base.util.LoggingStopWatch" level="DEBUG" additivity="false">
+      <appender-ref ref="PerformanceFileAppender"/>
+    </Logger>
+    <Root level="info">
+      <AppenderRef ref="FILE"/>
+      <AppenderRef ref="CONSOLE"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/assemblies/sample-war/pom.xml
+++ b/assemblies/sample-war/pom.xml
@@ -30,13 +30,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -35,13 +35,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/actions/global/QuitAction.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/actions/global/QuitAction.java
@@ -17,7 +17,7 @@
 
 package org.pentaho.reporting.designer.core.actions.global;
 
-import org.apache.log4j.LogManager;
+import org.apache.logging.log4j.LogManager;
 import org.pentaho.reporting.designer.core.ReportDesignerContext;
 import org.pentaho.reporting.designer.core.actions.AbstractDesignerContextAction;
 import org.pentaho.reporting.designer.core.actions.ActionMessages;

--- a/engine/demo/pom.xml
+++ b/engine/demo/pom.xml
@@ -48,8 +48,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>

--- a/engine/extensions-kettle/pom.xml
+++ b/engine/extensions-kettle/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>kettle-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.di.plugins</groupId>
-      <artifactId>kettle-log4j-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>metastore</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1238,17 +1238,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.pentaho.di.plugins</groupId>
-        <artifactId>kettle-log4j-core</artifactId>
-        <version>${pdi.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>pentaho</groupId>
         <artifactId>pentaho-big-data-plugin</artifactId>
         <version>${big-data-plugin.version}</version>


### PR DESCRIPTION
* [BISERVER-14721] Upgrade to log4j2.

* [BISERVER-14721] Upgrade to log4j2

* [BISERVER-14720] Removes unused kettle-log4j-core.

* [BISERVER-14720] Fix path in log4j2.xml

Co-authored-by: Luc Boudreau <lucboudreau@gmail.com>