### PR TITLE
[BACKLOG-43170] Remove copyright headers from PAD, PRD, and PSW splas…

### DIFF
--- a/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/splash/SplashScreen.java
+++ b/designer/report-designer/src/main/java/org/pentaho/reporting/designer/core/splash/SplashScreen.java
@@ -41,9 +41,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.io.InputStreamReader;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * A splashscreen component that is used to show progress of the application loading.
@@ -60,7 +57,6 @@ public class SplashScreen extends JWindow {
   private static final int YLOC = 80;
   private static final int TEXT_WIDTH = 700;
   private static final Color TRANSPARENT = new Color( 0, 0, 0, 0 );
-  private static final Color WHITE = new Color( 255, 255, 255 );
   private static final Color DARK_GREY = new Color( 65, 65, 65 );
   private static final EmptyBorder BORDER = new EmptyBorder( 0, 0, 0, 0 );
 
@@ -131,21 +127,6 @@ public class SplashScreen extends JWindow {
     versionLabel.setBounds( XLOC, YLOC, TEXT_WIDTH, versionLabel.getPreferredSize().height );
 
     // Overlay the license
-    final String year = new SimpleDateFormat( "yyyy" ).format( new Date() );
-    final JTextArea copyrightArea = new JTextArea( Messages.getString( "SplashScreen.Copyright", year ) );
-    copyrightArea.setEditable( false );
-    copyrightArea.setBounds( XLOC, YLOC + 25, TEXT_WIDTH, 25 );
-    copyrightArea.setOpaque( false );
-    copyrightArea.setLineWrap( true );
-    copyrightArea.setWrapStyleWord( true );
-    copyrightArea.setFont( COPYRIGHT_FONT );
-    copyrightArea.setEnabled( false );
-    copyrightArea.setBackground( TRANSPARENT );
-    copyrightArea.setForeground( DARK_GREY );
-    copyrightArea.setBorder( BORDER );
-    copyrightArea.setDisabledTextColor( copyrightArea.getForeground() );
-
-    // Overlay the copyright
     StringBuilder sb = new StringBuilder();
     String line;
     try {
@@ -160,7 +141,7 @@ public class SplashScreen extends JWindow {
     }
     final JTextArea licenseArea = new JTextArea( sb.toString() );
     licenseArea.setEditable( false );
-    licenseArea.setBounds( XLOC, YLOC + 50, TEXT_WIDTH, 800 );
+    licenseArea.setBounds( XLOC, YLOC + 25, TEXT_WIDTH, 825 );
     licenseArea.setOpaque( false );
     licenseArea.setLineWrap( true );
     licenseArea.setWrapStyleWord( true );
@@ -168,13 +149,12 @@ public class SplashScreen extends JWindow {
     licenseArea.setEnabled( false );
     licenseArea.setBackground( TRANSPARENT );
     licenseArea.setBorder( BORDER );
-    licenseArea.setDisabledTextColor( copyrightArea.getForeground() );
+    licenseArea.setDisabledTextColor( DARK_GREY );
 
     // Add all the overlays
     final JPanel imagePanelOverlay = new JPanel( null );
     imagePanelOverlay.setOpaque( false );
     imagePanelOverlay.add( versionLabel );
-    imagePanelOverlay.add( copyrightArea );
     imagePanelOverlay.add( licenseArea );
     imagePanelOverlay.setBackground( TRANSPARENT );
 

--- a/designer/report-designer/src/main/resources/org/pentaho/reporting/designer/core/messages/messages.properties
+++ b/designer/report-designer/src/main/resources/org/pentaho/reporting/designer/core/messages/messages.properties
@@ -136,7 +136,6 @@ ResizeReportOptionPane.OptionAlignNone=Do not change the layout
 ResizeReportOptionPane.Title=Resize Report Elements
 
 SplashScreen.Title=Pentaho Report Designer
-SplashScreen.Copyright=Copyright (c) {0} Hitachi Vantara. All rights reserved.
 SplashScreen.LicenseTextNotFound=Failed to load the license text
 SplashScreen.Version=Version: {0}
 SplashScreen.DevelopmentVersion=Development Version

--- a/designer/report-designer/src/main/resources/org/pentaho/reporting/designer/core/messages/messages_ja.properties
+++ b/designer/report-designer/src/main/resources/org/pentaho/reporting/designer/core/messages/messages_ja.properties
@@ -102,7 +102,6 @@ ResizeReportOptionPane.OptionAlignNone=\u30ec\u30a4\u30a2\u30a6\u30c8\u3092\u590
 ResizeReportOptionPane.Title=\u30ec\u30dd\u30fc\u30c8\u8981\u7d20\u306e\u30b5\u30a4\u30ba\u3092\u5909\u66f4
 
 SplashScreen.Title=Pentaho \u30ec\u30dd\u30fc\u30c8\u30c7\u30b6\u30a4\u30ca\u30fc
-SplashScreen.Copyright=Copyright (c) {0} Hitachi Vantara. All rights reserved.
 SplashScreen.LicenseTextNotFound=\u30e9\u30a4\u30bb\u30f3\u30b9\u30c6\u30ad\u30b9\u30c8\u306e\u8aad\u307f\u8fbc\u307f\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
 SplashScreen.Version=\u30d0\u30fc\u30b8\u30e7\u30f3: {0}
 SplashScreen.DevelopmentVersion=Development Version


### PR DESCRIPTION
…h screens, as those lines now exist in the license text

- Remove copyrightArea from SplashScreen and all related components that are not longer to be used