### PR TITLE
[BACKLOG-37746] Add option to freeze top row in HTML reports

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/AbstractHtmlPrinter.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/AbstractHtmlPrinter.java
@@ -265,9 +265,22 @@ public abstract class AbstractHtmlPrinter {
     writer.writeTag( XHTML_NAMESPACE, "meta", attrList, XmlWriterSupport.CLOSE );
   }
 
+  private void addStickyHeaderStyle(GlobalStyleManager styleManager) {
+    StyleBuilder styleBuilder = getStyleBuilder();
+    AttributeList attrs = new AttributeList();
+
+    attrs.setAttribute( HtmlPrinter.XHTML_NAMESPACE, AttributeNames.Html.STYLE_CLASS, "sticky-header" );
+    styleBuilder.append( StyleBuilder.CSSKeys.POSITION, "sticky" );
+    styleBuilder.append( StyleBuilder.CSSKeys.TOP, "0", "px" );
+
+    styleManager.updateStyleForcedStyleName( styleBuilder, attrs, "sticky-header" );
+  }
+
   protected StyleManager createStyleManager() {
     if ( isCreateBodyFragment() == false && isInlineStylesRequested() == false ) {
-      return new GlobalStyleManager();
+      GlobalStyleManager styleManager = new GlobalStyleManager();
+      addStickyHeaderStyle( styleManager );
+      return styleManager;
     }
 
     return new InlineStyleManager();

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/AbstractHtmlPrinter.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/AbstractHtmlPrinter.java
@@ -12,7 +12,7 @@
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
  *
- *  Copyright (c) 2006 - 2017 Hitachi Vantara..  All rights reserved.
+ *  Copyright (c) 2006 - 2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.output.table.html.helper;

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/GlobalStyleManager.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/GlobalStyleManager.java
@@ -68,6 +68,20 @@ public class GlobalStyleManager implements StyleManager {
    * @return the modified attribute list.
    */
   public AttributeList updateStyle( final StyleBuilder styleBuilder, final AttributeList attributeList ) {
+    return updateStyleForcedStyleName( styleBuilder, attributeList, null );
+  }
+
+  /**
+   * Updates the given attribute-List according to the current style rules. ForcedStyleNames cannot be reused
+   * and will be ignored if null or empty.
+   *
+   * @param styleBuilder
+   * @param attributeList
+   * @param forcedStyleName
+   * @return the modified attribute list.
+   */
+  public AttributeList updateStyleForcedStyleName( final StyleBuilder styleBuilder, final AttributeList attributeList,
+                                                   String forcedStyleName ) {
     if ( styleBuilder.isEmpty() ) {
       return attributeList;
     }
@@ -76,13 +90,12 @@ public class GlobalStyleManager implements StyleManager {
     final String styleText = styleBuilder.toString();
     String styleName = styles.get( value );
     if ( styleName == null ) {
-      styleName = "style-" + nameCounter;
+      styleName = StringUtils.isEmpty( forcedStyleName ) ? "style-" + nameCounter++ : forcedStyleName;
       styles.put( value, styleName );
       if ( stylesText.contains( styleText ) ) {
         throw new IllegalStateException();
       }
       stylesText.add( styleText );
-      nameCounter += 1;
     }
 
     final String attribute = attributeList.getAttribute( HtmlPrinter.XHTML_NAMESPACE, "class" );

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/GlobalStyleManager.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/GlobalStyleManager.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2013 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
+ * Copyright (c) 2001 - 2023 Object Refinery Ltd, Hitachi Vantara and Contributors..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.output.table.html.helper;

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/StyleBuilder.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/StyleBuilder.java
@@ -105,6 +105,8 @@ public interface StyleBuilder {
         "border-top-right-radius" ), BORDER_BOTTOM_LEFT_RADIUS( "border-bottom-left-radius" ), BORDER_BOTTOM_RIGHT_RADIUS(
         "border-bottom-right-radius" ),
 
+    POSITION( "position" ), TOP( "top" ),
+
     BACKGROUND_COLOR( "background-color", true ), OVERFLOW( "overflow" ), WIDTH( "width" ), HEIGHT( "height" ),
     TRANSFORM_ORIGIN( "transform-origin" ), TRANSFORM( "transform" ), DIRECTION( "direction" );
 

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/StyleBuilder.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/html/helper/StyleBuilder.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.output.table.html.helper;


### PR DESCRIPTION
This PR adds a new style to the global style manager necessary for sticky headers, whether or not anything actually uses that style. By default, it will not be used.

This style will not be added if reporting is set to use inline styles.