### PR TITLE
[BACKLOG-35696] Missing log4j 1.2 API bridge to provide dependency for

### DIFF
--- a/assemblies/prd-ce/pom.xml
+++ b/assemblies/prd-ce/pom.xml
@@ -247,6 +247,10 @@
       <artifactId>log4j-jcl</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
older hadoop libraries and other dependencies.