### PR TITLE
fix[PPP-5778] Check if scripts are allowed to run

### DIFF
--- a/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/CacheKillingIT.java
+++ b/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/CacheKillingIT.java
@@ -13,16 +13,16 @@
 
 package org.pentaho.reporting.engine.classic.core;
 
-import javax.cache.Cache;
-import javax.cache.CacheManager;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.cache.DataCacheKey;
 import org.pentaho.reporting.engine.classic.core.cache.EhCacheDataCache;
 
+import javax.cache.Cache;
+import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.swing.table.DefaultTableModel;
+import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/DataFactoryScriptingSupport.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/DataFactoryScriptingSupport.java
@@ -124,9 +124,7 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
         final ResourceData loadedResource = resourceManager.load( resourceKey );
         final byte[] resource = loadedResource.getResource( resourceManager );
         return eval( new String( resource, encoding ), defaultScriptLanguage );
-      } catch ( ResourceLoadingException e ) {
-        throw new ScriptException( e );
-      } catch ( UnsupportedEncodingException e ) {
+      } catch ( ResourceLoadingException | UnsupportedEncodingException e) {
         throw new ScriptException( e );
       }
     }
@@ -201,7 +199,7 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
           contextKey ), ScriptContext.ENGINE_SCOPE );
 
       this.scriptEngine = new ScriptEngineManager().getEngineByName( scriptLanguage );
-      if ( scriptEngine instanceof Invocable == false ) {
+      if ( !( scriptEngine instanceof Invocable ) ) {
         throw new ReportDataFactoryException( String.format( "Query script language '%s' is not usable.",
             scriptLanguage ) );
       }
@@ -243,7 +241,7 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
         throw new ReportDataFactoryException( "DataFactoryScriptingSupport: Failed to invoke computeQuery method.", e );
       } catch ( NoSuchMethodException e ) {
         // ignored ..
-        logger.debug( "Query script does not contain an 'computeQuery' function" );
+        logger.debug( "Query script does not contain a 'computeQuery' function" );
         return query;
       }
     }
@@ -258,7 +256,7 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
         final Object computeQuery =
             this.invocableEngine.invokeFunction( "postProcessResult", query, queryName, parameter, dataSet );
         final Object translated = convert( computeQuery );
-        if ( translated instanceof TableModel == false ) {
+        if ( !( translated instanceof TableModel ) ) {
           throw new ReportDataFactoryException(
               "DataFactoryScriptingSupport: postProcessResult method did not return a valid query." );
         }
@@ -311,14 +309,13 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
           rawArray = new Object[] { translated };
         }
 
-        final ArrayList<String> retval = new ArrayList<String>();
-        for ( int i = 0; i < rawArray.length; i++ ) {
-          final Object o = rawArray[i];
+        final ArrayList<String> retval = new ArrayList<>();
+        for ( final Object o : rawArray ) {
           if ( o != null ) {
             retval.add( String.valueOf( o ) );
           }
         }
-        return retval.toArray( new String[retval.size()] );
+        return retval.toArray( new String[ 0 ] );
       } catch ( ScriptException e ) {
         throw new ReportDataFactoryException(
             "DataFactoryScriptingSupport: Failed to invoke computeQueryFields method.", e );
@@ -348,8 +345,8 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
   private transient DataFactoryContext dataFactoryContext;
 
   public DataFactoryScriptingSupport() {
-    queryMappings = new HashMap<String, QueryCarrier>();
-    contextsByQuery = new HashMap<String, QueryScriptContext>();
+    queryMappings = new HashMap<>();
+    contextsByQuery = new HashMap<>();
   }
 
   public Object clone() {
@@ -412,7 +409,7 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
   }
 
   public String[] getQueryNames() {
-    return queryMappings.keySet().toArray( new String[queryMappings.size()] );
+    return queryMappings.keySet().toArray( new String[ 0 ] );
   }
 
   public String getGlobalScript() {
@@ -624,17 +621,15 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
     }
     synchronized ( DataFactoryScriptingSupport.class ) {
       if ( converters == null ) {
-        converters = new ArrayList<ScriptValueConverter>();
+        converters = new ArrayList<>();
         final Configuration globalConfig = ClassicEngineBoot.getInstance().getGlobalConfig();
-        final Iterator propertyKeys =
-            globalConfig
-                .findPropertyKeys( "org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.script-value-converters." );
+        final Iterator<String> propertyKeys = globalConfig.findPropertyKeys(
+          "org.pentaho.reporting.engine.classic.core.modules.misc.datafactory.script-value-converters." );
         while ( propertyKeys.hasNext() ) {
-          final String key = (String) propertyKeys.next();
+          final String key = propertyKeys.next();
           final String impl = globalConfig.getConfigProperty( key );
           final ScriptValueConverter converter =
-              (ScriptValueConverter) ObjectUtilities.loadAndInstantiate( impl, ScriptValueConverter.class,
-                  ScriptValueConverter.class );
+            ObjectUtilities.loadAndInstantiate( impl, ScriptValueConverter.class, ScriptValueConverter.class );
           if ( converter != null ) {
             converters.add( converter );
           }
@@ -665,7 +660,7 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
 
   private void readObject( final ObjectInputStream stream ) throws IOException, ClassNotFoundException {
     stream.defaultReadObject();
-    contextsByQuery = new HashMap<String, QueryScriptContext>();
+    contextsByQuery = new HashMap<>();
   }
 }
 

--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/DataFactoryScriptingSupport.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/misc/datafactory/DataFactoryScriptingSupport.java
@@ -176,6 +176,8 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
         final DataFactory dataFactory, final Configuration configuration,
         final ResourceBundleFactory resourceBundleFactory ) throws ReportDataFactoryException {
 
+      checkScriptEvaluation();
+
       this.context = new SimpleScriptContext();
 
       if ( globalContext != null ) {
@@ -437,11 +439,8 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
     if ( StringUtils.isEmpty( globalScriptLanguage ) ) {
       return;
     }
-    boolean allowScriptEval = ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty(
-                    "org.pentaho.reporting.engine.classic.core.allowScriptEvaluation", "false" )
-            .equalsIgnoreCase( "true" );
 
-    if ( !allowScriptEval ) {
+    if ( !isScriptEvaluationAllowed() ) {
       DataFactoryScriptingSupport.logger.error( "Scripts are prevented from running by default in order to avoid"
               + " potential remote code execution.  The system administrator must enable this capability by changing"
               + " the value of org.pentaho.reporting.engine.classic.core.allowScriptEvaluation to true." );
@@ -489,6 +488,8 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
       return;
     }
 
+    checkScriptEvaluation();
+
     try {
       initialized = true;
       if ( globalScriptEngine != null ) {
@@ -499,6 +500,29 @@ public final class DataFactoryScriptingSupport implements Cloneable, Serializabl
     } catch ( NoSuchMethodException e ) {
       // ignored ..
       logger.debug( "Global script does not contain an 'init' function" );
+    }
+  }
+
+  /**
+   * Checks the configuration to see if script evaluation is allowed.
+   *
+   * @return true if script evaluation is allowed, false otherwise.
+   */
+  private static boolean isScriptEvaluationAllowed() {
+    return ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty(
+        "org.pentaho.reporting.engine.classic.core.allowScriptEvaluation", "false" )
+      .equalsIgnoreCase( "true" );
+  }
+
+  /**
+   * Checks if script evaluation is allowed, and throws an exception if it is not.
+   *
+   * @throws ReportDataFactoryException if script evaluation is not allowed.
+   */
+  private static void checkScriptEvaluation() throws ReportDataFactoryException {
+    if ( !isScriptEvaluationAllowed() ) {
+      throw new ReportDataFactoryException( "Scripts are prevented from running by default in order to avoid"
+        + " potential remote code execution.  The system administrator must enable this capability." );
     }
   }
 


### PR DESCRIPTION
This pull request focuses on modernizing and improving the safety of the `DataFactoryScriptingSupport` class by refactoring code for readability, updating type usage, and strengthening script evaluation controls. The changes also include minor code cleanups and consistency improvements.

**Script Evaluation Security and Initialization:**

* Centralized the check for script evaluation permission by introducing `isScriptEvaluationAllowed()` and `checkScriptEvaluation()` helper methods, and ensured these checks are called before script execution and initialization. This makes script execution control more robust and easier to maintain. [[1]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L440-R440) [[2]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9R488-R489) [[3]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9R503-R525) [[4]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9R177-R178)

**Code Modernization and Readability:**

* Replaced explicit generic type declarations with diamond operators (e.g., `new HashMap<>()`, `new ArrayList<>()`) throughout the class to improve readability and reduce verbosity. [[1]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L349-R349) [[2]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L603-R632) [[3]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L644-R663)
* Updated array conversions to use the shorter and safer `toArray(new String[0])` form instead of the older `toArray(new String[size])` pattern. [[1]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L312-R318) [[2]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L413-R412)

**Code Consistency and Minor Fixes:**

* Replaced Yoda conditions and improved negation logic for type checks (e.g., `if (!(scriptEngine instanceof Invocable))`) for better clarity and alignment with Java best practices. [[1]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L202-R202) [[2]](diffhunk://#diff-f1ad4710d6377e883ce58d694789a9d9fccac1c48c71a0edd0d755fcb0eb11a9L259-R259)
* Fixed a typo in a log message for consistency ("a 'computeQuery' function" instead of "an 'computeQuery' function").
* Combined exception handling for resource loading and encoding in `evalFile()` for conciseness.

**Test and Import Cleanups:**

* Minor import reordering and cleanup in `CacheKillingIT.java` for consistency.

@pentaho/tatooine_dev 