### PR TITLE
[PIR-1513] - Moving some of the core classes and interface for async report generation to the reporting core library

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -89,6 +89,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>compile</scope>

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/AsyncExecutionStatus.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/AsyncExecutionStatus.java
@@ -1,0 +1,48 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+/**
+ * Execution status.
+ * Final statuses must not change according to the business logic.
+ */
+public enum AsyncExecutionStatus {
+
+  QUEUED( Boolean.FALSE ),
+  WORKING( Boolean.FALSE ),
+  CONTENT_AVAILABLE( Boolean.FALSE ),
+  //Can be overriden by SCHEDULED status
+  FINISHED( Boolean.FALSE ),
+  FAILED( Boolean.TRUE ),
+  CANCELED( Boolean.TRUE ),
+  PRE_SCHEDULED( Boolean.FALSE ),
+  SCHEDULED( Boolean.TRUE );
+
+  private final boolean isFinal;
+
+  public boolean isFinal() {
+    return isFinal;
+  }
+
+  AsyncExecutionStatus( final boolean isFinal ) {
+    this.isFinal = isFinal;
+  }
+
+
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/AsyncReportState.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/AsyncReportState.java
@@ -1,0 +1,144 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+import java.util.UUID;
+
+public class AsyncReportState implements IAsyncReportState {
+  private final String path;
+  private final UUID uuid;
+  private final AsyncExecutionStatus status;
+  private final int progress;
+  private final int page;
+  private final int totalPages;
+  private final int row;
+  private final int totalRows;
+  private final String activity;
+  private final String mimeType;
+  private final String errorMessage;
+  private final int generatedPage;
+  private final boolean isQueryLimitReached;
+
+  public AsyncReportState( final UUID id, final String path ) {
+    this.status = AsyncExecutionStatus.QUEUED;
+    this.uuid = id;
+    this.path = path;
+    this.progress = 0;
+    this.page = 0;
+    this.totalPages = 0;
+    this.generatedPage = 0;
+    this.row = 0;
+    this.totalRows = 0;
+    this.activity = null;
+    this.mimeType = null;
+    this.errorMessage = null;
+    this.isQueryLimitReached = false;
+  }
+
+  public AsyncReportState( final UUID uuid,
+                           final String path,
+                           final AsyncExecutionStatus status,
+                           final int progress,
+                           final int row,
+                           final int totalRows,
+                           final int page,
+                           final int totalPages,
+                           final int generatedPage,
+                           final String activity,
+                           final String mimeType,
+                           final String errorMessage,
+                           final boolean isQueryLimitReached ) {
+    this.uuid = uuid;
+    this.path = path;
+    this.status = status;
+    this.progress = progress;
+    this.row = row;
+    this.totalRows = totalRows;
+    this.page = page;
+    this.totalPages = totalPages;
+    this.generatedPage = generatedPage;
+    this.activity = activity;
+    this.mimeType = mimeType;
+    this.errorMessage = errorMessage;
+    this.isQueryLimitReached = isQueryLimitReached;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public UUID getUuid() {
+    return uuid;
+  }
+
+  @Override
+  public AsyncExecutionStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public int getProgress() {
+    return progress;
+  }
+
+  @Override
+  public int getPage() {
+    return page;
+  }
+
+  @Override
+  public int getTotalPages() {
+    return totalPages;
+  }
+
+  @Override public int getGeneratedPage() {
+    return generatedPage;
+  }
+
+  @Override
+  public int getRow() {
+    return row;
+  }
+
+  @Override
+  public int getTotalRows() {
+    return totalRows;
+  }
+
+  @Override
+  public String getActivity() {
+    return activity;
+  }
+
+  @Override
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public boolean getIsQueryLimitReached() {
+    return isQueryLimitReached;
+  }
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/AsyncReportStatusListener.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/AsyncReportStatusListener.java
@@ -1,0 +1,244 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.event.ReportProgressEvent;
+import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
+import org.pentaho.reporting.engine.classic.core.layout.output.AbstractReportProcessor;
+import org.pentaho.reporting.engine.classic.core.layout.output.ReportProcessorThreadHolder;
+import org.pentaho.reporting.libraries.base.config.ExtendedConfiguration;
+import org.pentaho.reporting.libraries.base.util.ArgumentNullException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Simple synchronized bean with async execution status. This class is part of the PentahoAsyncReportExecution
+ * implementation and should not be used outside of that.
+ */
+public class AsyncReportStatusListener implements IAsyncReportListener {
+
+  private static final String COMPUTING_LAYOUT = "AsyncComputingLayoutTitle";
+  private static final String PRECOMPUTING_VALUES = "AsyncPrecomputingValuesTitle";
+  private static final String PAGINATING = "AsyncPaginatingTitle";
+  private static final String GENERATING_CONTENT = "AsyncGeneratingContentTitle";
+  private List<IReportCancelEvent> reportCancelEvents = new ArrayList<>();
+
+  private final String path;
+  private final UUID uuid;
+  private final String mimeType;
+  private final List<? extends ReportProgressListener> callbackListeners;
+  private String errorMessage = null;
+  private AsyncExecutionStatus status = AsyncExecutionStatus.QUEUED;
+  private int progress = 0;
+  private int page = 0;
+  private int row = 0;
+  private int totalPages = 0;
+  private int totalRows = 0;
+  private String activity;
+  private boolean firstPageMode = false;
+  private int requestedPage = 0;
+  private int generatedPage = 0;
+  private boolean isQueryLimitReached;
+  private boolean manuallyInterrupted;
+
+  public AsyncReportStatusListener( final String path,
+                                    final UUID uuid,
+                                    final String mimeType,
+                                    final List<? extends ReportProgressListener> callbackListeners ) {
+
+    ArgumentNullException.validate( "callbackListeners", callbackListeners );
+
+    this.path = path;
+    this.uuid = uuid;
+    this.mimeType = mimeType;
+    this.callbackListeners = Collections.unmodifiableList( callbackListeners );
+
+    final ExtendedConfiguration config = ClassicEngineBoot.getInstance().getExtendedConfig();
+    firstPageMode = config.getBoolProperty( "org.pentaho.reporting.platform.plugin.output.FirstPageMode" );
+
+  }
+
+  @Override
+  public synchronized void setStatus( final AsyncExecutionStatus status ) {
+    if ( this.status == null || !this.status.isFinal() ) {
+      this.status = status;
+    }
+  }
+
+  @Override
+  public synchronized void setErrorMessage( final String errorMessage ) {
+    this.errorMessage = errorMessage;
+  }
+
+  public boolean isFirstPageMode() {
+    return firstPageMode;
+  }
+
+
+  public synchronized void setRequestedPage( final int requestedPage ) {
+    this.requestedPage = requestedPage;
+  }
+
+  @Override public synchronized int getRequestedPage() {
+    return requestedPage;
+  }
+
+  /**
+   * Updates generation status with latest generated page
+   * and restores requested page in order to avoid continuous cache writing
+   * @param generatedPage
+   */
+  @Override public synchronized void updateGenerationStatus( final int generatedPage ) {
+    this.generatedPage = generatedPage;
+    this.requestedPage = 0;
+  }
+
+  @Override public synchronized boolean isScheduled() {
+    return AsyncExecutionStatus.SCHEDULED.equals( this.status );
+  }
+
+
+  @Override
+  public synchronized void reportProcessingStarted( final ReportProgressEvent event ) {
+    setStatus( AsyncExecutionStatus.WORKING );
+    if ( CollectionUtils.isNotEmpty( callbackListeners ) ) {
+      for ( final ReportProgressListener listener : callbackListeners ) {
+        listener.reportProcessingStarted( event );
+      }
+    }
+  }
+
+  @Override
+  public synchronized void reportProcessingUpdate( final ReportProgressEvent event ) {
+    if ( manuallyInterrupted ) {
+      final AbstractReportProcessor processor = ReportProcessorThreadHolder.getProcessor();
+      if ( processor != null ) {
+        processor.cancel();
+      }
+    }
+
+    updateState( event );
+    if ( CollectionUtils.isNotEmpty( callbackListeners ) ) {
+      for ( final ReportProgressListener listener : callbackListeners ) {
+        listener.reportProcessingUpdate( event );
+      }
+    }
+  }
+
+  @Override
+  public synchronized void reportProcessingFinished( final ReportProgressEvent event ) {
+    //report is finished but still may be unavailable for client
+    if ( CollectionUtils.isNotEmpty( callbackListeners ) ) {
+      for ( final ReportProgressListener listener : callbackListeners ) {
+        listener.reportProcessingFinished( event );
+      }
+    }
+  }
+
+  @Override public String toString() {
+    return "AsyncReportStatusListener{"
+      + "path='" + path + '\''
+      + ", uuid=" + uuid
+      + ", status=" + status
+      + ", progress=" + progress
+      + ", page=" + page
+      + ", totalPages=" + totalPages
+      + ", generatedPage=" + generatedPage
+      + ", activity='" + activity + '\''
+      + ", row=" + row
+      + ", firstPageMode=" + firstPageMode
+      + ", mimeType='" + mimeType + '\''
+      + ", errorMessage='" + errorMessage + '\''
+      + '}';
+  }
+
+  private void updateState( final ReportProgressEvent event ) {
+    this.activity = getActivityCode( event.getActivity() );
+    this.progress = (int) ReportProgressEvent.computePercentageComplete( event, true );
+    this.page = event.getPage();
+    this.row = event.getRow();
+    this.totalRows = event.getMaximumRow();
+    this.totalPages = event.getTotalPages();
+  }
+
+  private static String getActivityCode( final int activity ) {
+    String result = "";
+
+    switch ( activity ) {
+      case ReportProgressEvent.COMPUTING_LAYOUT: {
+        result = COMPUTING_LAYOUT;
+        break;
+      }
+      case ReportProgressEvent.PRECOMPUTING_VALUES: {
+        result = PRECOMPUTING_VALUES;
+        break;
+      }
+      case ReportProgressEvent.PAGINATING: {
+        result = PAGINATING;
+        break;
+      }
+      case ReportProgressEvent.GENERATING_CONTENT: {
+        result = GENERATING_CONTENT;
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  public synchronized IAsyncReportState getState() {
+    return new AsyncReportState( uuid, path, status, progress, row, totalRows, page, totalPages, generatedPage, activity, mimeType, errorMessage, isQueryLimitReached );
+  }
+
+  public boolean isQueryLimitReached() {
+    return isQueryLimitReached;
+  }
+
+  @Override public void setIsQueryLimitReached( boolean isQueryLimitReached ) {
+    this.isQueryLimitReached = isQueryLimitReached;
+  }
+
+  @Override
+  public int getTotalRows() {
+    return totalRows;
+  }
+
+  public synchronized void cancel() {
+    manuallyInterrupted = true;
+    this.setStatus( AsyncExecutionStatus.CANCELED );
+    notifyReportCancelEventToSubscribers();
+  }
+
+  @Override
+  public void subscribeToReportCancelEvent( IReportCancelEvent reportCancelEvent ) {
+    reportCancelEvents.add( reportCancelEvent);
+  }
+  @Override
+  public void notifyReportCancelEventToSubscribers() {
+    for ( IReportCancelEvent reportCancelEvent :  reportCancelEvents ) {
+      reportCancelEvent.onReportCancel();
+    }
+  }
+
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/IAsyncReportListener.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/IAsyncReportListener.java
@@ -1,0 +1,49 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+
+import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
+
+public interface IAsyncReportListener extends ReportProgressListener {
+
+  void setStatus( AsyncExecutionStatus status );
+
+  boolean isFirstPageMode();
+
+  int getRequestedPage();
+
+  void updateGenerationStatus( int generatedPage );
+
+  void setErrorMessage( String errorMessage );
+
+  boolean isScheduled();
+
+  boolean isQueryLimitReached();
+
+  void setIsQueryLimitReached( boolean isQueryLimitReached );
+
+  default int getTotalRows() {
+    return 0;
+  }
+
+  void subscribeToReportCancelEvent( IReportCancelEvent reportCancelEvent );
+
+  void notifyReportCancelEventToSubscribers();
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/IAsyncReportState.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/IAsyncReportState.java
@@ -1,0 +1,91 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public interface IAsyncReportState extends Serializable {
+
+  /**
+   * @return Report path to be shown on ui
+   */
+  String getPath();
+
+  /**
+   * @return Identifier of async task
+   */
+  UUID getUuid();
+
+  /**
+   * @return Status of running task
+   */
+  AsyncExecutionStatus getStatus();
+
+  /**
+   * @return Progress from 0 to 100
+   */
+  int getProgress();
+
+  /**
+   * @return Page is currently being processed
+   */
+  int getPage();
+
+  /**
+   * @return Quantity of pages in the report
+   */
+  int getTotalPages();
+
+  /**
+   * @return Quantity of pages that were already generated
+   */
+  int getGeneratedPage();
+
+  /**
+   * @return Row is currently being processed
+   */
+  int getRow();
+
+  /**
+   * @return Quantity of rows in the report
+   */
+  int getTotalRows();
+
+  /**
+   * @return Activity code is currently being processed
+   */
+  String getActivity();
+
+  /**
+   * @return mime type advice of report content that will be generated at the end.
+   */
+  String getMimeType();
+
+  /**
+   * @return error message in case of exception
+   */
+  String getErrorMessage();
+
+  /**
+   * @return flag saying that Query limit is reached
+   */
+  boolean getIsQueryLimitReached();
+
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/IReportCancelEvent.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/IReportCancelEvent.java
@@ -1,0 +1,23 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+
+public interface IReportCancelEvent {
+    void onReportCancel();
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/ReportListenerThreadHolder.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/event/async/ReportListenerThreadHolder.java
@@ -1,0 +1,48 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2024 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.reporting.engine.classic.core.event.async;
+
+public class ReportListenerThreadHolder {
+
+  private static final ThreadLocal<IAsyncReportListener> listenerThreadLocal =
+    new ThreadLocal<>();
+  private static final ThreadLocal<String> auditIdLocal = new ThreadLocal<>();
+
+  public static IAsyncReportListener getListener() {
+    return listenerThreadLocal.get();
+  }
+
+  public static void setListener( final IAsyncReportListener listener ) {
+    listenerThreadLocal.set( listener );
+  }
+
+  public static void setRequestId( final String requestId ) {
+    auditIdLocal.set( requestId );
+  }
+
+  public static String getRequestId() {
+    return auditIdLocal.get();
+  }
+
+  public static void clear() {
+    listenerThreadLocal.remove();
+    auditIdLocal.remove();
+  }
+
+}

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/SimpleSQLReportDataFactory.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/sql/SimpleSQLReportDataFactory.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2001 - 2019 Object Refinery Ltd, Hitachi Vantara and Contributors.  All rights reserved.
+ * Copyright (c) 2024 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.sql;
@@ -25,6 +25,10 @@ import org.pentaho.reporting.engine.classic.core.DataFactory;
 import org.pentaho.reporting.engine.classic.core.DataRow;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryQueryTimeoutException;
+import org.pentaho.reporting.engine.classic.core.event.async.AsyncReportStatusListener;
+import org.pentaho.reporting.engine.classic.core.event.async.IAsyncReportListener;
+import org.pentaho.reporting.engine.classic.core.event.async.IReportCancelEvent;
+import org.pentaho.reporting.engine.classic.core.event.async.ReportListenerThreadHolder;
 import org.pentaho.reporting.libraries.base.config.Configuration;
 import org.pentaho.reporting.libraries.base.util.ObjectUtilities;
 
@@ -35,6 +39,7 @@ import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLTimeoutException;
 import java.sql.Statement;
 import java.sql.Timestamp;
@@ -43,12 +48,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashSet;
-
+import java.util.concurrent.Callable;
 
 /**
  * @noinspection AssignmentToCollectionOrArrayFieldFromParameter
  */
-public class SimpleSQLReportDataFactory extends AbstractDataFactory {
+public class SimpleSQLReportDataFactory extends AbstractDataFactory implements IReportCancelEvent {
   private transient Connection connection;
   private ConnectionProvider connectionProvider;
   private static final Log logger = LogFactory.getLog( SimpleSQLReportDataFactory.class );
@@ -71,6 +76,11 @@ public class SimpleSQLReportDataFactory extends AbstractDataFactory {
       this.columnNameMapping = "Name".equalsIgnoreCase( globalConfig.getConfigProperty( //$NON-NLS-1$
               SimpleSQLReportDataFactory.COLUMN_NAME_MAPPING_KEY, "Name" ) ); //$NON-NLS-1$
     }
+
+      IAsyncReportListener reportListener =  ReportListenerThreadHolder.getListener();
+      if ( reportListener != null ) {
+        reportListener.subscribeToReportCancelEvent( this );
+      }
   }
 
   public SimpleSQLReportDataFactory( final Connection connection ) {
@@ -339,7 +349,7 @@ public class SimpleSQLReportDataFactory extends AbstractDataFactory {
   }
 
   public ResultSet performQuery( Statement statement, final String translatedQuery, final String[] preparedParameterNames )
-    throws SQLException {
+          throws SQLException {
     final ResultSet res;
     if ( preparedParameterNames.length == 0 ) {
       res = statement.executeQuery( translatedQuery );
@@ -348,6 +358,22 @@ public class SimpleSQLReportDataFactory extends AbstractDataFactory {
       res = pstmt.executeQuery();
     }
     return res;
+  }
+
+  private void tryCancelStatement(Statement statement) throws SQLException {
+    try {
+      if (statement != null) {
+        logger.warn("Sending CANCEL to underlying SQL Statement");
+        statement.cancel();
+        logger.warn("CANCEL to underlying SQL Statement completed");
+      }
+    } catch (SQLFeatureNotSupportedException e) {
+      logger.error("Unable to cancel the underlying SQL Statement, this Driver does not support cancel feature");
+      throw e;
+    } catch (SQLException e) {
+      logger.error("Unable to cancel the underlying SQL Statement");
+      throw e;
+    }
   }
 
   private void parametrize( final DataRow parameters, final String[] params, final PreparedStatement pstmt,
@@ -556,5 +582,13 @@ public class SimpleSQLReportDataFactory extends AbstractDataFactory {
     list.add( translateQuery( queryName ) );
     list.add( connection );
     return list;
+  }
+
+  public void onReportCancel() {
+    try {
+      tryCancelStatement(currentRunningStatement);
+    } catch (SQLException sqlException ) {
+      logger.error( sqlException.getLocalizedMessage() );
+    }
   }
 }


### PR DESCRIPTION
https://pentaho-jira-archive.orl.eng.hitachivantara.com/browse/BISERVER-10627 This jira introduced cancellation of the report on user's request. All of this code due to some reasons was put in reporting plugin instead of reporting-core. I have move some there classes to engine-core.
The classes and interfaces were move from https://github.com/pentaho/pentaho-platform-plugin-reporting project by this PR https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/855