### PR TITLE
build[SP-7277]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1350,11 +1350,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcmail-jdk15to18</artifactId>
-        <version>${bcprov-jdk15to18.version}</version>
-      </dependency>
-      <dependency>
         <groupId>barbecue</groupId>
         <artifactId>barbecue</artifactId>
         <version>${barbecue.version}</version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1831

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1831
- Commit: c36293d7a6119a1f54c93fd4dcd73b360da0d250

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
