### PR TITLE
test[BACKLOG-35118]: restore PublishRestUtil integration tests

### DIFF
--- a/libraries/libpensol/src/it/java/org/pentaho/reporting/libraries/pensol/PublishRestUtilTestIT.java
+++ b/libraries/libpensol/src/it/java/org/pentaho/reporting/libraries/pensol/PublishRestUtilTestIT.java
@@ -20,7 +20,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.reporting.libraries.pensol.resources.TestRepositoryPublishResource;
 
@@ -45,7 +44,6 @@ public class PublishRestUtilTestIT extends JerseyTest {
     testPublish( TestRepositoryPublishResource.RETURN_200, 200 );
   }
 
-  @Ignore
   @Test
   public void publishUnauthorized() throws Exception {
     testPublish( TestRepositoryPublishResource.RETURN_401, 401 );
@@ -56,7 +54,6 @@ public class PublishRestUtilTestIT extends JerseyTest {
     testPublish( TestRepositoryPublishResource.RETURN_422, 422 );
   }
 
-  @Ignore
   @Test
   public void publishCrashingServer() throws Exception {
     testPublish( TestRepositoryPublishResource.RETURN_500, 500 );

--- a/libraries/libpensol/src/test/java/org/pentaho/reporting/libraries/pensol/resources/TestRepositoryPublishResource.java
+++ b/libraries/libpensol/src/test/java/org/pentaho/reporting/libraries/pensol/resources/TestRepositoryPublishResource.java
@@ -14,6 +14,7 @@
 
 package org.pentaho.reporting.libraries.pensol.resources;
 
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
@@ -22,9 +23,10 @@ import org.pentaho.platform.web.http.api.resources.services.RepositoryPublishSer
 
 import jakarta.ws.rs.Path;
 import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -43,7 +45,7 @@ public class TestRepositoryPublishResource extends RepositoryPublishResourceReve
   public TestRepositoryPublishResource() throws Exception {
     repositoryPublishService = mock( RepositoryPublishService.class );
     doAnswer( this ).when( repositoryPublishService )
-      .publishFile( anyString(), any( InputStream.class ), anyBoolean() );
+      .publishFile( anyString(), any( InputStream.class ), ArgumentMatchers.<Optional<Properties>>any() );
   }
 
 

--- a/libraries/libpensol/src/test/resources/applicationContext.xml
+++ b/libraries/libpensol/src/test/resources/applicationContext.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd" />


### PR DESCRIPTION
This PR restores the ignored unauthorized and server-error cases in PublishRestUtilTestIT. The tests were failing because `TestRepositoryPublishResource` mocked the obsolete `RepositoryPublishService.publishFile(String, InputStream, Boolean)` overload, while the current repository endpoint calls `publishFile(String, InputStream, Optional<Properties>)`. As a result, the configured exceptions were never thrown and the requests incorrectly returned HTTP 200 instead of 401 and 500. 

The fixture now mocks the correct overload, and a minimal test-only Spring `applicationContext.xml` has been added because the Jersey Spring dependency introduced by commit `df2d144a8` requires one during test-server initialization. The two @Ignore annotations have been removed. Validation completed successfully with all 4 `PublishRestUtilTestIT` cases and all 120 libpensol unit tests passing.