### PR TITLE
[SP-6771] Backport of MONDRIAN-2749 - CellFormatter scripting capability broken due to removal of Nashorn scripting engine from JDK (10.2 Suite)

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -153,7 +153,7 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>asm</groupId>
+      <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/libraries/libpensol/pom.xml
+++ b/libraries/libpensol/pom.xml
@@ -199,7 +199,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>asm</groupId>
+      <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <stax.version>1.2.0</stax.version>
     <jug.version>2.0.0</jug.version>
     <rsyntaxtextarea.version>1.3.2</rsyntaxtextarea.version>
-    <asm.version>3.2</asm.version>
+    <asm.version>7.1</asm.version>
     <pdi.version>10.2.0.0-SNAPSHOT</pdi.version>
     <edtftpj.version>2.1.0</edtftpj.version>
     <eclipse.commands.version>3.3.0-I20070605-0010</eclipse.commands.version>
@@ -1365,7 +1365,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>asm</groupId>
+        <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>${asm.version}</version>
       </dependency>


### PR DESCRIPTION
cherry-pick of [d4620d](https://github.com/pentaho/pentaho-reporting/commit/d4620d953b4c177a34591833ab7fe8a393f8e950) from PR: https://github.com/pentaho/pentaho-reporting/pull/1738