### PR TITLE
test[BACKLOG-35118]: update fast CSV empty report expectations

### DIFF
--- a/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/bugs/Backlog7181IT.java
+++ b/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/bugs/Backlog7181IT.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
+import org.pentaho.reporting.engine.classic.core.EmptyReportException;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.event.ReportProgressEvent;
 import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
@@ -108,11 +109,16 @@ public class Backlog7181IT {
     verify( mock, atLeastOnce() ).reportProcessingUpdate( any( ReportProgressEvent.class ) );
 
     try ( ByteArrayOutputStream stream = new ByteArrayOutputStream() ) {
-      FastCsvReportUtil.process( new MasterReport(), stream, mock );
+      try {
+        FastCsvReportUtil.process( new MasterReport(), stream, mock );
+        Assert.fail( "Expected an exception when processing a report with no data" );
+      } catch ( EmptyReportException e ) {
+        Assert.assertEquals( "Report did not generate any content.", e.getMessage() );
+      }
     }
 
     verify( mock, times( 2 ) ).reportProcessingStarted( any( ReportProgressEvent.class ) );
-    verify( mock, times( 2 ) ).reportProcessingFinished( any( ReportProgressEvent.class ) );
+    verify( mock, times( 1 ) ).reportProcessingFinished( any( ReportProgressEvent.class ) );
   }
 
 

--- a/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/bugs/Prd5180IT.java
+++ b/engine/core/src/it/java/org/pentaho/reporting/engine/classic/core/bugs/Prd5180IT.java
@@ -78,6 +78,8 @@ public class Prd5180IT {
     CSVReportUtil.createCSV( report, boutSlow, "UTF-8" );
     String htmlFast = boutFast.toString( "UTF-8" );
     String htmlSlow = boutSlow.toString( "UTF-8" );
+    //This fails due to divergences between fast and slow csv exporters;
+    //The fix for this will be handled in PRD-6278.
     Assert.assertEquals( htmlSlow, htmlFast );
   }
 


### PR DESCRIPTION
commits cherry-picked from: https://github.com/pentaho/pentaho-reporting/pull/1864
`61258fa` was not included because its the HSQLDB sample-data regeneration that increased the count to 15 was not backported to 11.0.