### PR TITLE
build[SP-7461]: Move dependency management of httpcore5 to maven parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1430,11 +1430,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>${httpcore5.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
         <version>${httpclient5.version}</version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7461 - Backport of PPP-6754 - (11.0 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/SP-7461)
- **Base Case:** [PPP-6754 - Backport of PPP-6754 - (11.0 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/PPP-6754)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1847

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1847
- Commit: cdf492129ceb7b830451a03da6c100da9cb5ce21

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
