### PR TITLE
[BISERVER-14865] - Impossible to download PIR reports onto Excel 2007 format once data is past Excel limitations

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>flute</artifactId>
     </dependency>
     <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-platform-core</artifactId>
+      <version>${platform.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml-schemas</artifactId>
       <scope>compile</scope>

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/output/AbstractOutputProcessorMetaData.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/output/AbstractOutputProcessorMetaData.java
@@ -468,6 +468,13 @@ public abstract class AbstractOutputProcessorMetaData implements OutputProcessor
     this.booleanFeatures.remove( feature );
   }
 
+  public void addNumericFeature( final OutputProcessorFeature.NumericOutputProcessorFeature feature, double val ) {
+    if ( feature == null ) {
+      throw new NullPointerException();
+    }
+    this.numericFeatures.put( feature, val );
+  }
+
   public boolean isFeatureSupported( final OutputProcessorFeature.BooleanOutputProcessorFeature feature ) {
     if ( feature == null ) {
       throw new NullPointerException();

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/output/OutputProcessorFeature.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/output/OutputProcessorFeature.java
@@ -170,6 +170,9 @@ public abstract class OutputProcessorFeature implements Serializable {
   public static final BooleanOutputProcessorFeature IGNORE_ROTATION =
     new BooleanOutputProcessorFeature( "ignore-rotation" );
 
+  public static final NumericOutputProcessorFeature SHEET_ROW_LIMIT =
+    new NumericOutputProcessorFeature( "sheet-row-limit" );
+
   private String name;
   private int hashCode;
 

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/FlowExcelOutputProcessor.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/FlowExcelOutputProcessor.java
@@ -18,10 +18,12 @@
 package org.pentaho.reporting.engine.classic.core.modules.output.table.xls;
 
 import org.pentaho.reporting.engine.classic.core.layout.model.LogicalPageBox;
+import org.pentaho.reporting.engine.classic.core.layout.output.AbstractOutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.layout.output.ContentProcessingException;
 import org.pentaho.reporting.engine.classic.core.layout.output.DisplayAllFlowSelector;
 import org.pentaho.reporting.engine.classic.core.layout.output.FlowSelector;
 import org.pentaho.reporting.engine.classic.core.layout.output.LogicalPageKey;
+import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorFeature;
 import org.pentaho.reporting.engine.classic.core.layout.output.OutputProcessorMetaData;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.base.AbstractTableOutputProcessor;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.base.SheetLayout;
@@ -64,6 +66,13 @@ public class FlowExcelOutputProcessor extends AbstractTableOutputProcessor {
 
   public void setUseXlsxFormat( final boolean useXlsxFormat ) {
     printer.setUseXlsxFormat( useXlsxFormat );
+  }
+
+  public void setMaxSheetRowCount( int rowCount ) {
+    if ( metaData instanceof AbstractOutputProcessorMetaData ) {
+      AbstractOutputProcessorMetaData meta = (AbstractOutputProcessorMetaData) metaData;
+      meta.addNumericFeature( OutputProcessorFeature.SHEET_ROW_LIMIT, rowCount );
+    }
   }
 
   public InputStream getTemplateInputStream() {

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelOutputProcessorMetaData.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelOutputProcessorMetaData.java
@@ -116,6 +116,13 @@ public class ExcelOutputProcessorMetaData extends AbstractOutputProcessorMetaDat
     if ( deviceResolution > 0 ) {
       setNumericFeatureValue( OutputProcessorFeature.DEVICE_RESOLUTION, deviceResolution );
     }
+
+    final double sheetRowLimit =
+        extendedConfig.getIntProperty(
+            "org.pentaho.reporting.engine.classic.core.modules.output.table.xls.SheetRowLimit", 1048576 );
+    if ( getNumericFeatureValue( OutputProcessorFeature.SHEET_ROW_LIMIT ) <= 0 && sheetRowLimit > 0 ) {
+      setNumericFeatureValue( OutputProcessorFeature.SHEET_ROW_LIMIT, sheetRowLimit );
+    }
   }
 
   /**

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelPrinter.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelPrinter.java
@@ -125,36 +125,45 @@ public class ExcelPrinter extends ExcelPrinterBase {
     final SheetLayout sheetLayout = contentProducer.getSheetLayout();
     final int colCount = sheetLayout.getColumnCount();
 
-    for ( int row = startRow; row < finishRow; row++ ) {
-      final Row hssfRow = getRowAt( row );
-      final double lastRowHeight = StrictGeomUtility.toExternalValue( sheetLayout.getRowHeight( row ) );
+    int sheetRow = startRow;
+    for ( int contentRow = startRow; contentRow < finishRow; contentRow++ ) {
+      if ( getMaxSheetRowCount() != -1 && sheetRow >= getMaxSheetRowCount() ) {
+        sheet = openSheet( contentProducer.getSheetName() );
+        // Start a new page.
+        configureSheetPaperSize( sheet, logicalPage.getPageGrid().getPage( 0, 0 ) );
+        configureSheetColumnWidths( sheet, contentProducer.getSheetLayout(), contentProducer.getColumnCount() );
+        configureSheetProperties( sheet, excelTableContentProducer );
+        sheetRow = 0;
+      }
+      final Row hssfRow = getRowAt( sheetRow );
+      final double lastRowHeight = StrictGeomUtility.toExternalValue( sheetLayout.getRowHeight( contentRow ) );
       hssfRow.setHeightInPoints( (float) ( lastRowHeight ) );
 
       for ( int col = 0; col < colCount; col++ ) {
-        final CellMarker.SectionType sectionType = contentProducer.getSectionType( row, col );
-        final RenderBox content = contentProducer.getContent( row, col );
+        final CellMarker.SectionType sectionType = contentProducer.getSectionType( contentRow, col );
+        final RenderBox content = contentProducer.getContent( contentRow, col );
 
         if ( content == null ) {
-          final RenderBox backgroundBox = contentProducer.getBackground( row, col );
+          final RenderBox backgroundBox = contentProducer.getBackground( contentRow, col );
           final CellBackground background;
           if ( backgroundBox != null ) {
             background =
-                cellBackgroundProducer.getBackgroundForBox( logicalPage, sheetLayout, col, row, 1, 1, true,
+                cellBackgroundProducer.getBackgroundForBox( logicalPage, sheetLayout, col, contentRow, 1, 1, true,
                     sectionType, backgroundBox );
           } else {
-            background = cellBackgroundProducer.getBackgroundAt( logicalPage, sheetLayout, col, row, true, sectionType );
+            background = cellBackgroundProducer.getBackgroundAt( logicalPage, sheetLayout, col, contentRow, true, sectionType );
           }
           if ( background == null ) {
-            if ( row == 0 && col == 0 ) {
+            if ( contentRow == 0 && col == 0 ) {
               // create a single cell, so that we dont run into nullpointer inside POI..
-              getCellAt( col, row );
+              getCellAt( col, contentRow );
             }
             // An empty cell .. ignore
             continue;
           }
 
           // A empty cell with a defined background ..
-          final Cell cell = getCellAt( col, row );
+          final Cell cell = getCellAt( col, sheetRow );
           final CellStyle style = getCellStyleProducer().createCellStyle( null, null, background );
           if ( style != null ) {
             cell.setCellStyle( style );
@@ -166,11 +175,11 @@ public class ExcelPrinter extends ExcelPrinterBase {
           throw new InvalidReportStateException( "Uncommited content encountered" );
         }
 
-        final long contentOffset = contentProducer.getContentOffset( row, col );
+        final long contentOffset = contentProducer.getContentOffset( contentRow, col );
         final TableRectangle rectangle =
             sheetLayout.getTableBounds( content.getX(), content.getY() + contentOffset, content.getWidth(), content
                 .getHeight(), null );
-        if ( rectangle.isOrigin( col, row ) == false ) {
+        if ( rectangle.isOrigin( col, contentRow ) == false ) {
           // A spanned cell ..
           continue;
         }
@@ -180,7 +189,7 @@ public class ExcelPrinter extends ExcelPrinterBase {
                 rectangle.getColumnSpan(), rectangle.getRowSpan(), false, sectionType, content );
         // export the cell and all content ..
 
-        final Cell cell = getCellAt( col, row );
+        final Cell cell = getCellAt( col, sheetRow );
         final CellStyle style =
             getCellStyleProducer().createCellStyle( content.getInstanceId(), content.getStyleSheet(), fastBackground );
         if ( style != null ) {
@@ -188,12 +197,12 @@ public class ExcelPrinter extends ExcelPrinterBase {
         }
 
         if ( applyCellValue( content, cell, sheetLayout, rectangle, contentOffset ) ) {
-          mergeCellRegion( rectangle, row, col, sheetLayout, logicalPage, content, contentProducer );
+          mergeCellRegion( rectangle, sheetRow, col, sheetLayout, logicalPage, content, contentProducer );
         }
 
         content.setFinishedTable( true );
       }
-
+      sheetRow++;
     }
 
     if ( incremental == false ) {

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelPrinterBase.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelPrinterBase.java
@@ -51,7 +51,10 @@ import java.util.HashMap;
 
 public abstract class ExcelPrinterBase {
   private static final Log logger = LogFactory.getLog( ExcelPrinterBase.class );
-  public static final int EXCEL_LIMIT = 1048576;
+  /*
+    Default MAX number of rows that can be printed to an Excel sheet
+   */
+  public static final int SHEET_ROW_LIMIT = 1048576;
   private final HashMap<String, Integer> sheetNamesCount;
   private Configuration config;
   private OutputProcessorMetaData metaData;
@@ -63,7 +66,7 @@ public abstract class ExcelPrinterBase {
   private CellStyleProducer cellStyleProducer;
   private ExcelImageHandler imageHandler;
   private Drawing patriarch;
-  private double maxSheetRowCount = EXCEL_LIMIT;
+  private double maxSheetRowCount = SHEET_ROW_LIMIT;
 
   public ExcelPrinterBase() {
     this.sheetNamesCount = new HashMap<String, Integer>();
@@ -78,11 +81,11 @@ public abstract class ExcelPrinterBase {
   }
 
   public void setMaxSheetRowCount( double rowCount ) {
-    if ( rowCount > 0 && rowCount < EXCEL_LIMIT ) {
+    if ( rowCount > 0 && rowCount < SHEET_ROW_LIMIT ) {
       maxSheetRowCount = rowCount;
     } else {
       // Set the row limit to the Excel limit if the configuration used falls outside the normal limits
-      maxSheetRowCount = EXCEL_LIMIT;
+      maxSheetRowCount = SHEET_ROW_LIMIT;
     }
   }
 

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelPrinterBase.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/helper/ExcelPrinterBase.java
@@ -115,13 +115,13 @@ public abstract class ExcelPrinterBase {
       } else {
         scaleFactor = Double.parseDouble( scaleFactorText );
       }
-      getSheetRowLimitConfig( this.metaData );
+      applySheetRowLimitConfig( this.metaData );
     } catch ( Exception e ) {
       this.scaleFactor = 50;
     }
   }
 
-  private void getSheetRowLimitConfig( OutputProcessorMetaData metaData ) {
+  private void applySheetRowLimitConfig( OutputProcessorMetaData metaData ) {
     double sheetRowLimit = metaData.getNumericFeatureValue( OutputProcessorFeature.SHEET_ROW_LIMIT );
     setMaxSheetRowCount( sheetRowLimit );
   }

--- a/engine/core/src/main/resources/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/config-description.xml
+++ b/engine/core/src/main/resources/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/config-description.xml
@@ -202,5 +202,11 @@
       <text>false</text>
     </enum>
   </key>
+  <key name="org.pentaho.reporting.engine.classic.core.modules.output.table.xls.SheetRowLimit" global="false"
+       hidden="false">
+    <description>Defines max number of rows to be printed to each sheet. Creates a new sheet once that limit is reached.
+    Max allowable limit is 1,048,576 according to Excel sheet limits.</description>
+    <text/>
+  </key>
 
 </config-description>

--- a/engine/core/src/main/resources/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/configuration.properties
+++ b/engine/core/src/main/resources/org/pentaho/reporting/engine/classic/core/modules/output/table/xls/configuration.properties
@@ -81,3 +81,4 @@ org.pentaho.reporting.engine.classic.core.modules.output.table.xls.ShapeAsConten
 org.pentaho.reporting.engine.classic.core.modules.output.table.xls.DeviceResolution=96
 org.pentaho.reporting.engine.classic.core.modules.output.table.xls.AssumeOverflowX=false
 org.pentaho.reporting.engine.classic.core.modules.output.table.xls.AssumeOverflowY=false
+org.pentaho.reporting.engine.classic.core.modules.output.table.xls.SheetRowLimit=1048576


### PR DESCRIPTION
Adding support for new Excel export settings.
See: https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/1045