### PR TITLE
Backport of PRD-6160 - When rendering html richtext containing style and fontsize specified in "px" then this text is displayed too big (10.2 Suite)

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/richtext/HtmlRichTextConverter.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/layout/richtext/HtmlRichTextConverter.java
@@ -686,7 +686,7 @@ public class HtmlRichTextConverter implements RichTextConverter {
         return new Float( nval * 72 );
       }
       if ( "px".equals( unit ) ) {
-        return new Float( nval * 72 );
+        return Float.valueOf((float) (nval * 0.75));
       }
       if ( "pc".equals( unit ) ) {
         return new Float( nval * 12 );


### PR DESCRIPTION
Fix for PRD-6160. This PR should only be merged after the [PR](https://github.com/pentaho/pentaho-reporting/pull/1726) with the corresponding unit test is merged, for QA purposes.
original PR: https://github.com/pentaho/pentaho-reporting/pull/1663
@pentaho/tatooine_dev