### PR TITLE
[PPP-4784] Vulnerable Component: groovy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <xalan.version>2.6.0</xalan.version>
     <ftp4che.version>0.7.1</ftp4che.version>
     <hibernate.version>3.6.9.Final</hibernate.version>
-    <groovy.version>2.4.8</groovy.version>
+    <groovy.version>2.4.21</groovy.version>
     <mockito.version>5.10.0</mockito.version>
     <powermock.version>1.6.3</powermock.version>
     <pentaho-osgi-bundles.version>10.3.0.0-SNAPSHOT</pentaho-osgi-bundles.version>


### PR DESCRIPTION
- Update groovy minor version to 2.4.21 to address CVE-2020-17521

JIRA: https://hv-eng.atlassian.net/browse/PPP-4784

PR Set:
- https://github.com/pentaho/pentaho-platform/pull/5680
- https://github.com/pentaho/pentaho-reporting/pull/1676
- https://github.com/pentaho/big-data-plugin/pull/2584
- https://github.com/pentaho/pentaho-big-data-ee/pull/612
- https://github.com/pentaho/mondrian/pull/1386