### PR TITLE
chore: remove outdated log4j version to use parent pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,6 @@
     <encryption-support.version>11.1.0.0-SNAPSHOT</encryption-support.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.21.0</commons-io.version>
-    <log4j.version>2.25.3</log4j.version>
     <xmlbeans.version>5.3.0</xmlbeans.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
@pentaho/tatooine_dev 
This pull request makes a minor update to the `pom.xml` file by removing the `log4j.version` property. This change likely reflects a cleanup or a shift in how the Log4j version is managed in the project.

- Dependency management:
  * Removed the `log4j.version` property from the Maven project configuration in `pom.xml`.