### PR TITLE
build[SP-7260]: update Hibernate dependency configuration to use parent version

### DIFF
--- a/designer/datasource-editor-jdbc/pom.xml
+++ b/designer/datasource-editor-jdbc/pom.xml
@@ -87,7 +87,7 @@
       <artifactId>ftp4che</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>

--- a/designer/datasource-editor-mondrian/pom.xml
+++ b/designer/datasource-editor-mondrian/pom.xml
@@ -43,7 +43,7 @@
       <artifactId>edtftpj</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>

--- a/designer/datasource-editor-olap4j/pom.xml
+++ b/designer/datasource-editor-olap4j/pom.xml
@@ -39,7 +39,7 @@
       <artifactId>commons-validator</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>

--- a/designer/datasource-editor-pmd/pom.xml
+++ b/designer/datasource-editor-pmd/pom.xml
@@ -50,7 +50,7 @@
       <artifactId>commons-validator</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>

--- a/designer/report-designer-extension-connectioneditor/pom.xml
+++ b/designer/report-designer-extension-connectioneditor/pom.xml
@@ -45,7 +45,7 @@
       <artifactId>commons-validator</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <plugin.enforcer.version>1.4.1</plugin.enforcer.version>
     <xalan.version>2.6.0</xalan.version>
     <ftp4che.version>0.7.1</ftp4che.version>
-    <hibernate.version>5.4.24.Final</hibernate.version>
     <groovy.version>2.4.21</groovy.version>
     <mockito.version>5.10.0</mockito.version>
     <powermock.version>1.6.3</powermock.version>
@@ -518,9 +517,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>${hibernate.version}</version>
+        <version>${hibernate-core.version}</version>
         <exclusions>
           <exclusion>
             <groupId>dom4j</groupId>
@@ -529,14 +528,6 @@
           <exclusion>
             <groupId>antlr</groupId>
             <artifactId>antlr</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <plugin.enforcer.version>1.4.1</plugin.enforcer.version>
     <xalan.version>2.6.0</xalan.version>
     <ftp4che.version>0.7.1</ftp4che.version>
+    <hibernate.version>5.4.24.Final</hibernate.version>
     <groovy.version>2.4.21</groovy.version>
     <mockito.version>5.10.0</mockito.version>
     <powermock.version>1.6.3</powermock.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7260 - Backport of PPP-6248 - (10.2 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7260)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1824

## Changes
- Cherry-picked PR #1824 (build[PPP-6248]: update Hibernate dependency configuration to use parent version).
- Commit: 4db125565

## Conflict Resolution
- Conflicts in 6 pom.xml files (datasource-editor-jdbc, -mondrian, -olap4j, -pmd, report-designer-extension-connectioneditor, root pom.xml): hibernate-jcache absent in 10.2 (uses hibernate-ehcache); kept hibernate-ehcache dependencies. hibernate-core groupId updated to org.hibernate.orm and version updated from ${hibernate.version} to ${hibernate-core.version}. The hibernate.version property removal from pom.xml was not applied as hibernate-ehcache still references it. Commit f911ff0ffee26975d2295556c9c6e1df6556d55f caused the discrepancy.

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
