### PR TITLE
[PDI-19936] - Formula Step : Unicode decimal code for surrogate pair characters is not returned correctly using CODE/UNICODE formula.

### DIFF
--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/text/UnicodeFunction.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/text/UnicodeFunction.java
@@ -53,7 +53,7 @@ public class UnicodeFunction implements Function {
       throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
     }
 
-    return new TypeValuePair( NumberType.GENERIC_NUMBER, new BigDecimal( result.charAt( 0 ) ) );
+    return new TypeValuePair( NumberType.GENERIC_NUMBER, new BigDecimal( result.codePointAt( 0 ) ) );
   }
 
   public String getCanonicalName() {


### PR DESCRIPTION
Changing character reference to accommodate 4 bytes characters in Unicode

@smmribeiro
@renato-s
@bcostahitachivantara

