### PR TITLE
Revert "[BACKLOG-39663] Replace ehcache-core.2.5.1 with ehcache-2.10.6 to eliminate 2.5.1 from getting into the server WEB-INF/lib and cause conflicts. (#1622)"

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -164,8 +164,7 @@
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache</artifactId>
-      <version>${ehcache.version}</version>
+      <artifactId>ehcache-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/libraries/libloader/pom.xml
+++ b/libraries/libloader/pom.xml
@@ -131,13 +131,13 @@
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache</artifactId>
-      <version>${ehcache.version}</version>
+      <artifactId>ehcache-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>xmlgraphics-commons</artifactId>
+      <version>${xml-graphics-common.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <javadbf.version>20081125</javadbf.version>
     <scannotation.version>1.0.2</scannotation.version>
     <olap4j.version>1.2.0</olap4j.version>
-    <ehcache.version>2.10.6</ehcache.version>
+    <ehcache-core.version>2.5.1</ehcache-core.version>
     <equinox.version>3.3.0-v20070426</equinox.version>
     <jcommon.version>1.0.16</jcommon.version>
     <javax.ws.rs.version>1.1.1</javax.ws.rs.version>


### PR DESCRIPTION


This reverts commit 7f7cb475fdcab6ceb24c463debe2a3c2200f8aec.