### PR TITLE
test[BACKLOG-35118]: re-enable Prd3857 gold run

### DIFF
--- a/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/bugs/Prd3857IT.java
+++ b/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/bugs/Prd3857IT.java
@@ -15,7 +15,6 @@
 package org.pentaho.reporting.engine.classic.core.bugs;
 
 import junit.framework.TestCase;
-import org.junit.Ignore;
 import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.ClassicEngineCoreModule;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
@@ -38,18 +37,18 @@ public class Prd3857IT extends TestCase {
     ClassicEngineBoot.getInstance().start();
   }
 
-//  @Ignore
-//  public void testGoldRun() throws Exception {
-//    final File file = GoldTestBase.locateGoldenSampleReport( "Prd-3239.prpt" );
-//    final ResourceManager mgr = new ResourceManager();
-//    mgr.registerDefaults();
-//    final Resource directly = mgr.createDirectly( file, MasterReport.class );
-//    final MasterReport report = (MasterReport) directly.getResource();
-//    report.setCompatibilityLevel( ClassicEngineBoot.computeVersionId( 3, 8, 0 ) );
-//
-//    DebugReportRunner.createXmlFlow( report );
-//    DebugReportRunner.showDialog( report );
-//  }
+  public void testGoldRun() throws Exception {
+    final File file = GoldTestBase.locateGoldenSampleReport( "Prd-3239.prpt" );
+    final ResourceManager mgr = new ResourceManager();
+    mgr.registerDefaults();
+    final Resource directly = mgr.createDirectly( file, MasterReport.class );
+    final MasterReport report = (MasterReport) directly.getResource();
+    report.setCompatibilityLevel( ClassicEngineBoot.computeVersionId( 3, 8, 0 ) );
+    report.getReportConfiguration().setConfigProperty( ClassicEngineCoreModule.STRICT_ERROR_HANDLING_KEY, "false" );
+
+    DebugReportRunner.createXmlFlow( report );
+    DebugReportRunner.showDialog( report );
+  }
 
   public void testGoldRun3857Visually() throws Exception {
     final File file = GoldTestBase.locateGoldenSampleReport( "Prd-3857-001.prpt" );


### PR DESCRIPTION
Re-enables `Prd3857IT.testGoldRun`, which was commented out after failing under strict formula error handling.

The regression was introduced by commit 7bd44e1630dad28616a5e126f5446f3060ea0b7a (https://github.com/pentaho/pentaho-reporting/pull/1067), which made expressions without an explicit `failOnError` setting inherit the global strict-error configuration. The legacy PRD-3239 report consequently aborts on an expected arithmetic formula error.

This change applies the same compatibility fix used by that commit’s related Prd3857Test: disable strict error handling for this legacy report only. Global production behavior remains unchanged.