### PR TITLE
chore: cleanup for testBarcodeDetection unit test

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/metadata/ElementTypeRegistry.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/metadata/ElementTypeRegistry.java
@@ -69,6 +69,10 @@ public final class ElementTypeRegistry {
     this.backend.put( metaData.getName(), new DefaultElementMetaData( metaData ) );
   }
 
+  public void removeElement( String elementKey ) {
+    this.backend.remove( elementKey );
+  }
+
   public AttributeRegistry getAttributeRegistry( final ElementType identifier ) {
     return getAttributeRegistry( identifier.getMetaData().getName() );
   }

--- a/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/output/fast/ReportStructureValidatorTest.java
+++ b/engine/core/src/test/java/org/pentaho/reporting/engine/classic/core/modules/output/fast/ReportStructureValidatorTest.java
@@ -33,6 +33,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ReportStructureValidatorTest {
+
+  public static final String SIMPLE_BARCODES_TYPE = "simple-barcodes";
+
   @Before
   public void setUp() throws Exception {
     ClassicEngineBoot.getInstance().start();
@@ -103,30 +106,33 @@ public class ReportStructureValidatorTest {
 
   @Test
   public void testBarcodeDetection() {
-    ElementMetaData em = new DefaultElementMetaData( "simple-barcodes", "simple-barcodes",
-     "simple-barcodes", "simple-barcodes", false, false, false,
-     false, null, new AttributeMap<>(), new HashMap<>(), BarcodeDummyType.class,
-     BarcodeDummyType.class, null, 1 );
-    ElementTypeRegistry.getInstance().registerElement( em );
+    try {
+      ElementMetaData em = new DefaultElementMetaData( SIMPLE_BARCODES_TYPE, SIMPLE_BARCODES_TYPE,
+        SIMPLE_BARCODES_TYPE, SIMPLE_BARCODES_TYPE, false, false, false,
+        false, null, new AttributeMap<>(), new HashMap<>(), BarcodeDummyType.class,
+        BarcodeDummyType.class, null, 1 );
+      ElementTypeRegistry.getInstance().registerElement( em );
 
-    Element e = new Element();
-    e.setElementType( new BarcodeDummyType() );
+      Element e = new Element();
+      e.setElementType( new BarcodeDummyType() );
 
-    SubReport sr = new SubReport();
-    sr.getReportDefinition().getItemBand().addElement( e );
+      SubReport sr = new SubReport();
+      sr.getReportDefinition().getItemBand().addElement( e );
 
-    MasterReport report = new MasterReport();
-    report.getReportHeader().addSubReport( sr );
+      MasterReport report = new MasterReport();
+      report.getReportHeader().addSubReport( sr );
 
-    ReportStructureValidator v = new ReportStructureValidator();
-    assertFalse( v.isValidForFastProcessing( report ) );
+      ReportStructureValidator v = new ReportStructureValidator();
+      assertFalse( v.isValidForFastProcessing( report ) );
+    } finally {
+      ElementTypeRegistry.getInstance().removeElement( SIMPLE_BARCODES_TYPE );
+    }
   }
 
   static class BarcodeDummyType extends ContentType {
     public BarcodeDummyType() {
-      super( "simple-barcodes" );
+      super( SIMPLE_BARCODES_TYPE );
     }
-
   }
 
 }


### PR DESCRIPTION
This fixes an issue that was making the UT `AttributeMetaDataValidationTest.testMetaData` fail on local maven runs of `engine.core` module. 

The issue was caused by adding the `BarcodeDummyType` to the `ElementTypeRegistry` instance. Since the validations in `AttributeMetaDataValidationTest.testMetaData` would then fail for this particular type.

The fix adds a cleanup step in the unit test that removes the `BarcodeDummyType`, from the registry, in the end of the test execution.

Failure stack trace:
```
[INFO] Running org.pentaho.reporting.engine.classic.core.metadata.AttributeMetaDataValidationTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.371 s <<< FAILURE! - in org.pentaho.reporting.engine.classic.core.metadata.AttributeMetaDataValidationTest
[ERROR] testMetaData(org.pentaho.reporting.engine.classic.core.metadata.AttributeMetaDataValidationTest)  Time elapsed: 0.371 s  <<< FAILURE!
java.lang.AssertionError: metadata creation failed
	at org.pentaho.reporting.engine.classic.core.metadata.AttributeMetaDataValidationTest.performTestOnElement(AttributeMetaDataValidationTest.java:45)
	at org.pentaho.reporting.engine.classic.core.metadata.AttributeMetaDataValidationTest.performTestOnElement(AttributeMetaDataValidationTest.java:24)
	at org.pentaho.reporting.engine.classic.core.metadata.AttributeMetaDataValidationTest.testMetaData(AttributeMetaDataValidationTest.java:35)
```