### PR TITLE
[PDI-19695] - Formula ATAN2 is not working as expected

### DIFF
--- a/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/math/Atan2Function.java
+++ b/libraries/libformula/src/main/java/org/pentaho/reporting/libraries/formula/function/math/Atan2Function.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2006 - 2017 Hitachi Vantara and Contributors.  All rights reserved.
+* Copyright (c) 2006 - 2023 Hitachi Vantara and Contributors.  All rights reserved.
 */
 
 package org.pentaho.reporting.libraries.formula.function.math;
@@ -50,17 +50,17 @@ public class Atan2Function implements Function {
     if ( result == null ) {
       throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
     }
-    final Type type2 = parameters.getType( 0 );
-    final Object value2 = parameters.getValue( 0 );
+    final Type type2 = parameters.getType( 1 );
+    final Object value2 = parameters.getValue( 1 );
     final Number result2 = context.getTypeRegistry().convertToNumber( type2, value2 );
     if ( result2 == null ) {
       throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
     }
-    final double d1 = result.doubleValue();
-    final double d2 = result2.doubleValue();
-    if ( d1 == 0 || d2 == 0 ) {
+    final double x = result.doubleValue();
+    final double y = result2.doubleValue();
+    if ( x == 0 || y == 0 ) {
       throw EvaluationException.getInstance( LibFormulaErrorValue.ERROR_INVALID_ARGUMENT_VALUE );
     }
-    return new TypeValuePair( NumberType.GENERIC_NUMBER, new BigDecimal( Math.atan2( d1, d2 ) ) );
+    return new TypeValuePair( NumberType.GENERIC_NUMBER,  new BigDecimal( Math.atan2( y, x  ) ) );
   }
 }

--- a/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/math/ATAN2FunctionTest.java
+++ b/libraries/libformula/src/test/java/org/pentaho/reporting/libraries/formula/function/math/ATAN2FunctionTest.java
@@ -1,0 +1,51 @@
+/*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2008 - 2023 Hitachi Vantara and Contributors.  All rights reserved.
+*/
+
+package org.pentaho.reporting.libraries.formula.function.math;
+
+import org.pentaho.reporting.libraries.formula.FormulaContext;
+import org.pentaho.reporting.libraries.formula.FormulaTestBase;
+import org.pentaho.reporting.libraries.formula.util.NumberUtil;
+
+import java.math.BigDecimal;
+
+/**
+ * @author Shiva Krishna Kurremula
+ */
+public class ATAN2FunctionTest extends FormulaTestBase {
+  private FormulaContext context;
+
+  public void testDefault() throws Exception {
+    runDefaultTest();
+  }
+
+  public Object[][] createDataTest() {
+    return new Object[][] {
+      { "ATAN2(5;10)", NumberUtil.performTuneRounding( new BigDecimal( 1.1071487177940904089723517245147377 ) ) },
+      { "ATAN2(10;5)", NumberUtil.performTuneRounding( new BigDecimal( 0.4636476090008060935154787784995278 ) ) },
+      { "ATAN2(10;10)", NumberUtil.performTuneRounding( new BigDecimal( 0.7853981633974482789994908671360463 ) ) },
+      { "ATAN2(30;45)", NumberUtil.performTuneRounding( new BigDecimal( 0.9827937232473290540823995797836687 ) ) },
+      { "ATAN2(45;30)", NumberUtil.performTuneRounding( new BigDecimal( 0.5880026035475675039165821544884238 ) ) },
+      { "ATAN2(90;30)", NumberUtil.performTuneRounding( new BigDecimal( 0.3217505543966421854840120886365184 ) ) },
+      { "ATAN2(30;90)", NumberUtil.performTuneRounding( new BigDecimal( 1.2490457723982544280261208768934011 ) ) },
+      { "ATAN2(90;45)", NumberUtil.performTuneRounding( new BigDecimal( 0.4636476090008060935154787784995278 ) ) },
+      { "ATAN2(45;90)", NumberUtil.performTuneRounding( new BigDecimal( 1.1071487177940904089723517245147377 ) ) },
+      { "ATAN2(90;90)", NumberUtil.performTuneRounding( new BigDecimal( 0.7853981633974482789994908671360462 ) ) },
+    };
+  }
+}
+


### PR DESCRIPTION
Two Issues with the code: 
(1) incorrect index used for 2nd parameter
(2) Order of passing parameter is incorrect in Math.atan2(double y, double x)

**Testing results**
![image](https://github.com/pentaho/pentaho-reporting/assets/141143387/6c9d4d4b-a919-4396-8bb9-91513e345c50)
