### PR TITLE
[PRD-6160] - When rendering html richtext containing style and fontsize specified in "px" then this text is displayed too big (fix)

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/richtext/HtmlRichTextConverter.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/richtext/HtmlRichTextConverter.java
@@ -690,7 +690,7 @@ public class HtmlRichTextConverter implements RichTextConverter {
         return new Float( nval * 72 );
       }
       if ( "px".equals( unit ) ) {
-        return new Float( nval * 72 );
+        return Float.valueOf((float) (nval * 0.75));
       }
       if ( "pc".equals( unit ) ) {
         return new Float( nval * 12 );


### PR DESCRIPTION
Fix for PRD-6160. This PR should only be merged after the [PR](https://github.com/pentaho/pentaho-reporting/pull/1662) with the corresponding unit test is merged, for QA purposes.

@pentaho/tatooine_dev 