### PR TITLE
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/libraries/libpensol/pom.xml
+++ b/libraries/libpensol/pom.xml
@@ -181,8 +181,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-servlet</artifactId>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-servlet-jakarta</artifactId>
       <version>${gwt.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,10 @@
           </exclusion>
           <exclusion>
             <artifactId>*</artifactId>
+            <groupId>org.gwtproject</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>*</artifactId>
             <groupId>org.apache.poi</groupId>
           </exclusion>
           <exclusion>


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request updates the `pom.xml` files to improve compatibility with the latest GWT project structure and plugin management. The most important changes focus on updating dependencies to use the new `org.gwtproject` group and switching to a more specific plugin version property.

Dependency updates:

* Changed the group ID for the `gwt-user`, and `gwt-dev` dependencies from `com.google.gwt` to `org.gwtproject` to align with the latest GWT project organization.

Plugin configuration:

* Updated the `gwt-maven-plugin` version reference to use the `${gwt-maven-plugin.version}` property instead of `${gwt.version}`, improving clarity and maintainability of plugin version management.