### PR TITLE
chore[SP-7518]: Pentaho 10.2.0.6 Hangs on bulk processing of reports

### DIFF
--- a/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/pageable/pdf/internal/PdfDocumentWriter.java
+++ b/engine/core/src/main/java/org/pentaho/reporting/engine/classic/core/modules/output/pageable/pdf/internal/PdfDocumentWriter.java
@@ -17,7 +17,7 @@ import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.io.OutputStream;
-
+import java.io.BufferedOutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.reporting.engine.classic.core.ClassicEngineInfo;
@@ -45,7 +45,7 @@ import com.lowagie.text.pdf.PdfWriter;
 @SuppressWarnings( "HardCodedStringLiteral" )
 public class PdfDocumentWriter {
   private static final Log logger = LogFactory.getLog( PdfDocumentWriter.class );
-
+    private static final int WRITE_BUFFER_SIZE = 65536;
   /**
    * A useful constant for specifying the PDF creator.
    */
@@ -87,7 +87,9 @@ public class PdfDocumentWriter {
     this.imageCache = new LFUMap<ResourceKey, com.lowagie.text.Image>( 50 );
     this.resourceManager = resourceManager;
     this.metaData = metaData;
-    this.out = out;
+    // Wrap in BufferedOutputStream to avoid expensive synchronous network I/O
+    // on each flush when multiple PDF jobs run in parallel on the server.
+    this.out = new BufferedOutputStream( out, WRITE_BUFFER_SIZE );
     this.config = metaData.getConfiguration();
   }
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7518 - Backport of BISERVER-15573 - (11.0 Suite) Pentaho 10.2.0.6 Hangs on bulk processing of reports](https://pentaho-eng.atlassian.net/browse/SP-7518)
- **Base Case:** [BISERVER-15573 - Backport of BISERVER-15573 - (11.0 Suite) Pentaho 10.2.0.6 Hangs on bulk processing of reports](https://pentaho-eng.atlassian.net/browse/BISERVER-15573)
- **Original Master PR:** https://github.com/pentaho/pentaho-reporting/pull/1832

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-reporting/pull/1832
- Commit: 24c69fd5e5f5bb994b7f93578a9f732ab7ce4420

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
