### PR TITLE
[PPP-4537] Use of Vulnerable Component: Components/akka

### DIFF
--- a/designer/report-designer/pom.xml
+++ b/designer/report-designer/pom.xml
@@ -71,8 +71,8 @@
       <artifactId>swingx</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-actor_3</artifactId>
+      <groupId>org.apache.pekko</groupId>
+      <artifactId>pekko-actor_3</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/ActorSystemHost.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/ActorSystemHost.java
@@ -17,10 +17,10 @@
 
 package org.pentaho.reporting.designer.core.model.data;
 
-import akka.actor.ActorSystem;
-import akka.actor.TypedActor;
-import akka.actor.TypedProps;
-import akka.util.Timeout;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.TypedActor;
+import org.apache.pekko.actor.TypedProps;
+import org.apache.pekko.util.Timeout;
 
 import java.util.concurrent.TimeUnit;
 

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/AsynchronousDataSchemaManager.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/AsynchronousDataSchemaManager.java
@@ -17,8 +17,8 @@
 
 package org.pentaho.reporting.designer.core.model.data;
 
-import akka.dispatch.OnFailure;
-import akka.dispatch.OnSuccess;
+import org.apache.pekko.dispatch.OnFailure;
+import org.apache.pekko.dispatch.OnSuccess;
 import org.pentaho.reporting.designer.core.util.exceptions.UncaughtExceptionsModel;
 import org.pentaho.reporting.engine.classic.core.AbstractReportDefinition;
 import org.pentaho.reporting.engine.classic.core.MasterReport;

--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/QueryMetaDataActorImpl.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/model/data/QueryMetaDataActorImpl.java
@@ -18,7 +18,7 @@
 package org.pentaho.reporting.designer.core.model.data;
 
 
-import akka.dispatch.Futures;
+import org.apache.pekko.dispatch.Futures;
 import org.pentaho.reporting.designer.core.model.ReportDataSchemaModel;
 import org.pentaho.reporting.engine.classic.core.AbstractReportDefinition;
 import org.pentaho.reporting.engine.classic.core.MasterReport;

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <test.long>false</test.long>
     <sapdb.version>7.4.4</sapdb.version>
-    <akka.version>2.8.6</akka.version>
+    <pekko.version>1.0.3</pekko.version>
     <json-simple.version>1.1</json-simple.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <mimepull.version>1.9.3</mimepull.version>
@@ -858,9 +858,9 @@
         <version>${swingx.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.typesafe.akka</groupId>
-        <artifactId>akka-actor_3</artifactId>
-        <version>${akka.version}</version>
+        <groupId>org.apache.pekko</groupId>
+        <artifactId>pekko-actor_3</artifactId>
+        <version>${pekko.version}</version>
       </dependency>
       <dependency>
         <groupId>pentaho</groupId>


### PR DESCRIPTION
relates to [PPP-4541] Use of Vulnerable Component: Components/scala

SECOND PR TO ADDRESS LICENSING ISSUE
See https://hv-eng.atlassian.net/browse/PPP-4537?focusedCommentId=2056460

- Changed akka version to nearest version with acceptable licensing model (Apache)
- Excluded transitive scala dependencies from akka
- Explicitly pulled in non-vulnerable scala version dependency

See previous commit 5c7a844e811f9dac7830aecf0fe10925055cdbb5

[PPP-4541]: https://hv-eng.atlassian.net/browse/PPP-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ