### PR TITLE
build[PPP-6390][PPP-6391]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1307,11 +1307,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcmail-jdk15to18</artifactId>
-        <version>${bcprov-jdk15to18.version}</version>
-      </dependency>
-      <dependency>
         <groupId>barbecue</groupId>
         <artifactId>barbecue</artifactId>
         <version>${barbecue.version}</version>


### PR DESCRIPTION
This pull request makes a minor update to `pom.xml` to use the `bouncycastle` version declared in `maven-parent-poms` `dependencyManagement`: https://github.com/pentaho/maven-parent-poms/pull/843