### PR TITLE
[PPP-5969] CVE-2025-46392: remove unused commons-configuration 1.9 from the PRD assembly

### DIFF
--- a/assemblies/prd-ce/pom.xml
+++ b/assemblies/prd-ce/pom.xml
@@ -253,11 +253,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>pdi-xml-plugin</artifactId>
       <type>zip</type>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
     <swt-linux.version>4.3.2</swt-linux.version>
     <swingx.version>1.6.1</swingx.version>
     <pentaho-karaf.version>11.1.0.0-SNAPSHOT</pentaho-karaf.version>
-    <commons-configuration.version>1.9</commons-configuration.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <joda.version>2.10.2</joda.version>
     <xmlgraphics-commons.version>2.9</xmlgraphics-commons.version>
@@ -1065,17 +1064,6 @@
         <artifactId>pentaho-big-data-plugin</artifactId>
         <version>${big-data-plugin.version}</version>
         <type>zip</type>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-configuration</groupId>
-        <artifactId>commons-configuration</artifactId>
-        <version>${commons-configuration.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>


### PR DESCRIPTION
## CVE-2025-46392 -- `commons-configuration:commons-configuration:1.9`

- **Advisory:** CVE-2025-46392 (alias GHSA-pvp8-3xj6-8c6x), CWE-400 Uncontrolled Resource Consumption, CVSS 6.5.
- **Upstream position:** the ASF states it *"does not intend to fix these issues in 1.x"*. There is **no fixed version on the 1.x line** (1.10 is the last release). The only fix is the 2.x line, which is a different `groupId` **and** a different Java package -- explicitly *not* a drop-in replacement.
- **Tracking:** PPP-5969 (https://pentaho-eng.atlassian.net/browse/PPP-5969). Sibling migrations: PPP-6525 (pentaho-kettle, done), PPP-6526 (pentaho-metaverse, done), PPP-6811 (big-data-plugin, in progress).
- **Build:** `pdia-master@11.1.0.0-402`, impact path `.../prd-ce-11.1.0.0-402.zip/report-designer/lib/commons-configuration-1.9.jar`.

### Why removal rather than an upgrade

Nothing in the Report Designer uses commons-configuration 1.x. This repo declares it **only** as an assembly `compile` dependency, whose sole effect is to copy the jar into `report-designer/lib`:

- **0** Java source files in this repo import `org.apache.commons.configuration`.
- The designer modules (`datasource-editor-{jdbc,mondrian,olap4j,pmd}`, `report-designer-extension-connectioneditor`) already depend on **commons-configuration2**.
- `git log -S` shows the declaration is a leftover of `748b00eda [BACKLOG-12334]-Mavenization`, predating the cc2 migration.

### Evidence from the shipped artifact

Every jar in the released `prd-ce-11.1.0.0-402.zip` was scanned for bytecode references to the 1.x package `org/apache/commons/configuration/`:

| scan | result |
|---|---|
| jars scanned | 333 |
| classes referencing `org/apache/commons/configuration/` (1.x) | **0** |
| **positive control** -- classes referencing `org/apache/commons/configuration2/` | **77**, across `kettle-engine`, `kettle-ui-swt`, `pentaho-metaverse-api`, `gremlin-core`, `tinkergraph-gremlin` |

The positive control confirms the scan detects real references on this data, so the zero is a genuine absence -- and it shows the PDI/metaverse code shipped inside PRD has already been migrated to cc2. The only textual matches for the 1.x name anywhere in the distribution are benign: commons-configuration2's own config key `org.apache.commons.configuration.format.date`, and the Jackson/gremlin-shaded deserialization **deny-list** entry `org.apache.commons.configuration.JNDIConfiguration` (a blocklist, not a usage).

This is also the shape prescribed when no fixed version exists: remove the component from the shipped artifact rather than bump it. Migrating to commons-configuration2 is a separate, much larger cross-repo effort (PPP-6811) and is deliberately **not** attempted here.

### Dependency-tree proof

`mvn dependency:tree -f assemblies/prd-ce/pom.xml -Dincludes=commons-configuration:commons-configuration`

**Before**
```
[INFO] org.pentaho.reporting:prd-ce:pom:11.1.0.0-SNAPSHOT
[INFO] \- commons-configuration:commons-configuration:jar:1.9:compile
[INFO] BUILD SUCCESS
```

**After**
```
(no matches -- the coordinate is absent from the resolved tree)
[INFO] BUILD SUCCESS
```

### Changes

- `pom.xml` -- drop the `<commons-configuration.version>` property and the `dependencyManagement` entry (the highest declaring point; no other module referenced it).
- `assemblies/prd-ce/pom.xml` -- drop the `compile` dependency.

### What a reviewer should check

The residual risk is a **reflective** load of a 1.x class from a source the static scan cannot see (a user-supplied driver in `report-designer/drivers`, or a plugin installed after packaging). The scan covered every jar in the released distribution, including `report-designer/plugins`, and found none. A smoke test of Report Designer start-up plus opening a JDBC/Mondrian/Metadata data source would confirm empirically. Note the prior incident BACKLOG-50367, where removing cc 1.x broke the **server** because `pentaho-metaverse` still referenced `org.apache.commons.configuration.ConfigurationException` -- that failure mode is exactly a bytecode reference, and this scan finds none in the PRD distribution.

Opened by the CodeMedic remediator. **Not auto-merged** -- this repo's owners review.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-402", "items": [{"cve": "CVE-2025-46392", "coordinate": "commons-configuration:commons-configuration"}, {"cve": "XRAY-698011", "coordinate": "commons-configuration:commons-configuration"}, {"cve": "GHSA-pvp8-3xj6-8c6x", "coordinate": "commons-configuration:commons-configuration"}]} -->
