### PR TITLE
build[PPP-6754]: Move dependency management of httpcore5 to maven parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1430,11 +1430,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>${httpcore5.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
         <version>${httpclient5.version}</version>


### PR DESCRIPTION
### What

Removes the redundant local `dependencyManagement` entry for `org.apache.httpcomponents.core5:httpcore5` so the version is owned solely by `maven-parent-poms` (BOM / single source of truth).

### Why

Part of **CVE-2026-54399** remediation (Jira: **PPP-6754**). The local entry only re-declared `${httpcore5.version}`, duplicating the parent. Removing it lets this repo inherit the fixed `5.4.3` directly from the parent POM and keeps future bumps centralized.

### Changes

- `pom.xml`: removed the redundant `httpcore5` `dependencyManagement` block.

### Validation

- `mvn -B -nsu -pl libraries/libpensol dependency:tree -Dincludes=org.apache.httpcomponents.core5:httpcore5` → `httpcore5:jar:5.4.3:compile`, BUILD SUCCESS.

### Notes

- Depends on the companion `maven-parent-poms` PPP-6754 PR that bumps `httpcore5.version` to `5.4.3`.
