### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/designer/datasource-editor-jdbc/src/main/resources/org/pentaho/reporting/ui/datasources/jdbc/configuration.properties
+++ b/designer/datasource-editor-jdbc/src/main/resources/org/pentaho/reporting/ui/datasources/jdbc/configuration.properties
@@ -1,5 +1,5 @@
 
-org.pentaho.reporting.ui.datasources.jdbc.driver-mapping.org.gjt.mm.mysql.Driver=org.pentaho.di.core.database.MySQLDatabaseMeta
+org.pentaho.reporting.ui.datasources.jdbc.driver-mapping.com.mysql.jdbc.Driver=org.pentaho.di.core.database.MySQLDatabaseMeta
 org.pentaho.reporting.ui.datasources.jdbc.driver-mapping.oracle.jdbc.driver.OracleDriver=org.pentaho.di.core.database.OracleDatabaseMeta
 org.pentaho.reporting.ui.datasources.jdbc.driver-mapping.com.ibm.as400.access.AS400JDBCDriver=org.pentaho.di.core.database.AS400DatabaseMeta
 org.pentaho.reporting.ui.datasources.jdbc.driver-mapping.net.sourceforge.jtds.jdbc.Driver=org.pentaho.di.core.database.MSSQLServerDatabaseMeta


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver