### PR TITLE
[PPP-4899] Vulnerable Component: commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <commons-configuration.version>1.9</commons-configuration.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <joda.version>2.10.2</joda.version>
-    <xmlgraphics-commons.version>2.2</xmlgraphics-commons.version>
+    <xmlgraphics-commons.version>2.9</xmlgraphics-commons.version>
     <sassy.version>0.5</sassy.version>
     <platform.version>10.3.0.0-SNAPSHOT</platform.version>
     <bsf.version>2.4.0</bsf.version>


### PR DESCRIPTION
Jira: https://hv-eng.atlassian.net/browse/PPP-4899

- Update xmlgraphics-commons 2.2 -> 2.9 -- this gets us to commons-io 2.16.1, which is 2.7+, addressing CVE-2021-29425

```
[INFO] org.pentaho.reporting.library:libloader:jar:10.3.0.0-SNAPSHOT
...
[INFO] +- org.apache.xmlgraphics:xmlgraphics-commons:jar:2.9:compile
[INFO] |  \- commons-io:commons-io:jar:2.16.1:compile
```

Related PRs:
https://github.com/pentaho/pentaho-kettle/pull/9525
https://github.com/pentaho/maven-parent-poms/pull/588