### PR TITLE
build[SP-7278]: build[PPP-6390][PPP-6391]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1307,11 +1307,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcmail-jdk15to18</artifactId>
-        <version>${bcprov-jdk15to18.version}</version>
-      </dependency>
-      <dependency>
         <groupId>barbecue</groupId>
         <artifactId>barbecue</artifactId>
         <version>${barbecue.version}</version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7278 - Backport of PPP-6391 - (11.0 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7278)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (11.0 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1831

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1831
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
