### PR TITLE
fix[SP-7317]: remove outdated log4j version to use parent pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@
     <encryption-support.version>11.0.0.0-SNAPSHOT</encryption-support.version>
     <commons-compress.version>1.26.1</commons-compress.version>
     <commons-io.version>2.16.1</commons-io.version>
-    <log4j.version>2.23.1</log4j.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7317 - Backport of PPP-6425 - (11.0 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/SP-7317)
- **Base Case:** [PPP-6425 - Backport of PPP-6425 - (11.0 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/PPP-6425)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1838

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1838
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
