### PR TITLE
[SP-6802] Backport of PPP-4899 - Vulnerable Component: commons-io (10…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <commons-configuration.version>1.9</commons-configuration.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <joda.version>2.10.2</joda.version>
-    <xmlgraphics-commons.version>2.2</xmlgraphics-commons.version>
+    <xmlgraphics-commons.version>2.9</xmlgraphics-commons.version>
     <sassy.version>0.5</sassy.version>
     <platform.version>10.2.0.0-SNAPSHOT</platform.version>
     <bsf.version>2.4.0</bsf.version>


### PR DESCRIPTION
….2 Suite)

[PPP-4899] Vulnerable Component: commons-io

Jira: https://hv-eng.atlassian.net/browse/PPP-4899

- Update xmlgraphics-commons 2.2 -> 2.9 -- this gets us to commons-io 2.16.1, which is 2.7+, addressing CVE-2021-29425

```
[INFO] org.pentaho.reporting.library:libloader:jar:10.3.0.0-SNAPSHOT
...
[INFO] +- org.apache.xmlgraphics:xmlgraphics-commons:jar:2.9:compile
[INFO] |  \- commons-io:commons-io:jar:2.16.1:compile
```

(cherry picked from commit 78e954e954073c95698b3fc20d917fc5b15fd3a9)

[PPP-4899]: https://hv-eng.atlassian.net/browse/PPP-4899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ