### PR TITLE
[PPP-4848] commons-net has a security vulnerability, but is not used by

### DIFF
--- a/engine/extensions-kettle/pom.xml
+++ b/engine/extensions-kettle/pom.xml
@@ -74,11 +74,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-net</groupId>
-      <artifactId>commons-net</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-digester</groupId>
       <artifactId>commons-digester</artifactId>
       <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
     <asm.version>3.2</asm.version>
     <pdi.version>10.1.0.0-SNAPSHOT</pdi.version>
     <edtftpj.version>2.1.0</edtftpj.version>
-    <commons-net.version>1.4.1</commons-net.version>
     <eclipse.commands.version>3.3.0-I20070605-0010</eclipse.commands.version>
     <pdi-json-plugin.version>10.1.0.0-SNAPSHOT</pdi-json-plugin.version>
     <license.header.file>license/templates/licenseHeader.txt</license.header.file>
@@ -1558,11 +1557,6 @@
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-net</groupId>
-        <artifactId>commons-net</artifactId>
-        <version>${commons-net.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
any of this code.  Removing to simplify dependency management.