### PR TITLE
fix(BISERVER-15619): PRPT Report Exported to PDF from PUC on Windows Uses Incorrect Font

### DIFF
--- a/libraries/libfonts/src/main/java/org/pentaho/reporting/libraries/fonts/registry/AbstractFontFileRegistry.java
+++ b/libraries/libfonts/src/main/java/org/pentaho/reporting/libraries/fonts/registry/AbstractFontFileRegistry.java
@@ -35,6 +35,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -46,6 +48,8 @@ import java.util.StringTokenizer;
  */
 public abstract class AbstractFontFileRegistry implements FontRegistry {
   private static final Log logger = LogFactory.getLog( AbstractFontFileRegistry.class );
+  private static final String FILE_SEPARATOR_PROPERTY = "file.separator";
+  private static final String USER_HOME_PROPERTY = "user.home";
 
   private HashMap<String, FontFileRecord> seenFiles;
   private HashMap<String, DefaultFontFamily> fontFamilies;
@@ -99,13 +103,13 @@ public abstract class AbstractFontFileRegistry implements FontRegistry {
 
     final String osname = safeSystemGetProperty( "os.name", "<protected by system security>" );
     final String jrepath = safeSystemGetProperty( "java.home", "." );
-    final String fs = safeSystemGetProperty( "file.separator", File.separator );
+    final String fs = safeSystemGetProperty( FILE_SEPARATOR_PROPERTY, File.separator );
 
     logger.debug( "Running on operating system: " + osname );
     logger.debug( "Character encoding used as default: " + encoding );
 
     if ( StringUtils.startsWithIgnoreCase( osname, "mac os x" ) ) {
-      final String userhome = safeSystemGetProperty( "user.home", "." );
+      final String userhome = safeSystemGetProperty( USER_HOME_PROPERTY, "." );
       logger.debug( "Detected MacOS." );
       registerFontPath( new File( userhome + "/Library/Fonts" ), encoding );
       registerFontPath( new File( "/Library/Fonts" ), encoding );
@@ -284,49 +288,115 @@ public abstract class AbstractFontFileRegistry implements FontRegistry {
   }
 
   /**
-   * Registers the default windows font path. Once a font was found in the old seenFiles map and confirmed, that this
+   * Registers the default windows font paths. Once a font was found in the old seenFiles map and confirmed, that this
    * font still exists, it gets copied into the confirmedFiles map.
    *
    * @param encoding the default font encoding.
    */
   private void registerWindowsFontPath( final String encoding ) {
     logger.debug( "Found 'Windows' in the OS name, assuming DOS/Win32 structures" );
-    // Assume windows
-    // If you are not using windows, ignore this. This just checks if a windows system
-    // directory exist and includes a font dir.
 
-    String fontPath = null;
+    // Keyed by the lower-cased path, as the Windows file system is case-insensitive.
+    final LinkedHashMap<String, String> fontPaths = new LinkedHashMap<>();
+    // The Windows directory published by the operating system is authoritative. Unlike 'java.library.path' it
+    // cannot be replaced by the launcher, and application servers commonly override 'java.library.path' with
+    // their own native-library folder, which would otherwise leave the registry without a single system font.
+    addWindowsFontPath( fontPaths, safeSystemGetEnv( "WINDIR" ) );
+    addWindowsFontPath( fontPaths, safeSystemGetEnv( "SystemRoot" ) );
+    final String windowsDir = findWindowsDirectoryFromLibraryPath();
+    if ( windowsDir != null ) {
+      addWindowsFontPath( fontPaths, windowsDir );
+    }
+    addPerUserWindowsFontPath( fontPaths );
+
+    if ( fontPaths.isEmpty() ) {
+      logger.warn( "Unable to locate the Windows font directory. No system fonts will be available, and all "
+        + "output will fall back to the built-in default fonts. Set the 'WINDIR' environment variable or declare "
+        + "the font directories via the 'org.pentaho.reporting.libraries.fonts.extra-font-dirs.*' configuration "
+        + "keys." );
+      return;
+    }
+
+    for ( final String fontPath : fontPaths.values() ) {
+      logger.debug( "Fonts located in \"" + fontPath + '\"' );
+      registerFontPath( new File( fontPath ), encoding );
+    }
+  }
+
+  /**
+   * Derives the Windows directory from the 'java.library.path' system property by locating its 'System32' entry.
+   *
+   * @return the Windows directory, or null if the library path does not contain a 'System32' entry.
+   */
+  private String findWindowsDirectoryFromLibraryPath() {
     final String windirs = safeSystemGetProperty( "java.library.path", null );
-    final String fs = safeSystemGetProperty( "file.separator", File.separator );
+    if ( windirs == null ) {
+      return null;
+    }
 
-    if ( windirs != null ) {
-      final StringTokenizer strtok = new StringTokenizer
-        ( windirs, safeSystemGetProperty( "path.separator", File.pathSeparator ) );
-      while ( strtok.hasMoreTokens() ) {
-        final String token = strtok.nextToken();
+    final String fs = safeSystemGetProperty( FILE_SEPARATOR_PROPERTY, File.separator );
+    final StringTokenizer strtok = new StringTokenizer
+      ( windirs, safeSystemGetProperty( "path.separator", File.pathSeparator ) );
+    while ( strtok.hasMoreTokens() ) {
+      final String token = strtok.nextToken();
+      if ( !StringUtils.endsWithIgnoreCase( token, "System32" ) ) {
+        continue;
+      }
 
-        if ( StringUtils.endsWithIgnoreCase( token, "System32" ) ) {
-          // found windows folder ;-)
-          final int lastBackslash = token.lastIndexOf( fs );
-          if ( lastBackslash != -1 ) {
-            fontPath = token.substring( 0, lastBackslash ) + fs + "Fonts";
-            break;
-          }
-          // try with forward slashs. Some systems may use the unix-semantics instead.
-          // (Windows accepts both characters as path-separators for historical reasons)
-          final int lastSlash = token.lastIndexOf( '/' );
-          if ( lastSlash != -1 ) {
-            fontPath = token.substring( 0, lastSlash ) + fs + "Fonts";
-            break;
-          }
-        }
+      // found windows folder ;-)
+      final int lastBackslash = token.lastIndexOf( fs );
+      if ( lastBackslash != -1 ) {
+        return token.substring( 0, lastBackslash );
+      }
+      // try with forward slashes. Some systems may use the unix-semantics instead.
+      // (Windows accepts both characters as path-separators for historical reasons)
+      final int lastSlash = token.lastIndexOf( '/' );
+      if ( lastSlash != -1 ) {
+        return token.substring( 0, lastSlash );
       }
     }
-    logger.debug( "Fonts located in \"" + fontPath + '\"' );
-    if ( fontPath != null ) {
-      final File file = new File( fontPath );
-      registerFontPath( file, encoding );
+    return null;
+  }
+
+  /**
+   * Adds the 'Fonts' sub-directory of the given Windows directory to the set of font paths to scan.
+   *
+   * @param fontPaths  the collected font paths, keyed by their lower-cased form.
+   * @param windowsDir the Windows directory, possibly null.
+   */
+  private void addWindowsFontPath( final LinkedHashMap<String, String> fontPaths, final String windowsDir ) {
+    if ( StringUtils.isEmpty( windowsDir, true ) ) {
+      return;
     }
+
+    final String fs = safeSystemGetProperty( FILE_SEPARATOR_PROPERTY, File.separator );
+    final String trimmed = windowsDir.trim();
+    final String separator = ( trimmed.endsWith( fs ) || trimmed.endsWith( "/" ) ) ? "" : fs;
+    addFontPath( fontPaths, trimmed + separator + "Fonts" );
+  }
+
+  /**
+   * Adds the per-user font directory introduced with Windows 10. Fonts installed without administrator rights are
+   * stored there and never appear in the system font directory.
+   *
+   * @param fontPaths the collected font paths, keyed by their lower-cased form.
+   */
+  private void addPerUserWindowsFontPath( final LinkedHashMap<String, String> fontPaths ) {
+    String localAppData = safeSystemGetEnv( "LOCALAPPDATA" );
+    final String fs = safeSystemGetProperty( FILE_SEPARATOR_PROPERTY, File.separator );
+    if ( StringUtils.isEmpty( localAppData, true ) ) {
+      final String userHome = safeSystemGetProperty( USER_HOME_PROPERTY, null );
+      if ( StringUtils.isEmpty( userHome, true ) ) {
+        return;
+      }
+      localAppData = userHome.trim() + fs + "AppData" + fs + "Local";
+    }
+    addFontPath( fontPaths, localAppData.trim() + fs + "Microsoft" + fs + "Windows" + fs + "Fonts" );
+  }
+
+  private void addFontPath( final LinkedHashMap<String, String> fontPaths, final String fontPath ) {
+    final String key = fontPath.toLowerCase( Locale.ROOT );
+    fontPaths.computeIfAbsent( key, ignored -> fontPath );
   }
 
   /**
@@ -423,6 +493,14 @@ public abstract class AbstractFontFileRegistry implements FontRegistry {
     }
   }
 
+  protected String safeSystemGetEnv( final String name ) {
+    try {
+      return System.getenv( name );
+    } catch ( SecurityException se ) {
+      return null;
+    }
+  }
+
 
   protected boolean isCacheValid( final HashMap cachedSeenFiles ) {
     final Iterator iterator = cachedSeenFiles.entrySet().iterator();
@@ -450,7 +528,7 @@ public abstract class AbstractFontFileRegistry implements FontRegistry {
       return null;
     }
 
-    final String homeDirectory = safeSystemGetProperty( "user.home", null );
+    final String homeDirectory = safeSystemGetProperty( USER_HOME_PROPERTY, null );
     if ( homeDirectory == null ) {
       return null;
     }

--- a/libraries/libfonts/src/test/java/org/pentaho/reporting/libraries/fonts/registry/AbstractFontFileRegistryTest.java
+++ b/libraries/libfonts/src/test/java/org/pentaho/reporting/libraries/fonts/registry/AbstractFontFileRegistryTest.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -31,43 +33,75 @@ public class AbstractFontFileRegistryTest {
   private AbstractFontFileRegistry registry;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     registry = new DummyFontFileRegistry();
     registry = spy( registry );
   }
 
   @Test
-  public void registerWindowsFontPaths_WithSlashes() throws Exception {
-    assertRegistersWindowsFontPaths( "c:/qwerty;c:/Windows/System32;c:/asdfg", "c:\\Windows\\Fonts" );
+  public void registerWindowsFontPaths_WithSlashes() {
+    stubWindows( "c:/qwerty;c:/Windows/System32;c:/asdfg" );
+
+    registry.registerDefaultFontPath();
+
+    assertRegistered( "c:\\Windows\\Fonts" );
   }
 
   @Test
-  public void registerWindowsFontPaths_WithBackslashes() throws Exception {
-    assertRegistersWindowsFontPaths( "c:\\qwerty;c:\\Windows\\System32;c:\\asdfg", "c:\\Windows\\Fonts" );
+  public void registerWindowsFontPaths_WithBackslashes() {
+    stubWindows( "c:\\qwerty;c:\\Windows\\System32;c:\\asdfg" );
+
+    registry.registerDefaultFontPath();
+
+    assertRegistered( "c:\\Windows\\Fonts" );
   }
 
-  private void assertRegistersWindowsFontPaths( String directories, String expectedFontPath ) {
+  /**
+   * The Pentaho Server start scripts replace 'java.library.path' with their own native library folder, leaving no
+   * 'System32' entry to derive the font directory from.
+   */
+  @Test
+  public void registerWindowsFontPaths_WithoutSystem32OnLibraryPath() {
+    stubWindows( "c:\\pentaho-server\\pentaho-solutions\\native-lib\\win64" );
+    doReturn( "c:\\Windows" ).when( registry ).safeSystemGetEnv( "WINDIR" );
+
+    registry.registerDefaultFontPath();
+
+    assertRegistered( "c:\\Windows\\Fonts" );
+  }
+
+  @Test
+  public void registerWindowsFontPaths_IncludesPerUserFonts() {
+    stubWindows( "c:\\Windows\\System32" );
+    doReturn( "c:\\Users\\pentaho\\AppData\\Local" ).when( registry ).safeSystemGetEnv( "LOCALAPPDATA" );
+
+    registry.registerDefaultFontPath();
+
+    assertRegistered( "c:\\Users\\pentaho\\AppData\\Local\\Microsoft\\Windows\\Fonts" );
+  }
+
+  private void stubWindows( String libraryPath ) {
     doReturn( "windows" ).when( registry ).safeSystemGetProperty( eq( "os.name" ), anyString() );
     doReturn( "\\" ).when( registry ).safeSystemGetProperty( eq( "file.separator" ), anyString() );
     doReturn( ";" ).when( registry ).safeSystemGetProperty( eq( "path.separator" ), anyString() );
-    doReturn( directories ).when( registry ).safeSystemGetProperty( eq( "java.library.path" ), nullable( String.class ) );
+    doReturn( libraryPath ).when( registry ).safeSystemGetProperty( eq( "java.library.path" ), nullable( String.class ) );
+    doReturn( null ).when( registry ).safeSystemGetEnv( anyString() );
 
     doNothing().when( registry ).loadFromCache( anyString() );
     doNothing().when( registry ).storeToCache( anyString() );
-    doNothing().when( registry ).registerFontFile( any( File.class ), anyString() );
+    doNothing().when( registry ).registerFontPath( any( File.class ), anyString() );
+  }
 
+  private void assertRegistered( String expectedFontPath ) {
     ArgumentCaptor<File> captor = ArgumentCaptor.forClass( File.class );
+    verify( registry, atLeastOnce() ).registerFontPath( captor.capture(), anyString() );
 
-    registry.registerDefaultFontPath();
-    verify( registry, atLeastOnce() )
-      .registerFontPath( captor.capture(), ArgumentCaptor.forClass( String.class ).capture() );
-
-    String actual = captor.getAllValues().get( 0 ).getAbsolutePath();
-    // this test is likely to be run on Linux by CI
-    // since we cannot prevent inserting slash as a file separator by java.io.File,
-    // we are forced to replace it manually
-    actual = actual.replaceAll( "/", "\\\\" ).toUpperCase();
-    // Linux also adds current dir to the path it cannot recognize, so let's check the end of the resulting path
-    assertTrue( actual, actual.endsWith( expectedFontPath.toUpperCase() ) );
+    // java.io.File keeps the foreign separator when this test runs on Linux, so compare normalised paths.
+    List<String> registered = new ArrayList<String>();
+    for ( File path : captor.getAllValues() ) {
+      registered.add( path.getPath().replace( '/', '\\' ).toUpperCase() );
+    }
+    assertTrue( "expected " + expectedFontPath + " among " + registered,
+      registered.contains( expectedFontPath.toUpperCase() ) );
   }
 }


### PR DESCRIPTION
This pull request improves the detection and registration of Windows font directories in the font registry, making the process more robust and compatible with various Windows configurations. It also updates the related test suite to cover new scenarios and edge cases.

**Enhancements to Windows font path detection and registration:**

* Refactored the `registerWindowsFontPath` method in `AbstractFontFileRegistry.java` to collect possible Windows font directories from multiple sources, including environment variables (`WINDIR`, `SystemRoot`), the `java.library.path` property, and the per-user font directory introduced in Windows 10; added helper methods for each source and ensured the registry is resilient to missing or non-standard configurations.
* Added a new `safeSystemGetEnv` method to safely retrieve environment variables, handling potential security exceptions.

**Test improvements for Windows font path registration:**

* Expanded and refactored tests in `AbstractFontFileRegistryTest.java` to cover scenarios such as missing `System32` in the library path, per-user fonts, and both slash and backslash path separators; introduced helper methods `stubWindows` and `assertRegistered` for cleaner and more robust assertions.
* Improved normalization and comparison of registered font paths in tests to ensure platform-independent verification, accounting for path separator differences.
* Added necessary imports for new test logic, such as `ArrayList` and `List`.

**Dependency update:**

* Imported `LinkedHashMap` in the registry implementation to preserve insertion order for font path collection.