### PR TITLE
00felix/upgrade/xalan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.pentaho</groupId>
@@ -35,7 +33,7 @@
     <wstx.version>3.2.4</wstx.version>
     <monetdb.version>2.8</monetdb.version>
     <plugin.enforcer.version>1.4.1</plugin.enforcer.version>
-    <xalan.version>2.6.0</xalan.version>
+    <xalan.version>2.7.3</xalan.version>
     <ftp4che.version>0.7.1</ftp4che.version>
     <hibernate.version>5.4.24.Final</hibernate.version>
     <groovy.version>2.4.21</groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.pentaho</groupId>


### PR DESCRIPTION
**Upgrade `xalan:xalan` from `2.6.0` to `2.7.3`**

This pull request upgrades `xalan:xalan` from version `2.6.0` to `2.7.3` to address multiple security vulnerabilities and ensure compliance with security best practices. The upgrade has been tested locally to confirm compatibility with existing functionality.
Vulnerabilities Addressed

| Vulnerability | Description |
| --- | --- |
| CVE-2014-0107 | Improper Authorization in Apache Xalan-Java. Improper Authorization in Apache Xalan-Java |
| CVE-2022-34169 | Apache Xalan Java XSLT library integer truncation issue when processing malicious XSLT stylesheets. Apache Xalan Java XSLT library integer truncation issue when processing malicious XSLT stylesheets |


This upgrade enhances the security and stability of the `xalan:xalan` dependency.