### PR TITLE
build[PDI-20311]: remove declaration of unused dependency trilead-ssh2

### DIFF
--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -161,10 +161,6 @@
       <artifactId>syslog4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/designer/datasource-editor-mondrian/pom.xml
+++ b/designer/datasource-editor-mondrian/pom.xml
@@ -124,10 +124,6 @@
       <artifactId>syslog4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-dbdialog</artifactId>
       <scope>compile</scope>

--- a/designer/datasource-editor-olap4j/pom.xml
+++ b/designer/datasource-editor-olap4j/pom.xml
@@ -120,10 +120,6 @@
       <artifactId>syslog4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-dbdialog</artifactId>
       <scope>compile</scope>

--- a/designer/datasource-editor-pmd/pom.xml
+++ b/designer/datasource-editor-pmd/pom.xml
@@ -135,10 +135,6 @@
       <artifactId>syslog4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>feed4j</groupId>
       <artifactId>feed4j</artifactId>
     </dependency>

--- a/designer/report-designer-extension-connectioneditor/pom.xml
+++ b/designer/report-designer-extension-connectioneditor/pom.xml
@@ -114,10 +114,6 @@
       <artifactId>syslog4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-jcache</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
     <xml-apis-ext.version>1.3.04</xml-apis-ext.version>
     <xmlunit.version>1.3</xmlunit.version>
     <plugin.sortpom.version>2.4.0</plugin.sortpom.version>
-    <trilead-ssh2.version>build213</trilead-ssh2.version>
     <ldapjdk.version>20000524</ldapjdk.version>
     <jcifs.version>1.3.3</jcifs.version>
     <commons-xul.version>11.0.0.0-SNAPSHOT</commons-xul.version>
@@ -495,11 +494,6 @@
         <groupId>org.syslog4j</groupId>
         <artifactId>syslog4j</artifactId>
         <version>${syslo4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>trilead-ssh2</groupId>
-        <artifactId>trilead-ssh2</artifactId>
-        <version>${trilead-ssh2.version}</version>
       </dependency>
       <dependency>
         <groupId>pentaho-kettle</groupId>


### PR DESCRIPTION
Remove unused trilead-ssh2 dependency declarations

## Problem
The dependency `trilead-ssh2` is declared in 5 modules across this project:
- designer/datasource-editor-jdbc/pom.xml
- designer/datasource-editor-olap4j/pom.xml  
- designer/datasource-editor-mondrian/pom.xml
- designer/datasource-editor-pmd/pom.xml
- designer/report-designer-extension-connectioneditor/pom.xml

However, `maven-dependency-plugin:analyze` identifies `trilead-ssh2` as an "Unused declared dependency" in all of these modules, indicating the dependency is not actually used in the codebase.

## Solution
This PR removes all trilead-ssh2 dependency declarations from the affected POMs.

## Verification
- Confirmed no actual usage of trilead-ssh2 classes in the codebase via code search
- Verified all modules still compile successfully after removal
- Verified PRD launches and is useable if the trilead-ssh2 jar is removed from the `lib/` folder
- Dependency analysis no longer reports trilead-ssh2 as unused

## Context
This cleanup is part of PDI-20311, where trilead-ssh2 will be replaced with other SSH client tools. Since this dependency is unused in the pentaho-reporting project, it can be safely removed.