### PR TITLE
[PPP-6549] CVE fix: CVE-2016-3093 in ognl:ognl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <pentaho-metadata.version>11.1.0.0-SNAPSHOT</pentaho-metadata.version>
     <pentaho.pentaho-versionchecker.version>${project.version}</pentaho.pentaho-versionchecker.version>
     <jsonpath.vesrion>1.0</jsonpath.vesrion>
-    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix, 3.0.21) -->
+    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix) -->
     <contiperf.version>2.2.0</contiperf.version>
     <feed4j.version>1.0</feed4j.version>
     <launcher.version>11.1.0.0-SNAPSHOT</launcher.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <pentaho-metadata.version>11.1.0.0-SNAPSHOT</pentaho-metadata.version>
     <pentaho.pentaho-versionchecker.version>${project.version}</pentaho.pentaho-versionchecker.version>
     <jsonpath.vesrion>1.0</jsonpath.vesrion>
-    <ognl.version>2.6.9</ognl.version>
+    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix, 3.0.21) -->
     <contiperf.version>2.2.0</contiperf.version>
     <feed4j.version>1.0</feed4j.version>
     <launcher.version>11.1.0.0-SNAPSHOT</launcher.version>


### PR DESCRIPTION
## CVE fix: CVE-2016-3093 in ognl:ognl

Advisory: CVE-2016-3093 -- OGNL < 3.0.12 DoS (CWE-20), CVSS 5.3 MEDIUM. Fixed upstream in OGNL 3.0.12.

Change: removes the local `<ognl.version>2.6.9</ognl.version>` property override in the root `pom.xml` so it now inherits the centralized fix (`3.0.21`) from `pentaho-ce-jar-parent-pom` (see pentaho/maven-parent-poms#899).

No direct OGNL API usage in this repo (`extensions-kettle` compiles against `ognl:ognl` only because it depends on kettle-core, which is where the real usage lives -- companion fix in pentaho/pentaho-kettle).

### Proof
`mvn help:evaluate -Dexpression=ognl.version` on `engine/extensions-kettle` now returns `3.0.21` (was `2.6.9` before this change).

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.