### PR TITLE
[PPP-4537][PPP-4541] Use of Vulnerable Component: Components/akka, scala

### DIFF
--- a/designer/report-designer/pom.xml
+++ b/designer/report-designer/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-actor_2.10</artifactId>
+      <artifactId>akka-actor_3</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/AsynchronousDataSchemaManager.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/AsynchronousDataSchemaManager.java
@@ -90,8 +90,8 @@ public class AsynchronousDataSchemaManager implements DataSchemaManager, ReportM
     }
     Future<ContextAwareDataSchemaModel> retrieve = this.actor.retrieve( masterReport, report );
     // IntelliJ does not know how to handle this construct, thinks it is not valid.
-    retrieve.onSuccess( new SuccessHandler(), ActorSystemHost.INSTANCE.getSystem().dispatcher() );
-    retrieve.onFailure( new FailureHandler(), ActorSystemHost.INSTANCE.getSystem().dispatcher() );
+    retrieve.foreach( new SuccessHandler(), ActorSystemHost.INSTANCE.getSystem().dispatcher() );
+    retrieve.failed().foreach( new FailureHandler(), ActorSystemHost.INSTANCE.getSystem().dispatcher() );
   }
 
   public void close() {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <test.long>false</test.long>
     <sapdb.version>7.4.4</sapdb.version>
-    <akka.version>2.3.3</akka.version>
+    <akka.version>2.8.6</akka.version>
     <json-simple.version>1.1</json-simple.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <mimepull.version>1.9.3</mimepull.version>
@@ -872,7 +872,7 @@
       </dependency>
       <dependency>
         <groupId>com.typesafe.akka</groupId>
-        <artifactId>akka-actor_2.10</artifactId>
+        <artifactId>akka-actor_3</artifactId>
         <version>${akka.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
relates to [PPP-4541] Use of Vulnerable Component: Components/scala
- Updated akka-actor to nearest, non-vulnerable version
- This new version has an updated scala library version that depricated `onSuccess` and `onFailure`

[PPP-4541]: https://hv-eng.atlassian.net/browse/PPP-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ