### PR TITLE
fix[SP-7316]: remove outdated log4j version to use parent pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,6 @@
     <jakarta-annotation-api.version>1.3.5</jakarta-annotation-api.version>
     <commons-compress.version>1.26.1</commons-compress.version>
     <commons-io.version>2.16.1</commons-io.version>
-    <log4j.version>2.23.1</log4j.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7316 - Backport of PPP-6425 - (10.2 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/SP-7316)
- **Base Case:** [PPP-6425 - Backport of PPP-6425 - (10.2 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/PPP-6425)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1838

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1838
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
