### PR TITLE
build[SP-7462]: Move dependency management of httpcore5 to maven parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1473,11 +1473,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>${httpcore5.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
         <version>${httpclient5.version}</version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7462 - Backport of PPP-6754 - (10.2 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/SP-7462)
- **Base Case:** [PPP-6754 - Backport of PPP-6754 - (10.2 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/PPP-6754)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1847

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1847
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
